### PR TITLE
Do not flag placeholders as bad DOIs

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -976,12 +976,13 @@ class Template extends Item {
           }
         }
         echo " (ok)";
-      } else {
+      } else if ( stripos( $doi, 'placeholder') === FALSE ) { // Ignore DOIs that are actually comments, etc.
         echo "\n - No CrossRef record found for doi '" . htmlspecialchars($doi) ."'; marking as broken";
         $url_test = "http://dx.doi.org/".$doi ;
         $headers_test = get_headers($url_test, 1);
-        if(empty($headers_test['Location']))
+        if(empty($headers_test['Location'])) {
                 $this->add_if_new('doi-broken-date', date('Y-m-d'));  // Only mark as broken if dx.doi.org also fails to resolve
+        }
       }
     }
   }
@@ -2024,6 +2025,7 @@ class Template extends Item {
 
   protected function verify_doi () {
     $doi = $this->get_without_comments('doi');
+    if (stripos( $doi, 'placeholder') === TRUE) return FALSE ; // Some type of place holder
     if (!$doi) return NULL;
     // DOI not correctly formatted
     switch (substr($doi, -1)) {
@@ -2062,8 +2064,9 @@ class Template extends Item {
       $this->forget("doi_brokendate");
       $url_test = "http://dx.doi.org/".$doi ;
       $headers_test = get_headers($url_test, 1);
-      if(empty($headers_test['Location']))
+      if(empty($headers_test['Location'])) {
          $this->set("doi-broken-date", date("Y-m-d"));  // dx.doi.org might work, even if cross-ref fails
+      }
       echo "\n   ! Broken doi: " . htmlspecialchars($doi);
       return FALSE;
     } else {

--- a/Template.php
+++ b/Template.php
@@ -2058,7 +2058,7 @@ class Template extends Item {
     if ($this->query_crossref() === FALSE) {
       // Replace old "doi_inactivedate" and/or other broken/inactive-date parameters,
       // if present, with new "doi-broken-date"
-      if (stripos( $doi, 'placeholder') === TRUE) return FALSE ; // Some type of place holder.  Test here, just in case real DOI has the phrase placehold in it
+      if (stripos( $doi, 'placeholder') !== FALSE) return FALSE ; // Some type of place holder.  Test here, just in case real DOI has the phrase placehold in it
       $this->forget("doi_inactivedate");
       $this->forget("doi-inactive-date");
       $this->forget("doi_brokendate");

--- a/Template.php
+++ b/Template.php
@@ -976,7 +976,7 @@ class Template extends Item {
           }
         }
         echo " (ok)";
-      } else if ( stripos( $doi, 'placeholder') === FALSE ) { // Ignore DOIs that are actually comments, etc.
+      } elseif ( stripos( $doi, 'placeholder') === FALSE ) { // Ignore DOIs that are actually comments, etc.
         echo "\n - No CrossRef record found for doi '" . htmlspecialchars($doi) ."'; marking as broken";
         $url_test = "http://dx.doi.org/".$doi ;
         $headers_test = get_headers($url_test, 1);

--- a/Template.php
+++ b/Template.php
@@ -2025,7 +2025,6 @@ class Template extends Item {
 
   protected function verify_doi () {
     $doi = $this->get_without_comments('doi');
-    if (stripos( $doi, 'placeholder') === TRUE) return FALSE ; // Some type of place holder
     if (!$doi) return NULL;
     // DOI not correctly formatted
     switch (substr($doi, -1)) {
@@ -2059,6 +2058,7 @@ class Template extends Item {
     if ($this->query_crossref() === FALSE) {
       // Replace old "doi_inactivedate" and/or other broken/inactive-date parameters,
       // if present, with new "doi-broken-date"
+      if (stripos( $doi, 'placeholder') === TRUE) return FALSE ; // Some type of place holder.  Test here, just in case real DOI has the phrase placehold in it
       $this->forget("doi_inactivedate");
       $this->forget("doi-inactive-date");
       $this->forget("doi_brokendate");

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -150,7 +150,7 @@ class TemplateTest extends PHPUnit\Framework\TestCase {
     $expanded = $this->process_citation($text);
     var_dump($expanded->get('doi-brokendate'));
     $this->assertNull($expanded->get('doi-broken-date'));
-    
+  
     $text = '{{cite journal|doi=10.3265/Nefrologia.NOTAREALDOI.broken|title=Acute renal failure due to multiple stings by Africanized bees. Report on 43 cases}}';
     $expanded = $this->process_citation($text);
     $this->assertNotNull($expanded->get('doi-broken-date'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -154,6 +154,10 @@ class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{cite journal|doi=10.3265/Nefrologia.NOTAREALDOI.broken|title=Acute renal failure due to multiple stings by Africanized bees. Report on 43 cases}}';
     $expanded = $this->process_citation($text);
     $this->assertNotNull($expanded->get('doi-broken-date'));
+
+    $text = '{{cite journal|doi= <!-- MC Hammer says to not touch this !-->}}';
+    $expanded = $this->process_citation($text);
+    $this->assertNull($expanded->get('doi-broken-date'));
   }
   
   public function testOpenAccessLookup() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -155,7 +155,7 @@ class TemplateTest extends PHPUnit\Framework\TestCase {
     $expanded = $this->process_citation($text);
     $this->assertNotNull($expanded->get('doi-broken-date'));
 
-    $text = '{{cite journal|doi= <!-- MC Hammer says to not touch this !-->}}';
+    $text = '{{cite journal|doi= <!-- MC Hammer says to not touch this -->}}';
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('doi-broken-date'));
   }


### PR DESCRIPTION
Fixes marking comments are bad DOIS

Changes proposed in this pull request:
- Check for the phrase "placeholder" in DOIs
