### PR TITLE
standardize placeholders

### DIFF
--- a/Comment.php
+++ b/Comment.php
@@ -6,7 +6,7 @@
 require_once('Item.php');
 
 class Comment extends Item {
-  const PLACEHOLDER_TEXT = '# # # Citation bot : comment placeholder %s # # #';
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_COMMENTS %s # # #';
   const REGEXP = '~<!--.*?-->~us';
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
 
@@ -20,7 +20,7 @@ class Comment extends Item {
 }
 
 class Nowiki extends Item {
-  const PLACEHOLDER_TEXT = '# # # Citation bot : no wiki placeholder %s # # #';  // Have space in nowiki so that it does not through some crazy bug match itself recursively
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_NOWIKI %s # # #';  // Have space in nowiki so that it does not through some crazy bug match itself recursively
   const REGEXP = '~<nowiki>.*?</nowiki>~us'; 
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   

--- a/Comment.php
+++ b/Comment.php
@@ -6,7 +6,7 @@
 require_once('Item.php');
 
 class Comment extends Item {
-  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_COMMENTS %s # # #';
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_COMMENT %s # # #';
   const REGEXP = '~<!--.*?-->~us';
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
 

--- a/Page.php
+++ b/Page.php
@@ -202,7 +202,7 @@ class Page {
         echo "\n ! Possible edit conflict detected. Aborting.";
         return FALSE;
       }
-      if ( stripos($this->text,"CITATION_BOT_PLACEHOLDER") != FALSE )  {
+      if ( stripos($this->text,"CITATION_BOT_PLACEHOLDER") !== FALSE )  {
         echo "\n ! Citation bot placeholder left escaped. Aborting.";
         return FALSE;
       }

--- a/Page.php
+++ b/Page.php
@@ -202,8 +202,8 @@ class Page {
         echo "\n ! Possible edit conflict detected. Aborting.";
         return FALSE;
       }
-      if ( stripos($this->text,"Citation bot : comment placeholder") != FALSE )  {
-        echo "\n ! Comment placeholder left escaped. Aborting.";
+      if ( stripos($this->text,"CITATION_BOT_PLACEHOLDER") != FALSE )  {
+        echo "\n ! Citation bot placeholder left escaped. Aborting.";
         return FALSE;
       }
       $submit_vars = array(

--- a/Template.php
+++ b/Template.php
@@ -19,7 +19,7 @@ require_once("Page.php");
 require_once("Parameter.php");
 
 class Template extends Item {
-  const PLACEHOLDER_TEXT = '# # # Citation bot : template placeholder %s # # #';
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_TEMPLATE %s # # #';
   const REGEXP = '~\{\{(?:[^\{]|\{[^\{])+?\}\}~s';
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
 

--- a/constants.php
+++ b/constants.php
@@ -6,7 +6,7 @@ foreach ($constant_files as $file) {
 
 define('HOME', dirname(__FILE__) . '/');
 
-const PIPE_PLACEHOLDER = '%%CITATION_BOT_PIPE_PLACEHOLDER%%';
+const PIPE_PLACEHOLDER = '%%CITATION_BOT_PLACEHOLDER_PIPE%%';
 const TEMP_PLACEHOLDER = "# # # CCITATION_BOT_PLACEHOLDER_TEMPORARY %s # # #";
 const TO_EN_DASH = "--?|\&mdash;|\xe2\x80\x94|\?\?\?"; // regexp for replacing to ndashes using mb_ereg_replace
 const EN_DASH = "\xe2\x80\x93"; // regexp for replacing to ndashes using mb_ereg_replace

--- a/constants.php
+++ b/constants.php
@@ -6,8 +6,8 @@ foreach ($constant_files as $file) {
 
 define('HOME', dirname(__FILE__) . '/');
 
-const PIPE_PLACEHOLDER = '%%CITATION_BOT_PLACEHOLDER_PIPE%%';
-const TEMP_PLACEHOLDER = "# # # CCITATION_BOT_PLACEHOLDER_TEMPORARY %s # # #";
+const PIPE_PLACEHOLDER = '# # # CITATION_BOT_PLACEHOLDER_PIPE # # #';
+const TEMP_PLACEHOLDER = "# # # CITATION_BOT_PLACEHOLDER_TEMPORARY %s # # #";
 const TO_EN_DASH = "--?|\&mdash;|\xe2\x80\x94|\?\?\?"; // regexp for replacing to ndashes using mb_ereg_replace
 const EN_DASH = "\xe2\x80\x93"; // regexp for replacing to ndashes using mb_ereg_replace
 const WIKI_ROOT = "https://en.wikipedia.org/w/index.php?";

--- a/constants.php
+++ b/constants.php
@@ -7,7 +7,7 @@ foreach ($constant_files as $file) {
 define('HOME', dirname(__FILE__) . '/');
 
 const PIPE_PLACEHOLDER = '%%CITATION_BOT_PIPE_PLACEHOLDER%%';
-const TEMP_PLACEHOLDER = "# # # Citation Bot: Temprorary Placeholder %s # # #";
+const TEMP_PLACEHOLDER = "# # # CCITATION_BOT_PLACEHOLDER_TEMPORARY %s # # #";
 const TO_EN_DASH = "--?|\&mdash;|\xe2\x80\x94|\?\?\?"; // regexp for replacing to ndashes using mb_ereg_replace
 const EN_DASH = "\xe2\x80\x93"; // regexp for replacing to ndashes using mb_ereg_replace
 const WIKI_ROOT = "https://en.wikipedia.org/w/index.php?";

--- a/tests/phpunit/ParameterTest.php
+++ b/tests/phpunit/ParameterTest.php
@@ -15,7 +15,7 @@ class ParameterTest extends PHPUnit\Framework\TestCase {
   protected function setUp() {
     if (!defined("PIPE_PLACEHOLDER")) {
 // this is usually done elsewhere in the code
-      define("PIPE_PLACEHOLDER", '%%CITATION_BOT_PLACEHOLDER_PIPE%%');
+      define("PIPE_PLACEHOLDER", '# # # CITATION_BOT_PLACEHOLDER_PIPE # # #');
     }
   }
 
@@ -32,7 +32,7 @@ class ParameterTest extends PHPUnit\Framework\TestCase {
  * FIXME: these tests have too many assertions. Probably will require some refactoring of Parameter::parse_text().
  */
   public function testValueWithPipeAndTrailingNewline() {
-    $text = "last1 = [[:en:Bigwig%%CITATION_BOT_PLACEHOLDER_PIPE%%SomeoneFamous]]\n";
+    $text = "last1 = [[:en:Bigwig# # # CITATION_BOT_PLACEHOLDER_PIPE # # #SomeoneFamous]]\n";
     $parameter = $this->parameter_parse_text_helper($text);
 
     $this->assertEquals($parameter->pre, '');

--- a/tests/phpunit/ParameterTest.php
+++ b/tests/phpunit/ParameterTest.php
@@ -15,7 +15,7 @@ class ParameterTest extends PHPUnit\Framework\TestCase {
   protected function setUp() {
     if (!defined("PIPE_PLACEHOLDER")) {
 // this is usually done elsewhere in the code
-      define("PIPE_PLACEHOLDER", '%%CITATION_BOT_PIPE_PLACEHOLDER%%');
+      define("PIPE_PLACEHOLDER", '%%CITATION_BOT_PLACEHOLDER_PIPE%%');
     }
   }
 
@@ -32,7 +32,7 @@ class ParameterTest extends PHPUnit\Framework\TestCase {
  * FIXME: these tests have too many assertions. Probably will require some refactoring of Parameter::parse_text().
  */
   public function testValueWithPipeAndTrailingNewline() {
-    $text = "last1 = [[:en:Bigwig%%CITATION_BOT_PIPE_PLACEHOLDER%%SomeoneFamous]]\n";
+    $text = "last1 = [[:en:Bigwig%%CITATION_BOT_PLACEHOLDER_PIPE%%SomeoneFamous]]\n";
     $parameter = $this->parameter_parse_text_helper($text);
 
     $this->assertEquals($parameter->pre, '');

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -233,7 +233,7 @@ class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals('1234', $expanded->get('oclc'));
       $this->assertEquals('12345', $expanded->get('ol'));
       $this->assertNotNull($expanded->get('doi-broken-date'));
-      $this->assertEquals(1, preg_match('~' . sprintf(CITATION_BOT_PLACEHOLDER_TEMPLATE, '\d+') . '~i', $expanded->get('id')));
+      $this->assertEquals(1, preg_match('~' . sprintf(Template::CITATION_BOT_PLACEHOLDER, '\d+') . '~i', $expanded->get('id')));
       
       $text = '{{cite book | id={{arxiv|id=1234.5678}}}}';
       $expanded = $this->process_citation($text); // Not process_citation as there's an embedded template

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -233,7 +233,7 @@ class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals('1234', $expanded->get('oclc'));
       $this->assertEquals('12345', $expanded->get('ol'));
       $this->assertNotNull($expanded->get('doi-broken-date'));
-      $this->assertEquals(1, preg_match('~' . sprintf(Template::PLACEHOLDER_TEXT, '\d+') . '~i', $expanded->get('id')));
+      $this->assertEquals(1, preg_match('~' . sprintf(CITATION_BOT_PLACEHOLDER_TEMPLATE, '\d+') . '~i', $expanded->get('id')));
       
       $text = '{{cite book | id={{arxiv|id=1234.5678}}}}';
       $expanded = $this->process_citation($text); // Not process_citation as there's an embedded template

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -233,7 +233,7 @@ class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals('1234', $expanded->get('oclc'));
       $this->assertEquals('12345', $expanded->get('ol'));
       $this->assertNotNull($expanded->get('doi-broken-date'));
-      $this->assertEquals(1, preg_match('~' . sprintf(Template::CITATION_BOT_PLACEHOLDER, '\d+') . '~i', $expanded->get('id')));
+      $this->assertEquals(1, preg_match('~' . sprintf(Template::PLACEHOLDER_TEXT, '\d+') . '~i', $expanded->get('id')));
       
       $text = '{{cite book | id={{arxiv|id=1234.5678}}}}';
       $expanded = $this->process_citation($text); // Not process_citation as there's an embedded template

--- a/tests/phpunit/constantsTest.php
+++ b/tests/phpunit/constantsTest.php
@@ -20,7 +20,7 @@ class constantsTest extends PHPUnit\Framework\TestCase {
   }
 
   public function testConstantsDefined() {
-    $this->assertEquals(PIPE_PLACEHOLDER, '%%CITATION_BOT_PLACEHOLDER_PIPE%%');
+    $this->assertEquals(PIPE_PLACEHOLDER, '# # # CITATION_BOT_PLACEHOLDER_PIPE # # #');
     for ($i = 0; $i < sizeof(JOURNAL_ACRONYMS); $i++) {
       $this->assertEquals(UCFIRST_JOURNAL_ACRONYMS[$i], mb_convert_case(JOURNAL_ACRONYMS[$i], MB_CASE_TITLE, "UTF-8"));
     }

--- a/tests/phpunit/constantsTest.php
+++ b/tests/phpunit/constantsTest.php
@@ -20,7 +20,7 @@ class constantsTest extends PHPUnit\Framework\TestCase {
   }
 
   public function testConstantsDefined() {
-    $this->assertEquals(PIPE_PLACEHOLDER, '%%CITATION_BOT_PIPE_PLACEHOLDER%%');
+    $this->assertEquals(PIPE_PLACEHOLDER, '%%CITATION_BOT_PLACEHOLDER_PIPE%%');
     for ($i = 0; $i < sizeof(JOURNAL_ACRONYMS); $i++) {
       $this->assertEquals(UCFIRST_JOURNAL_ACRONYMS[$i], mb_convert_case(JOURNAL_ACRONYMS[$i], MB_CASE_TITLE, "UTF-8"));
     }


### PR DESCRIPTION
Makes it easier to search for placeholders by standardizing text to:

CITATION_BOT_PLACEHOLDER_XYZ
