### PR TITLE
forgot dashes in ISBN13

### DIFF
--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -404,13 +404,13 @@ ER -  }}';
     $this->assertEquals('9783902823243', $expanded->get('isbn'));   // Unchanged without dashes
     $text = "{{cite book|isbn=3902823240}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('9783902823243', $expanded->get('isbn'));   // Convert without dashes
+    $this->assertEquals('978-3902823243', $expanded->get('isbn'));   // Convert without dashes
     $text = "{{cite book|isbn=1-84309-164-X}}";
     $expanded = $this->process_citation($text);  
     $this->assertEquals('978-1-84309-164-6', $expanded->get('isbn'));  // Convert with dashes and a big X
     $text = "{{cite book|isbn=184309164x}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('9781843091646', $expanded->get('isbn'));  // Convert without dashes and a tiny x
+    $this->assertEquals('978-1843091646', $expanded->get('isbn'));  // Convert without dashes and a tiny x
     $text = "{{cite book|isbn=Hello Brother}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('Hello Brother', $expanded->get('isbn')); // Rubbish unchanged


### PR DESCRIPTION
Fixes incorrect test

Changes proposed in this pull request:
- Make the test check the right values
- ISBN 13 is formated 978-########, not 978#######
-
