### PR TITLE
Forget dx.doi.org URLS when getting DOIs from them

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -631,11 +631,16 @@ class Template extends Item {
       } elseif (preg_match("~^https?://d?x?\.?doi\.org/([^\?]*)~", $url, $match)) {
         quiet_echo("\n   ~ URL is hard-coded DOI; converting to use DOI parameter.");
         if (strpos($this->name, 'web')) $this->name = 'Cite journal';
+        if (is_null($url_sent)) {
+          $this->forget('url');
+        }
         return $this->add_if_new("doi", urldecode($match[1])); // Will expand from DOI when added
         
       } elseif (extract_doi($url)[1]) {
-        
         quiet_echo("\n   ~ Recognized DOI in URL; dropping URL");
+        if (is_null($url_sent)) {
+          $this->forget('url');
+        }
         return $this->add_if_new('doi', extract_doi($url)[1]);
         
       } elseif (preg_match("~\barxiv\.org/.*(?:pdf|abs)/(.+)$~", $url, $match)) {

--- a/Template.php
+++ b/Template.php
@@ -638,9 +638,6 @@ class Template extends Item {
         
       } elseif (extract_doi($url)[1]) {
         quiet_echo("\n   ~ Recognized DOI in URL; dropping URL");
-        if (is_null($url_sent)) {
-          $this->forget('url');
-        }
         return $this->add_if_new('doi', extract_doi($url)[1]);
         
       } elseif (preg_match("~\barxiv\.org/.*(?:pdf|abs)/(.+)$~", $url, $match)) {

--- a/Template.php
+++ b/Template.php
@@ -637,6 +637,7 @@ class Template extends Item {
         return $this->add_if_new("doi", urldecode($match[1])); // Will expand from DOI when added
         
       } elseif (extract_doi($url)[1]) {
+        
         quiet_echo("\n   ~ Recognized DOI in URL; dropping URL");
         return $this->add_if_new('doi', extract_doi($url)[1]);
         


### PR DESCRIPTION
Fixes inconsistency in using URLS.  
When we find a DOI, get rid of URL and add DOI.