### PR TITLE
Both encoded and non-encoded Jstor SICI tests

### DIFF
--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -538,6 +538,9 @@ ER -  }}';
        $text = '{{Cite journal|url=https://www.jstor.org/sici?sici=0003-0279(196101/03)81:1<43:WLIMP>2.0.CO;2-9}}';
        $expanded = $this->process_citation($text);
        $this->assertEquals('594900', $expanded->get('jstor'));
+       $text = '{{Cite journal|url=https://www.jstor.org/sici?sici=0080-4649(1969)173%3A1031%3C235%3ATPOBAG%3E2.0}}';
+       $expanded = $this->process_citation($text);
+       $this->assertEquals('75817', $expanded->get('jstor'));
    }
     
    public function getDateAndYear($input){

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -538,9 +538,13 @@ ER -  }}';
        $text = '{{Cite journal|url=https://www.jstor.org/sici?sici=0003-0279(196101/03)81:1<43:WLIMP>2.0.CO;2-9}}';
        $expanded = $this->process_citation($text);
        $this->assertEquals('594900', $expanded->get('jstor'));
-       $text = '{{Cite journal|url=https://www.jstor.org/sici?sici=0080-4649(1969)173%3A1031%3C235%3ATPOBAG%3E2.0}}';
+  }
+    
+    
+   public function testJstorSICIEncoded() {
+       $text = '{{Cite journal|url=https://www.jstor.org/sici?sici=0003-0279(196101%2F03)81%3A1%3C43%3AWLIMP%3E2.0.CO%3B2-9}}';
        $expanded = $this->process_citation($text);
-       $this->assertEquals('75817', $expanded->get('jstor'));
+       $this->assertEquals('594900', $expanded->get('jstor'));
    }
     
    public function getDateAndYear($input){


### PR DESCRIPTION
Instead of "either or", do "both and".
Have an encoded and non-encoded test
Made them separate tests so that the first one failing does not stop the second one from trying.