### PR TITLE
don't upgrade dashes if more than one

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1779,7 +1779,7 @@ class Template extends Item {
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);
             break; // Don't want 'Edition ed.'
           case 'year':
-            if (preg_match ('~\d{4}\-\d\d\-\d\d~', $p->val)) { // We have more than one dash, must not be range of years.
+            if (preg_match ("~\d\d*\-\d\d*\-\d\d*~", $p->val)) { // We have more than one dash, must not be range of years.
                $this->add_if_new('date', $p->val);
                $this->forget('year');
                break; 

--- a/Template.php
+++ b/Template.php
@@ -1786,7 +1786,7 @@ class Template extends Item {
             }
             // No break here
           case 'pages': case 'page': case 'issue': case 'year':
-            if (!preg_match("~^[A-Za-z ]+\-~", $p->val) && mb_ereg(to_en_dash, $p->val) && (stripos($p->val, "http") === FALSE )) {
+            if (!preg_match("~^[A-Za-z ]+\-~", $p->val) && mb_ereg(to_en_dash, $p->val) && (stripos($p->val, "http") === FALSE)) {
               $this->mod_dashes = TRUE;
               echo ( "\n   ~ Upgrading to en-dash in " . htmlspecialchars($p->param) .
                     " parameter" . tag());

--- a/Template.php
+++ b/Template.php
@@ -1778,8 +1778,15 @@ class Template extends Item {
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);
             break; // Don't want 'Edition ed.'
+          case 'year':
+            if (preg_match ('~\d{4}\-\d\d\-\d\d~', $p->val)) { // We have more than one dash, must not be range of years.
+               $this->add_if_new('date', $p->val);
+               $this->forget('year');
+               break; 
+            }
+            // No break here
           case 'pages': case 'page': case 'issue': case 'year':
-            if (!preg_match("~^[A-Za-z ]+\-~", $p->val) && mb_ereg(to_en_dash, $p->val) && (stripos($p->val, "http") === FALSE && (substr_count($p->val, '-') < 2 || substr_count($p->val, '--') != 0 ))) {
+            if (!preg_match("~^[A-Za-z ]+\-~", $p->val) && mb_ereg(to_en_dash, $p->val) && (stripos($p->val, "http") === FALSE )) {
               $this->mod_dashes = TRUE;
               echo ( "\n   ~ Upgrading to en-dash in " . htmlspecialchars($p->param) .
                     " parameter" . tag());

--- a/Template.php
+++ b/Template.php
@@ -1779,7 +1779,7 @@ class Template extends Item {
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);
             break; // Don't want 'Edition ed.'
           case 'pages': case 'page': case 'issue': case 'year':
-            if (!preg_match("~^[A-Za-z ]+\-~", $p->val) && mb_ereg(to_en_dash, $p->val) && (stripos($p->val, "http") === FALSE)) {
+            if (!preg_match("~^[A-Za-z ]+\-~", $p->val) && mb_ereg(to_en_dash, $p->val) && (stripos($p->val, "http") === FALSE && (substr_count($p->val, '-') < 2 || substr_count($p->val, '--') != 0 ))) {
               $this->mod_dashes = TRUE;
               echo ( "\n   ~ Upgrading to en-dash in " . htmlspecialchars($p->param) .
                     " parameter" . tag());


### PR DESCRIPTION
Unless of course they are next to each other.
This avoids changing 1970-10-7 to invalid date 1970–10–7 (really should not be in year, but date).
This also avoids changing 1-4–1-7 to 1–4–1–7 (page 4 to seven of section 1) .
This still changes if it has -- (of course 1-4--1-7 will get hosed still).