### PR TITLE
pubmed does not believe in capitalization often

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -907,7 +907,7 @@ class Template extends Item {
                 case "Title":   $this->add_if_new('title',  format_title_text(str_replace(array("[", "]"), "",(string) $item),FALSE));
         break;  case "PubDate": preg_match("~(\d+)\s*(\w*)~", $item, $match);
                                 $this->add_if_new('year', (string) $match[1]);
-        break;  case "FullJournalName": $this->add_if_new('journal',  format_title_text((string) $item));
+        break;  case "FullJournalName": $this->add_if_new('journal',  format_title_text(ucwords((string) $item)));
         break;  case "Volume":  $this->add_if_new('volume', (string) $item);
         break;  case "Issue":   $this->add_if_new('issue', (string) $item);
         break;  case "Pages":   $this->add_if_new('pages', (string) $item);


### PR DESCRIPTION
We then count on format_title_text to clean up.  
I worry that MB_CASE_TITLE would change ZooKeys to Zookeys, if pubmed had it right for a change.