### PR TITLE
Do not reformat Wiki-linked journal names

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -428,7 +428,11 @@ class Template extends Item {
       
       case 'volume':
         if ($this->blank($param_name)) {
-          if (in_array(strtolower($this->get('journal')), HAS_NO_VOLUME) === TRUE ) {
+          $temp_string = strtolower($this->get('journal')) ;
+          if(substr($temp_string,0,2) === "[[" && substr($temp_string,-2) === "]]") {  // Wikilinked journal title 
+               $temp_string = substr(substr($temp_string,2),0,-2); // Remove [[ and ]]
+          }
+          if (in_array($temp_string, HAS_NO_VOLUME) === TRUE ) {
             // This journal has no volume.  This is really the issue number
             return $this->add_if_new('issue', $value);
           } else {

--- a/expandFns.php
+++ b/expandFns.php
@@ -237,10 +237,10 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
     create_function('$matches', 'return "\'\'" . ucfirst(strtolower($matches[\'taxon\'])) . "\'\' " . strtolower($matches["nova"]);'),
     $new_case);
   
-  // Capitalization exceptions, e.g. Elife -> eLife  
+  // Capitalization exceptions, e.g. Elife -> eLife
   $new_case = str_replace(UCFIRST_JOURNAL_ACRONYMS, JOURNAL_ACRONYMS, " " .  $new_case . " ");
   $new_case = substr($new_case, 1, strlen($new_case) - 2); // remove spaces, needed for matching in LC_SMALL_WORDS
-
+    
   /* I believe we can do without this now
   if (preg_match("~^(the|into|at?|of)\b~", $new_case)) {
     // If first word is a little word, it should still be capitalized

--- a/expandFns.php
+++ b/expandFns.php
@@ -202,7 +202,10 @@ function restore_italics ($text) {
  */
 function title_capitalization($in, $caps_after_punctuation = TRUE) {
   // Use 'straight quotes' per WP:MOS
-  $new_case = straighten_quotes($in);
+  $new_case = straighten_quotes(trim($in));
+  if(substr($new_case,0,2) === "[[" && substr($new_case,-2) === "]]") {
+     return $new_case;  // And now we ignore wikilinked names since who knows what's going on there.  We would need to not break links.  Deal with [[Journal YZ|J. YZ]] etc.
+  }
   
   if ( $new_case == mb_strtoupper($new_case) 
      && mb_strlen(str_replace(array("[", "]"), "", trim($in))) > 6
@@ -234,15 +237,10 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
     create_function('$matches', 'return "\'\'" . ucfirst(strtolower($matches[\'taxon\'])) . "\'\' " . strtolower($matches["nova"]);'),
     $new_case);
   
-  // Capitalization exceptions, e.g. Elife -> eLife
+  // Capitalization exceptions, e.g. Elife -> eLife  
   $new_case = str_replace(UCFIRST_JOURNAL_ACRONYMS, JOURNAL_ACRONYMS, " " .  $new_case . " ");
   $new_case = substr($new_case, 1, strlen($new_case) - 2); // remove spaces, needed for matching in LC_SMALL_WORDS
-  // And now with wikilinked names, e.g. [[Elife]] -> [[eLife]]
-  if(substr($new_case,0,2) === "[[" && substr($new_case,-2) === "]]") {
-    $new_case = substr(substr($new_case,2),0,-2); // Remove [[ and ]]
-    $new_case = str_replace(UCFIRST_JOURNAL_ACRONYMS, JOURNAL_ACRONYMS, " " .  $new_case . " ");
-    $new_case = '[[' . substr($new_case, 1, strlen($new_case) - 2) . ']]';
-  }
+
   /* I believe we can do without this now
   if (preg_match("~^(the|into|at?|of)\b~", $new_case)) {
     // If first word is a little word, it should still be capitalized

--- a/expandFns.php
+++ b/expandFns.php
@@ -237,7 +237,12 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
   // Capitalization exceptions, e.g. Elife -> eLife
   $new_case = str_replace(UCFIRST_JOURNAL_ACRONYMS, JOURNAL_ACRONYMS, " " .  $new_case . " ");
   $new_case = substr($new_case, 1, strlen($new_case) - 2); // remove spaces, needed for matching in LC_SMALL_WORDS
-    
+  // And now with wikilinked names, e.g. [[Elife]] -> [[eLife]]
+  if(substr($new_case,0,2) === "[[" && substr($new_case,-2) === "]]") {
+    $new_case = substr(substr($new_case,2),0,-2); // Remove [[ and ]]
+    $new_case = str_replace(UCFIRST_JOURNAL_ACRONYMS, JOURNAL_ACRONYMS, " " .  $new_case . " ");
+    $new_case = '[[' . substr($new_case, 1, strlen($new_case) - 2) . ']]';
+  }
   /* I believe we can do without this now
   if (preg_match("~^(the|into|at?|of)\b~", $new_case)) {
     // If first word is a little word, it should still be capitalized

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -508,7 +508,7 @@ ER -  }}';
       $this->assertNull($expanded->get('volume'));
       $text = '{{Cite journal|doi=10.3897/zookeys.445.7778|journal=[[Zookeys]]}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('[[Zookeys]]', $expanded->get('journal'));
+      $this->assertEquals('[[Zookeys]]', $expanded->get('journal'));  // This is wrong capitalization, but because of [[ ]], we leave alone, not wanting to break links
       $this->assertEquals('445', $expanded->get('issue'));
       $this->assertNull($expanded->get('volume'));
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -508,7 +508,7 @@ ER -  }}';
       $this->assertNull($expanded->get('volume'));
       $text = '{{Cite journal|doi=10.3897/zookeys.445.7778|journal=[[Zookeys]]}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('[[ZooKeys]]', $expanded->get('journal'));
+      $this->assertEquals('[[Zookeys]]', $expanded->get('journal'));
       $this->assertEquals('445', $expanded->get('issue'));
       $this->assertNull($expanded->get('volume'));
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -506,6 +506,11 @@ ER -  }}';
       $this->assertEquals('ZooKeys', $expanded->get('journal'));
       $this->assertEquals('445', $expanded->get('issue'));
       $this->assertNull($expanded->get('volume'));
+      $text = '{{Cite journal|doi=10.3897/zookeys.445.7778|journal=[[zookeys]]}}';
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('[[ZooKeys]]', $expanded->get('journal'));
+      $this->assertEquals('445', $expanded->get('issue'));
+      $this->assertNull($expanded->get('volume'));
   }
   public function testTitleItalics(){
       $text = '{{cite journal|doi=10.1111/pala.12168}}';

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -25,7 +25,6 @@ class TemplateTest extends PHPUnit\Framework\TestCase {
   protected function process_citation($text) {
     $template = new Template();
     $template->parse_text($text);
-    $template->process();
     return $template;
   }
   
@@ -500,18 +499,27 @@ ER -  }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('Synthetic studies on β-lactam antibiotics. Part 10. Synthesis of 7β-&#91;2-carboxy-2-(4-hydroxyphenyl)acetamido&#93;-7.alpha.-methoxy-3-&#91;&#91;(1-methyl-1H-tetrazol-5-yl)thio&#93;methyl&#93;-1-oxa-1-dethia-3-cephem-4-carboxylic acid disodium salt (6059-S) and its related 1-oxacephems', $expanded->get('title'));
   }
+   
+      
+  public function testWikiJournalsWikilinked() {
+      $text = '{{cite journal | author = Welch J. J. | year = 2010 | title = The "Island Rule" and Deep-Sea Gastropods: Re-Examining the Evidence | journal = [[PLOS ONE]] | volume = 5 | issue = 1| page = e8776 | doi = 10.1371/journal.pone.0008776 |bibcode = 2010PLoSO...5.8776W | pmid=20098740 | pmc=2808249}}';
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('[[PLOS ONE]]', $expanded->get('journal'));
+  }
+    
   public function testZooKeys() {
       $text = '{{Cite journal|doi=10.3897/zookeys.445.7778}}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('ZooKeys', $expanded->get('journal'));
       $this->assertEquals('445', $expanded->get('issue'));
       $this->assertNull($expanded->get('volume'));
-      $text = '{{Cite journal|doi=10.3897/zookeys.445.7778|journal=[[zookeys]]}}';
+      $text = '{{Cite journal|doi=10.3897/zookeys.445.7778|journal=[[Zookeys]]}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('[[ZooKeys]]', $expanded->get('journal'));
+      $this->assertEquals('[[Zookeys]]', $expanded->get('journal'));  // We do not fix existing stuff
       $this->assertEquals('445', $expanded->get('issue'));
       $this->assertNull($expanded->get('volume'));
   }
+    
   public function testTitleItalics(){
       $text = '{{cite journal|doi=10.1111/pala.12168}}';
       $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -25,6 +25,7 @@ class TemplateTest extends PHPUnit\Framework\TestCase {
   protected function process_citation($text) {
     $template = new Template();
     $template->parse_text($text);
+    $template->process();
     return $template;
   }
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -500,7 +500,6 @@ ER -  }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('Synthetic studies on β-lactam antibiotics. Part 10. Synthesis of 7β-&#91;2-carboxy-2-(4-hydroxyphenyl)acetamido&#93;-7.alpha.-methoxy-3-&#91;&#91;(1-methyl-1H-tetrazol-5-yl)thio&#93;methyl&#93;-1-oxa-1-dethia-3-cephem-4-carboxylic acid disodium salt (6059-S) and its related 1-oxacephems', $expanded->get('title'));
   }
-
   public function testZooKeys() {
       $text = '{{Cite journal|doi=10.3897/zookeys.445.7778}}';
       $expanded = $this->process_citation($text);
@@ -513,13 +512,12 @@ ER -  }}';
       $this->assertEquals('445', $expanded->get('issue'));
       $this->assertNull($expanded->get('volume'));
   }
-
   public function testTitleItalics(){
       $text = '{{cite journal|doi=10.1111/pala.12168}}';
       $expanded = $this->process_citation($text);
       $this->assertEquals("The macro- and microfossil record of the Cambrian priapulid ''Ottoia''", $expanded->get('title'));
   }
-
+ 
   public function testSpeciesCaps() {
     $text = '{{Cite journal | doi = 10.1007%2Fs001140100225}}';
     $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -500,14 +500,7 @@ ER -  }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('Synthetic studies on β-lactam antibiotics. Part 10. Synthesis of 7β-&#91;2-carboxy-2-(4-hydroxyphenyl)acetamido&#93;-7.alpha.-methoxy-3-&#91;&#91;(1-methyl-1H-tetrazol-5-yl)thio&#93;methyl&#93;-1-oxa-1-dethia-3-cephem-4-carboxylic acid disodium salt (6059-S) and its related 1-oxacephems', $expanded->get('title'));
   }
-   
-      
-  public function testWikiJournalsWikilinked() {
-      $text = '{{cite journal | author = Welch J. J. | year = 2010 | title = The "Island Rule" and Deep-Sea Gastropods: Re-Examining the Evidence | journal = [[PLOS ONE]] | volume = 5 | issue = 1| page = e8776 | doi = 10.1371/journal.pone.0008776 |bibcode = 2010PLoSO...5.8776W | pmid=20098740 | pmc=2808249}}';
-      $expanded = $this->process_citation($text);
-      $this->assertEquals('[[PLOS ONE]]', $expanded->get('journal'));
-  }
-    
+
   public function testZooKeys() {
       $text = '{{Cite journal|doi=10.3897/zookeys.445.7778}}';
       $expanded = $this->process_citation($text);
@@ -516,17 +509,17 @@ ER -  }}';
       $this->assertNull($expanded->get('volume'));
       $text = '{{Cite journal|doi=10.3897/zookeys.445.7778|journal=[[Zookeys]]}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('[[Zookeys]]', $expanded->get('journal'));  // We do not fix existing stuff
+      $this->assertEquals('[[ZooKeys]]', $expanded->get('journal'));
       $this->assertEquals('445', $expanded->get('issue'));
       $this->assertNull($expanded->get('volume'));
   }
-    
+
   public function testTitleItalics(){
       $text = '{{cite journal|doi=10.1111/pala.12168}}';
       $expanded = $this->process_citation($text);
       $this->assertEquals("The macro- and microfossil record of the Cambrian priapulid ''Ottoia''", $expanded->get('title'));
   }
- 
+
   public function testSpeciesCaps() {
     $text = '{{Cite journal | doi = 10.1007%2Fs001140100225}}';
     $expanded = $this->process_citation($text);


### PR DESCRIPTION
Fixes existing wiki-linked names getting formatted.  We just leave as-is.