### PR TITLE
Fix whitespace and author param handling, add automated tests for Parameter.php

### DIFF
--- a/Parameter.php
+++ b/Parameter.php
@@ -7,12 +7,15 @@
 class Parameter {
   public $pre, $param, $eq, $val, $post;
 
+/*
+ * Breaks a citation template down to component parts.
+ */
   public function parse_text($text) {
     $text = str_replace(PIPE_PLACEHOLDER, '|', $text);
     $split = explode('=', $text, 2);
-    preg_match('~^(\s*?)(\S[\s\S]*?)(\s*+)$~m', $split[0], $pre_eq);
+    preg_match('~^(\s*?)(\S[\s\S]*?)(\s*+)$~', $split[0], $pre_eq);
     if (count($split) == 2) {
-      preg_match('~^(\s*)([\s\S]*?)(\s*+)$~', $split[1], $post_eq);
+      preg_match('~^([ \t]*)([\s\S]*?)(\s*+)$~', $split[1], $post_eq);
       if (count($pre_eq) == 0) {
         $this->eq    = $split[0] . '=' . $post_eq[1];
       } else {
@@ -31,6 +34,7 @@ class Parameter {
     }
   }
 
+  // FIXME: this does not appear to actually parse values, should be renamed.
   protected function parse_val($value) {
     switch ($this->param) {
       case 'pages':
@@ -40,7 +44,13 @@ class Parameter {
     }
   }
 
+/*
+ * Returns a string with, for example, 'param1 = value1 | param2 = value2, etc.'
+ */
   public function parsed_text() {
-    return $this->pre . $this->param . (($this->param && empty($this->eq))?' = ':$this->eq) . $this->val . $this->post;
+    if ($this->param && empty($this->eq)) {
+      $this->eq = ' = ';
+    }
+    return $this->pre . $this->param . $this->eq . $this->val . $this->post;
   }
 }

--- a/Parameter.php
+++ b/Parameter.php
@@ -9,13 +9,16 @@ class Parameter {
 
 /*
  * Breaks a citation template down to component parts.
+ * Expects that any instances of "|" in $text will have been replaced with
+ * PIPE_PLACEHOLDER (usually '%%CITATION_BOT_PIPE_PLACEHOLDER%%' and set
+ * in expandFns.php) before this function is called.
  */
   public function parse_text($text) {
     $text = str_replace(PIPE_PLACEHOLDER, '|', $text);
     $split = explode('=', $text, 2);
     preg_match('~^(\s*?)(\S[\s\S]*?)(\s*+)$~', $split[0], $pre_eq);
     if (count($split) == 2) {
-      preg_match('~^([ \t]*)([\s\S]*?)(\s*+)$~', $split[1], $post_eq);
+      preg_match('~^([ \t\p{Zs}]*)([\s\S]*?)(\s*+)$~', $split[1], $post_eq);
       if (count($pre_eq) == 0) {
         $this->eq    = $split[0] . '=' . $post_eq[1];
       } else {
@@ -46,6 +49,8 @@ class Parameter {
 
 /*
  * Returns a string with, for example, 'param1 = value1 | param2 = value2, etc.'
+ * FIXME: might be better named "join_parsed_text" or similar to make it clear what
+ * this function does to the parsed text.
  */
   public function parsed_text() {
     if ($this->param && empty($this->eq)) {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ above include/require it. It includes several files itself:
    appears to use curl only for https, so the path to curl on Labs must be
    correct or the bot will fail to log in because the request can't reach the
    server.
-* `DOITools.php`: defines `$bot` (the Snoopy instance), some regexes,
+* `DOItools.php`: defines `$bot` (the Snoopy instance), some regexes,
    capitalization
 * `objects.php`: mix of variables, script, functions, and classes with their
    methods. Classes include `Page`, of which the key methods are

--- a/Template.php
+++ b/Template.php
@@ -43,7 +43,7 @@ class Template extends Item {
       $this->initial_param[$p->param] = $p->val;
 
       // Save author params for special handling
-      if (in_array($p->param, $flattened_author_params)) {
+      if (in_array($p->param, $flattened_author_params) && $p->val) {
         $this->initial_author_params[$p->param] = $p->val;
       }
     }

--- a/Template.php
+++ b/Template.php
@@ -16,6 +16,7 @@
 
 require_once("Item.php");
 require_once("Page.php");
+require_once("Parameter.php");
 
 class Template extends Item {
   const placeholder_text = '# # # Citation bot : template placeholder %s # # #';
@@ -55,6 +56,8 @@ class Template extends Item {
     if ($this->wikiname() == 'cite doi')
       $text = preg_replace('~d?o?i?\s*[:.,;>]*\s*(10\.\S+).*?(\s*)$~', "$1$2", $text);
     $params = explode('|', $text);
+    // TODO: this naming is confusing, distinguish between $text above and
+    //       $text in the loop (derived from $text above via $params)
     foreach ($params as $i => $text) {
       $this->param[$i] = new Parameter();
       $this->param[$i]->parse_text($text);

--- a/Template.php
+++ b/Template.php
@@ -1662,8 +1662,10 @@ class Template extends Item {
 
   protected function join_params() {
     $ret = '';
-    if ($this->param) foreach($this->param as $p) {
-      $ret .= '|' . $p->parsed_text();
+    if ($this->param) {
+      foreach($this->param as $p) {
+        $ret .= '|' . $p->parsed_text();
+      }
     }
     return $ret;
   }
@@ -2018,11 +2020,13 @@ class Template extends Item {
   }
 
   // Amend parameters
-  public function rename($old, $new, $new_value = FALSE) {
+  public function rename($old_param, $new_param, $new_value = FALSE) {
     foreach ($this->param as $p) {
-      if ($p->param == $old) {
-        $p->param = $new;
-        if ($new_value) $p->val = $new_value;
+      if ($p->param == $old_param) {
+        $p->param = $new_param;
+        if ($new_value) {
+          $p->val = $new_value;
+        }
       }
     }
   }
@@ -2100,7 +2104,14 @@ class Template extends Item {
   protected function added($param) {return $this->modified($param, '+');}
 
   public function modifications ($type='all') {
-    if ($this->param) foreach ($this->param as $p) $new[$p->param] = $p->val; else $new = array();
+    if ($this->param) {
+      foreach ($this->param as $p) {
+        $new[$p->param] = $p->val;
+      }
+    } else {
+      $new = array();
+    }
+
     $old = ($this->initial_param) ? $this->initial_param : array();
     if ($new) {
       if ($old) {

--- a/tests/phpunit/ParameterTest.php
+++ b/tests/phpunit/ParameterTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * Tests for Parameter.php.
+ */
+
+class ParameterTest extends PHPUnit_Framework_TestCase {
+
+  protected function setUp() {
+    if (!defined("PIPE_PLACEHOLDER")) {
+// this is usually done elsewhere in the code
+      define("PIPE_PLACEHOLDER", '%%CITATION_BOT_PIPE_PLACEHOLDER%%');
+    }
+  }
+
+  protected function tearDown() {
+  }
+
+  protected function parameter_parse_text_helper($text) {
+    $parameter = new Parameter();
+    $parameter->parse_text($text);
+    return $parameter;
+  }
+
+/*
+ * FIXME: these tests have too many assertions. Probably will require some refactoring of Parameter::parse_text().
+ */
+  public function testValueWithPipeAndTrailingNewline() {
+    $text = "last1 = [[:en:Bigwig%%CITATION_BOT_PIPE_PLACEHOLDER%%SomeoneFamous]]\n";
+    $parameter = $this->parameter_parse_text_helper($text);
+
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, 'last1');
+    $this->assertEquals($parameter->eq, ' = ');
+    $this->assertEquals($parameter->val, '[[:en:Bigwig|SomeoneFamous]]');
+    $this->assertEquals($parameter->post, "\n");
+  }
+
+  public function testBlankValueWithSpacesLeadingSpaceTrailingNewline() {
+    $text = " first1 = \n";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, ' ');
+    $this->assertEquals($parameter->param, 'first1');
+    $this->assertEquals($parameter->eq, ' = ');
+    $this->assertEquals($parameter->val, '');
+    $this->assertEquals($parameter->post, "\n");
+  }
+
+  public function testBlankValueWithSpacesAndTrailingNewline() {
+    $text = "first2 = \n";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, 'first2');
+    $this->assertEquals($parameter->eq, ' = ');
+    $this->assertEquals($parameter->val, '');
+    $this->assertEquals($parameter->post, "\n");
+  }
+
+  public function testBlankValueWithPreEqSpaceAndTrailingNewline() {
+    $text = "first3 =\n";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, 'first3');
+    $this->assertEquals($parameter->eq, ' =');
+    $this->assertEquals($parameter->val, '');
+    $this->assertEquals($parameter->post, "\n");
+  }
+
+  public function testBlankValueWithPostEqSpaceAndTrailingNewline() {
+    $text = "first4= \n";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, 'first4');
+    $this->assertEquals($parameter->eq, '= ');
+    $this->assertEquals($parameter->val, '');
+    $this->assertEquals($parameter->post, "\n");
+  }
+
+  public function testBlankValueNoSpacesTrailingNewline() {
+    $text = "first5=\n";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, 'first5');
+    $this->assertEquals($parameter->eq, '=');
+    $this->assertEquals($parameter->val, '');
+    $this->assertEquals($parameter->post, "\n");
+  }
+
+  public function testBlankValueNoEquals() {
+    $text = "first6 \n";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, '');
+    $this->assertEquals($parameter->eq, '');
+    $this->assertEquals($parameter->val, 'first6');
+    $this->assertEquals($parameter->post, " \n");
+  }
+
+  public function testBlankValueNonBreakingSpaces() {
+    $text = " first7 = \n";
+    $parameter = $this->parameter_parse_text_helper($text);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, ' first7 ');  //These are non-breaking spaces
+    $this->assertEquals($parameter->eq, '=');
+    $this->assertEquals($parameter->val, ' ');  //This is a non-breaking space
+    $this->assertEquals($parameter->post, "\n");
+  }
+
+  public function testMultilineParamTrailingNewline() {
+    $text = "multiline\nparam=\n";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, "multiline\nparam");
+    $this->assertEquals($parameter->eq, '=');
+    $this->assertEquals($parameter->val, '');
+    $this->assertEquals($parameter->post, "\n");
+  }
+
+  public function testTwoBracketsInValue() {
+    $text = "title=Synthetic studies on β-lactam antibiotics. Part 10. Synthesis of 7β-[2-carboxy-2-(4-hydroxyphenyl)acetamido]-7.alpha.-methoxy-3-[[(1-methyl-1H-tetrazol-5-yl)thio]methyl]-1-oxa-1-dethia-3-cephem-4-carboxylic acid disodium salt (6059-S) and its related 1-oxacephems";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, 'title');
+    $this->assertEquals($parameter->eq, '=');
+    $this->assertEquals($parameter->val, "Synthetic studies on β-lactam antibiotics. Part 10. Synthesis of 7β-[2-carboxy-2-(4-hydroxyphenyl)acetamido]-7.alpha.-methoxy-3-[[(1-methyl-1H-tetrazol-5-yl)thio]methyl]-1-oxa-1-dethia-3-cephem-4-carboxylic acid disodium salt (6059-S) and its related 1-oxacephems");
+    $this->assertEquals($parameter->post, "");
+  }
+
+  public function testHasProtectedCommentInValue() {
+    $text = "archivedate= 24 April 2008 # # # Citation bot : comment placeholder 0 # # #";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, 'archivedate');
+    $this->assertEquals($parameter->eq, '= ');
+    $this->assertEquals($parameter->val, "24 April 2008 # # # Citation bot : comment placeholder 0 # # #");
+    $this->assertEquals($parameter->post, "");
+  }
+  public function testHasUnreplacedCommentInValue() {
+    $text = "archivedate= 9 August 2006 <!--DASHBot-->";
+    $parameter = $this->parameter_parse_text_helper($text);
+    var_dump($parameter);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, 'archivedate');
+    $this->assertEquals($parameter->eq, '= ');
+    $this->assertEquals($parameter->val, "9 August 2006 <!--DASHBot-->");
+    $this->assertEquals($parameter->post, "");
+  }
+}

--- a/tests/phpunit/ParameterTest.php
+++ b/tests/phpunit/ParameterTest.php
@@ -29,8 +29,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
     $text = "last1 = [[:en:Bigwig%%CITATION_BOT_PIPE_PLACEHOLDER%%SomeoneFamous]]\n";
     $parameter = $this->parameter_parse_text_helper($text);
 
-    var_dump($parameter);
-
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, 'last1');
     $this->assertEquals($parameter->eq, ' = ');
@@ -41,7 +39,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testBlankValueWithSpacesLeadingSpaceTrailingNewline() {
     $text = " first1 = \n";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, ' ');
     $this->assertEquals($parameter->param, 'first1');
@@ -53,7 +50,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testBlankValueWithSpacesAndTrailingNewline() {
     $text = "first2 = \n";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, 'first2');
@@ -65,7 +61,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testBlankValueWithPreEqSpaceAndTrailingNewline() {
     $text = "first3 =\n";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, 'first3');
@@ -77,7 +72,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testBlankValueWithPostEqSpaceAndTrailingNewline() {
     $text = "first4= \n";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, 'first4');
@@ -89,7 +83,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testBlankValueNoSpacesTrailingNewline() {
     $text = "first5=\n";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, 'first5');
@@ -101,7 +94,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testBlankValueNoEquals() {
     $text = "first6 \n";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, '');
@@ -124,7 +116,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testMultilineParamTrailingNewline() {
     $text = "multiline\nparam=\n";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, "multiline\nparam");
@@ -136,7 +127,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testTwoBracketsInValue() {
     $text = "title=Synthetic studies on β-lactam antibiotics. Part 10. Synthesis of 7β-[2-carboxy-2-(4-hydroxyphenyl)acetamido]-7.alpha.-methoxy-3-[[(1-methyl-1H-tetrazol-5-yl)thio]methyl]-1-oxa-1-dethia-3-cephem-4-carboxylic acid disodium salt (6059-S) and its related 1-oxacephems";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, 'title');
@@ -148,7 +138,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testHasProtectedCommentInValue() {
     $text = "archivedate= 24 April 2008 # # # Citation bot : comment placeholder 0 # # #";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, 'archivedate');
@@ -159,7 +148,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
   public function testHasUnreplacedCommentInValue() {
     $text = "archivedate= 9 August 2006 <!--DASHBot-->";
     $parameter = $this->parameter_parse_text_helper($text);
-    var_dump($parameter);
 
     $this->assertEquals($parameter->pre, '');
     $this->assertEquals($parameter->param, 'archivedate');

--- a/tests/phpunit/ParameterTest.php
+++ b/tests/phpunit/ParameterTest.php
@@ -102,6 +102,8 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($parameter->post, " \n");
   }
 
+  // This test may not work, depending on your test environment.
+  // Works on Tool Labs with PHP 5.5.9-1ubuntu4.13 (cli), PHPUnit 3.7.28
   public function testBlankValueNonBreakingSpaces() {
     $text = " first7 = \n";
     $parameter = $this->parameter_parse_text_helper($text);
@@ -133,17 +135,6 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($parameter->eq, '=');
     $this->assertEquals($parameter->val, '');
     $this->assertEquals($parameter->post, "\n");
-  }
-
-  public function testTwoBracketsInValue() {
-    $text = "title=Synthetic studies on β-lactam antibiotics. Part 10. Synthesis of 7β-[2-carboxy-2-(4-hydroxyphenyl)acetamido]-7.alpha.-methoxy-3-[[(1-methyl-1H-tetrazol-5-yl)thio]methyl]-1-oxa-1-dethia-3-cephem-4-carboxylic acid disodium salt (6059-S) and its related 1-oxacephems";
-    $parameter = $this->parameter_parse_text_helper($text);
-
-    $this->assertEquals($parameter->pre, '');
-    $this->assertEquals($parameter->param, 'title');
-    $this->assertEquals($parameter->eq, '=');
-    $this->assertEquals($parameter->val, "Synthetic studies on β-lactam antibiotics. Part 10. Synthesis of 7β-[2-carboxy-2-(4-hydroxyphenyl)acetamido]-7.alpha.-methoxy-3-[[(1-methyl-1H-tetrazol-5-yl)thio]methyl]-1-oxa-1-dethia-3-cephem-4-carboxylic acid disodium salt (6059-S) and its related 1-oxacephems");
-    $this->assertEquals($parameter->post, "");
   }
 
   public function testHasProtectedCommentInValue() {

--- a/tests/phpunit/ParameterTest.php
+++ b/tests/phpunit/ParameterTest.php
@@ -113,6 +113,17 @@ class ParameterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($parameter->post, "\n");
   }
 
+  public function testMultilinevalueTrailingNewline() {
+    $text = "param=multiline\nvalue\n";
+    $parameter = $this->parameter_parse_text_helper($text);
+
+    $this->assertEquals($parameter->pre, '');
+    $this->assertEquals($parameter->param, "param");
+    $this->assertEquals($parameter->eq, '=');
+    $this->assertEquals($parameter->val, "multiline\nvalue");
+    $this->assertEquals($parameter->post, "\n");
+  }
+
   public function testMultilineParamTrailingNewline() {
     $text = "multiline\nparam=\n";
     $parameter = $this->parameter_parse_text_helper($text);

--- a/tests/phpunit/README.md
+++ b/tests/phpunit/README.md
@@ -1,0 +1,4 @@
+##Tests for Citation Bot classes
+To run the tests for Parameter.php (for example), run:
+
+`phpunit --bootstrap /path/to/Parameter.php ParameterTest.php`


### PR DESCRIPTION
* Fix bug where an author param with no value would block author lookup
* Stop parameter-parsing regex from putting newlines before the added value
* Add automated tests for Parameter.php, handle initial Unicode space 