### PR TITLE
Fix Gadget API-Do not echo stuff to wikipedia

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -71,10 +71,10 @@ class Page {
     return $this->text;
   }
   
-  public function expand_text($echo_html = TRUE) {
+  public function expand_text($introduce_yourself = TRUE) {
     $safetitle = htmlspecialchars($this->title);
     date_default_timezone_set('UTC');
-    if( $echo_html === TRUE ) {
+    if( $introduce_yourself === TRUE ) {
      html_echo ("\n<hr>[" . date("H:i:s") . "] Processing page '<a href='http://en.wikipedia.org/?title=" 
       . urlencode($this->title) 
       . "' style='text-weight:bold;'>{$safetitle}</a>' &mdash; <a href='http://en.wikipedia.org/?title="

--- a/Page.php
+++ b/Page.php
@@ -74,8 +74,10 @@ class Page {
   public function expand_text() {
     $safetitle = htmlspecialchars($this->title);
     date_default_timezone_set('UTC');
-    //this is set to -1 only in [erstwhile file?] text.php, because there's no need to output
+    // this is set to -1 only in [erstwhile file?] text.php, because there's no need to output
     // a buffer of text for the citation-expander gadget
+    // This is needed because the Gadget API expects only JSON back, and nothing else.
+    // This buffer is later closed with ob_end_clean() which deletes the buffer without printing it
     if (HTML_OUTPUT === -1) {
       ob_start();
     }

--- a/Page.php
+++ b/Page.php
@@ -129,7 +129,7 @@ class Page {
 
     $this->replace_object($comments);
     $this->replace_object($nowiki);
-  
+
     return strcasecmp($this->text, $this->start_text) != 0;
   }
 

--- a/Page.php
+++ b/Page.php
@@ -71,11 +71,15 @@ class Page {
     return $this->text;
   }
   
-  public function expand_text($introduce_yourself = TRUE) {
+  public function expand_text() {
     $safetitle = htmlspecialchars($this->title);
     date_default_timezone_set('UTC');
-    if( $introduce_yourself === TRUE ) {
-     html_echo ("\n<hr>[" . date("H:i:s") . "] Processing page '<a href='http://en.wikipedia.org/?title=" 
+    //this is set to -1 only in [erstwhile file?] text.php, because there's no need to output
+    // a buffer of text for the citation-expander gadget
+    if (HTML_OUTPUT === -1) {
+      ob_start();
+    }
+    html_echo ("\n<hr>[" . date("H:i:s") . "] Processing page '<a href='http://en.wikipedia.org/?title=" 
       . urlencode($this->title) 
       . "' style='text-weight:bold;'>{$safetitle}</a>' &mdash; <a href='http://en.wikipedia.org/?title="
       . urlencode($this->title)
@@ -85,18 +89,11 @@ class Page {
       . "document.title=\"Citation bot: '"
       . str_replace("+", " ", urlencode($this->title)) ."'\";</script>", 
       "\n[" . date("H:i:s") . "] Processing page " . $this->title . "...\n");
-    }
     $text = $this->text;
     $this->modifications = array();
     if (!$text) {
       echo "\n\n  ! No text retrieved.\n";
       return FALSE;
-    }
-
-    //this is set to -1 only in [erstwhile file?] text.php, because there's no need to output
-    // a buffer of text for the citation-expander gadget
-    if (HTML_OUTPUT === -1) {
-      ob_start();
     }
 
     // COMMENTS //

--- a/Page.php
+++ b/Page.php
@@ -74,13 +74,6 @@ class Page {
   public function expand_text() {
     $safetitle = htmlspecialchars($this->title);
     date_default_timezone_set('UTC');
-    // this is set to -1 only in [erstwhile file?] text.php, because there's no need to output
-    // a buffer of text for the citation-expander gadget
-    // This is needed because the Gadget API expects only JSON back, and nothing else.
-    // This buffer is later closed with ob_end_clean() which deletes the buffer without printing it
-    if (HTML_OUTPUT === -1) {
-      ob_start();
-    }
     html_echo ("\n<hr>[" . date("H:i:s") . "] Processing page '<a href='http://en.wikipedia.org/?title=" 
       . urlencode($this->title) 
       . "' style='text-weight:bold;'>{$safetitle}</a>' &mdash; <a href='http://en.wikipedia.org/?title="
@@ -136,12 +129,7 @@ class Page {
 
     $this->replace_object($comments);
     $this->replace_object($nowiki);
-   
-    // seems to be set as -1  in text.php and then re-set
-    if (HTML_OUTPUT === -1) {
-      ob_end_clean();
-    }
-
+  
     return strcasecmp($this->text, $this->start_text) != 0;
   }
 

--- a/Page.php
+++ b/Page.php
@@ -71,10 +71,11 @@ class Page {
     return $this->text;
   }
   
-  public function expand_text() {
+  public function expand_text($echo_html = TRUE) {
     $safetitle = htmlspecialchars($this->title);
     date_default_timezone_set('UTC');
-    html_echo ("\n<hr>[" . date("H:i:s") . "] Processing page '<a href='http://en.wikipedia.org/?title=" 
+    if( $echo_html === TRUE ) {
+     html_echo ("\n<hr>[" . date("H:i:s") . "] Processing page '<a href='http://en.wikipedia.org/?title=" 
       . urlencode($this->title) 
       . "' style='text-weight:bold;'>{$safetitle}</a>' &mdash; <a href='http://en.wikipedia.org/?title="
       . urlencode($this->title)
@@ -84,6 +85,7 @@ class Page {
       . "document.title=\"Citation bot: '"
       . str_replace("+", " ", urlencode($this->title)) ."'\";</script>", 
       "\n[" . date("H:i:s") . "] Processing page " . $this->title . "...\n");
+    }
     $text = $this->text;
     $this->modifications = array();
     if (!$text) {

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Bugs and requested changes are listed here: https://en.wikipedia.org/wiki/User_t
 ## Structure
 
 Basic structure of a Citation bot script:
-* define configuration constants (for instance, `html_output` will allow or suppress
-  buffered output)
+* define configuration constants
 * require `expandFns.php`, which will set up the rest of the needed functions
 * use Page functions to fetch/expand/post the page's text
 

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -35,7 +35,7 @@ try {  // This just exists to block any output to STDERR about uncaught exceptio
   );
 } catch (Exception $e) {
    ob_end_clean();
-   exit(0); 
+   die(0); 
 }
 
 // Throw away all output

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -2,8 +2,6 @@
 header("Access-Control-Allow-Origin: *"); //This is ok because the API is not authenticated
 header("Content-Type: text/json");
 
-define("HTML_OUTPUT", -1);
-
 //Set up tool requirements
 require_once __DIR__ . '/expandFns.php';
 

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -31,6 +31,7 @@ try {
     'editsummary' => $editSummary,
   );
 } catch (Exception $e) {
+   ob_end_clean();
    exit(0);  // This just exists to block any output to STDERR about uncaught exceptions being passed back to Wikipedia
 }
 

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -2,11 +2,10 @@
 header("Access-Control-Allow-Origin: *"); //This is ok because the API is not authenticated
 header("Content-Type: text/json");
 
-// This is needed because the Gadget API expects only JSON back, and nothing else.
-// This buffer is later deleted without printing it by ob_end_clean() 
-// Just to be clear, ALL output from the citation bot is throw away and lost forever other than the JSON output
-// This needs to be the absolute first thing done (Other than the header lines that must be the absolute zeroth thing done)
-// This exact code is not tested currently since it requires running a webserver etc., but we have a copy of this code in the tests
+// This code is not tested, but we have a copy of this code in the tests
+
+// This is needed because the Gadget API expects only JSON back
+// ALL output from the citation bot is throw away
 ob_start();
   
 //Set up tool requirements
@@ -18,7 +17,6 @@ $editSummary = $_POST['summary'];
 //Expand text from postvars
 $page = new Page();
 $page->text = $originalText;
-
 $page->expand_text();
 
 //Modify edit summary to identify bot-assisted edits

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -14,7 +14,7 @@ $editSummary = $_POST['summary'];
 //Expand text from postvars
 $page = new Page();
 $page->text = $originalText;
-$page->expand_text();
+$page->expand_text( FALSE );
 
 //Modify edit summary to identify bot-assisted edits
 if ($editSummary) {

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -8,35 +8,29 @@ header("Content-Type: text/json");
 // This needs to be the absolute first thing done (Other than the header lines that must be the absolute zeroth thing done)
 // This exact code is not tested currently since it requires running a webserver etc., but we have a copy of this code in the tests
 ob_start();
-
-try {  // This just exists to block any output to STDERR about uncaught exceptions being passed back to Wikipedia
   
-  //Set up tool requirements
-  require_once __DIR__ . '/expandFns.php';
+//Set up tool requirements
+require_once __DIR__ . '/expandFns.php';
 
-  $originalText = $_POST['text'];
-  $editSummary = $_POST['summary'];
+$originalText = $_POST['text'];
+$editSummary = $_POST['summary'];
 
-  //Expand text from postvars
-  $page = new Page();
-  $page->text = $originalText;
+//Expand text from postvars
+$page = new Page();
+$page->text = $originalText;
 
-  $page->expand_text();
+$page->expand_text();
 
-  //Modify edit summary to identify bot-assisted edits
-  if ($editSummary) {
-    $editSummary .= " | ";
-  }
-  $editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
-
-  $result = array(
-    'expandedtext' => $page->text,
-    'editsummary' => $editSummary,
-  );
-} catch (Exception $e) {
-   ob_end_clean();
-   die(0); 
+//Modify edit summary to identify bot-assisted edits
+if ($editSummary) {
+  $editSummary .= " | ";
 }
+$editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
+
+$result = array(
+  'expandedtext' => $page->text,
+  'editsummary' => $editSummary,
+);
 
 // Throw away all output
 ob_end_clean();

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -2,10 +2,7 @@
 header("Access-Control-Allow-Origin: *"); //This is ok because the API is not authenticated
 header("Content-Type: text/json");
 
-// This code is not tested, but we have a copy of this code in the tests
-
-// This is needed because the Gadget API expects only JSON back
-// ALL output from the citation bot is throw away
+// This is needed because the Gadget API expects only JSON back, therefore ALL output from the citation bot is thrown away
 ob_start();
   
 //Set up tool requirements

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -2,34 +2,39 @@
 header("Access-Control-Allow-Origin: *"); //This is ok because the API is not authenticated
 header("Content-Type: text/json");
 
-//Set up tool requirements
-require_once __DIR__ . '/expandFns.php';
-
-$originalText = $_POST['text'];
-$editSummary = $_POST['summary'];
-
-//Expand text from postvars
-$page = new Page();
-$page->text = $originalText;
-
 // This is needed because the Gadget API expects only JSON back, and nothing else.
 // This buffer is later closed with ob_end_clean() which deletes the buffer without printing it
+// This needs to be the absolute first thing done (Other than the header lines that must be the zeroth thing done)
 ob_start();
 
-$page->expand_text();
+try {
+  //Set up tool requirements
+  require_once __DIR__ . '/expandFns.php';
 
-//Modify edit summary to identify bot-assisted edits
-if ($editSummary) {
-  $editSummary .= " | ";
+  $originalText = $_POST['text'];
+  $editSummary = $_POST['summary'];
+
+  //Expand text from postvars
+  $page = new Page();
+  $page->text = $originalText;
+
+  $page->expand_text();
+
+  //Modify edit summary to identify bot-assisted edits
+  if ($editSummary) {
+    $editSummary .= " | ";
+  }
+  $editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
+
+  $result = array(
+    'expandedtext' => $page->text,
+    'editsummary' => $editSummary,
+  );
+} catch (Exception $e) {
+   exit(0);  // This just exists to block any output to STDERR about uncaught exceptions being passed back to Wikipedia
 }
-$editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
-
-$result = array(
-  'expandedtext' => $page->text,
-  'editsummary' => $editSummary,
-);
 
 // Throw away all output
 ob_end_clean();
 
-echo json_encode($result);
+echo json_encode($result);  // On error returns "FALSE", which makes echo print nothing.  Thus we do not have to check for FALSE

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -3,7 +3,7 @@ header("Access-Control-Allow-Origin: *"); //This is ok because the API is not au
 header("Content-Type: text/json");
 
 //Configure setting to suppress buffered output
-define("HTML_OUTPUT", -1);
+define("HTML_OUTPUT", FALSE);
 
 //Set up tool requirements
 require_once __DIR__ . '/expandFns.php';
@@ -14,7 +14,7 @@ $editSummary = $_POST['summary'];
 //Expand text from postvars
 $page = new Page();
 $page->text = $originalText;
-$page->expand_text( FALSE );
+$page->expand_text( HTML_OUTPUT );
 
 //Modify edit summary to identify bot-assisted edits
 if ($editSummary) {

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -6,7 +6,7 @@ header("Content-Type: text/json");
 // This buffer is later deleted without printing it by ob_end_clean() 
 // Just to be clear, ALL output from the citation bot is throw away and lost forever other than the JSON output
 // This needs to be the absolute first thing done (Other than the header lines that must be the absolute zeroth thing done)
-// This code is not tested currently, since we trust the ob_* functions, the try block, and the json_encode function to do their jobs
+// This exact code is not tested currently since it requires running a webserver etc., but we have a copy of this code in the tests
 ob_start();
 
 try {  // This just exists to block any output to STDERR about uncaught exceptions being passed back to Wikipedia

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -14,7 +14,7 @@ $editSummary = $_POST['summary'];
 //Expand text from postvars
 $page = new Page();
 $page->text = $originalText;
-$page->expand_text( FALSE );
+$page->expand_text();
 
 //Modify edit summary to identify bot-assisted edits
 if ($editSummary) {

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -3,7 +3,7 @@ header("Access-Control-Allow-Origin: *"); //This is ok because the API is not au
 header("Content-Type: text/json");
 
 //Configure setting to suppress buffered output
-define("HTML_OUTPUT", FALSE);
+define("HTML_OUTPUT", -1);
 
 //Set up tool requirements
 require_once __DIR__ . '/expandFns.php';
@@ -14,7 +14,7 @@ $editSummary = $_POST['summary'];
 //Expand text from postvars
 $page = new Page();
 $page->text = $originalText;
-$page->expand_text( HTML_OUTPUT );
+$page->expand_text( FALSE );
 
 //Modify edit summary to identify bot-assisted edits
 if ($editSummary) {

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -2,7 +2,6 @@
 header("Access-Control-Allow-Origin: *"); //This is ok because the API is not authenticated
 header("Content-Type: text/json");
 
-//Configure setting to suppress buffered output
 define("HTML_OUTPUT", -1);
 
 //Set up tool requirements
@@ -14,6 +13,11 @@ $editSummary = $_POST['summary'];
 //Expand text from postvars
 $page = new Page();
 $page->text = $originalText;
+
+// This is needed because the Gadget API expects only JSON back, and nothing else.
+// This buffer is later closed with ob_end_clean() which deletes the buffer without printing it
+ob_start();
+
 $page->expand_text();
 
 //Modify edit summary to identify bot-assisted edits
@@ -26,5 +30,8 @@ $result = array(
   'expandedtext' => $page->text,
   'editsummary' => $editSummary,
 );
+
+// Throw away all output
+ob_end_clean();
 
 echo json_encode($result);

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -3,11 +3,14 @@ header("Access-Control-Allow-Origin: *"); //This is ok because the API is not au
 header("Content-Type: text/json");
 
 // This is needed because the Gadget API expects only JSON back, and nothing else.
-// This buffer is later closed with ob_end_clean() which deletes the buffer without printing it
-// This needs to be the absolute first thing done (Other than the header lines that must be the zeroth thing done)
+// This buffer is later deleted without printing it by ob_end_clean() 
+// Just to be clear, ALL output from the citation bot is throw away and lost forever other than the JSON output
+// This needs to be the absolute first thing done (Other than the header lines that must be the absolute zeroth thing done)
+// This code is not tested currently, since we trust the ob_* functions, the try block, and the json_encode function to do their jobs
 ob_start();
 
-try {
+try {  // This just exists to block any output to STDERR about uncaught exceptions being passed back to Wikipedia
+  
   //Set up tool requirements
   require_once __DIR__ . '/expandFns.php';
 
@@ -32,7 +35,7 @@ try {
   );
 } catch (Exception $e) {
    ob_end_clean();
-   exit(0);  // This just exists to block any output to STDERR about uncaught exceptions being passed back to Wikipedia
+   exit(0); 
 }
 
 // Throw away all output

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -564,7 +564,7 @@ ER -  }}';
            'editsummary' => $editSummary,
        );
        $expanded = json_encode($result);
-       $this->assertEquals('{"expandedtext":"This is a page. {{Cite web|url=http:\/\/apple.com\/phones\/buy_android}}. Indeed it is","editsummary":"I made this page | [[WP:UCB|Assisted by Citation bot]]"}',$expanded);
+       $this->assertEquals(base64_encode('{"expandedtext":"This is a page. {{Cite web|url=http:\/\/apple.com\/phones\/buy_android}}. Indeed it is","editsummary":"I made this page | [[WP:UCB|Assisted by Citation bot]]"}'),base64_encode($expanded));
    }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -563,30 +563,6 @@ ER -  }}';
        $expanded = $this->process_citation($text);
        $this->assertEquals('cite book', $expanded->wikiname());
    }
-    
-   public function testGadgetAPI() {
-       // This does not really test API right now, but it does emulate it without firing up a webserver etc.
-       $originalText = 'This is a page.  {{Cite web|website=apple.com/phones/buy_android}}.  Indeed it is';
-       $editSummary  = 'I made this page';
-
-       $page = new Page();
-       $page->text = $originalText;
-       $page->start_text = $originalText; // Only in test environment.  Not in GadgetAPI
-       $page->expand_text();
-
-       //Modify edit summary to identify bot-assisted edits
-       if ($editSummary) {
-          $editSummary .= " | ";
-       }
-       $editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
-
-       $result = array(
-           'expandedtext' => $page->text,
-           'editsummary' => $editSummary,
-       );
-       $expanded = json_encode($result);
-       $this->assertEquals('{"expandedtext":"This is a page.  {{Cite web|url=http:\/\/apple.com\/phones\/buy_android}}.  Indeed it is","editsummary":"I made this page | [[WP:UCB|Assisted by Citation bot]]"}',$expanded);
-   }
 
    public function testPagesDash() {
        $text = '{{cite journal|pages=1-2|title=do change}}';

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -564,7 +564,7 @@ ER -  }}';
            'editsummary' => $editSummary,
        );
        $expanded = json_encode($result);
-       $this->assertEquals(base64_encode('{"expandedtext":"This is a page.  {{Cite web|url=http:\/\/apple.com\/phones\/buy_android}}.  Indeed it is","editsummary":"I made this page | [[WP:UCB|Assisted by Citation bot]]"}'),base64_encode($expanded));
+       $this->assertEquals('{"expandedtext":"This is a page.  {{Cite web|url=http:\/\/apple.com\/phones\/buy_android}}.  Indeed it is","editsummary":"I made this page | [[WP:UCB|Assisted by Citation bot]]"}',$expanded);
    }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -550,7 +550,7 @@ ER -  }}';
 
        $page = new Page();
        $page->text = $originalText;
-       $this->start_text = $originalText; // Only in test environment.  Not in GadgetAPI
+       $page->start_text = $originalText; // Only in test environment.  Not in GadgetAPI
        $page->expand_text();
 
        //Modify edit summary to identify bot-assisted edits

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -563,7 +563,7 @@ ER -  }}';
        $expanded = $this->process_citation($text);
        $this->assertEquals('cite book', $expanded->wikiname());
    }
-
+    
    public function testPagesDash() {
        $text = '{{cite journal|pages=1-2|title=do change}}';
        $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -545,12 +545,12 @@ ER -  }}';
     
    public function testGadgetAPI() {
        // This does not really test API right now, but it does emulate it without firing up a webserver etc.
-       $originalText = 'This is a page.  {{Cite web|url=http://apple.com}}.  Indeed it is';
+       $originalText = 'This is a page.  {{Cite web|website=apple.com/phones/buy_android}}.  Indeed it is';
        $editSummary  = 'I made this page';
 
        $page = new Page();
        $page->text = $originalText;
-
+       $this->start_text = $originalText; // Only in test environment.  Not in GadgetAPI
        $page->expand_text();
 
        //Modify edit summary to identify bot-assisted edits

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -542,6 +542,30 @@ ER -  }}';
        $expanded = $this->process_citation($text);
        $this->assertEquals('cite book', $expanded->wikiname());
    }
+    
+   public function testGadgetAPI() {
+       // This does not really test API right now, but it does emulate it without firing up a webserver etc.
+       $originalText = 'This is a page.  {{Cite web|url=http://apple.com}}.  Indeed it is';
+       $editSummary  = 'I made this page';
+
+       $page = new Page();
+       $page->text = $originalText;
+
+       $page->expand_text();
+
+       //Modify edit summary to identify bot-assisted edits
+       if ($editSummary) {
+          $editSummary .= " | ";
+       }
+       $editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
+
+       $result = array(
+           'expandedtext' => $page->text,
+           'editsummary' => $editSummary,
+       );
+       $expanded = json_encode($result);
+       $this->assertEquals('WANTED',$expanded);
+   }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors
   Test finding a DOI and using it to expand a paper [See testLongAuthorLists - Arxiv example?]

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -564,7 +564,7 @@ ER -  }}';
            'editsummary' => $editSummary,
        );
        $expanded = json_encode($result);
-       $this->assertEquals('WANTED',$expanded);
+       $this->assertEquals('{"expandedtext":"This is a page. {{Cite web|url=http:\/\/apple.com\/phones\/buy_android}}. Indeed it is","editsummary":"I made this page | [[WP:UCB|Assisted by Citation bot]]"}',$expanded);
    }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -564,7 +564,7 @@ ER -  }}';
            'editsummary' => $editSummary,
        );
        $expanded = json_encode($result);
-       $this->assertEquals(base64_encode('{"expandedtext":"This is a page. {{Cite web|url=http:\/\/apple.com\/phones\/buy_android}}. Indeed it is","editsummary":"I made this page | [[WP:UCB|Assisted by Citation bot]]"}'),base64_encode($expanded));
+       $this->assertEquals(base64_encode('{"expandedtext":"This is a page.  {{Cite web|url=http:\/\/apple.com\/phones\/buy_android}}.  Indeed it is","editsummary":"I made this page | [[WP:UCB|Assisted by Citation bot]]"}'),base64_encode($expanded));
    }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors


### PR DESCRIPTION
Fixes Gadget API.

Bot sends this when processes page with simply "MyText":
[15:36:43] Processing page ...
{"expandedtext":"MyText","editsummary":"\/* Testing *\/  | [[WP:UCB|Assisted by Citation bot]]"}
Leads to error on wiki side because of processing page line is not valid json:
SyntaxError: JSON.parse: expected ',' or ']' after array element at line 2 column 4 of the JSON data

I was confused about cause.  Turns out that HTML had nothing to do with it.

This turns on the eating of the buffer sooner.