### PR TITLE
Add debug option to gadget API

### DIFF
--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/expandFns.php';
 
 $originalText = $_POST['text'];
 $editSummary = $_POST['summary'];
+$debug_mode = isset($_REQUEST['debug']) && $_REQUEST['debug']==='1';
 
 //Expand text from postvars
 $page = new Page();
@@ -22,10 +23,19 @@ if ($editSummary) {
 }
 $editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
 
-$result = array(
+if ($debug_mode) {
+ $debug_text = ob_get_contents();
+ $result = array(
   'expandedtext' => $page->text,
   'editsummary' => $editSummary,
-);
+  'debug' => $debug_text;
+ );
+} else {
+ $result = array(
+  'expandedtext' => $page->text,
+  'editsummary' => $editSummary,
+ );
+}
 
 // Throw away all output
 ob_end_clean();

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -10,7 +10,6 @@ require_once __DIR__ . '/expandFns.php';
 
 $originalText = $_POST['text'];
 $editSummary = $_POST['summary'];
-$debug_mode = isset($_REQUEST['debug']) && $_REQUEST['debug']==='1';
 
 //Expand text from postvars
 $page = new Page();
@@ -23,8 +22,8 @@ if ($editSummary) {
 }
 $editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
 
-if ($debug_mode) {
- $debug_text = ob_get_contents();
+if (isset($_REQUEST['debug']) && $_REQUEST['debug']==='1') {
+  $debug_text = ob_get_contents();
 } else {
   $debug_text = '';
 }
@@ -33,8 +32,7 @@ $result = array(
   'expandedtext' => $page->text,
   'editsummary' => $editSummary,
   'debug' => $debug_text;
- );
-}
+);
 
 // Throw away all output
 ob_end_clean();

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -25,15 +25,14 @@ $editSummary .= "[[WP:UCB|Assisted by Citation bot]]";
 
 if ($debug_mode) {
  $debug_text = ob_get_contents();
- $result = array(
+} else {
+  $debug_text = '';
+}
+
+$result = array(
   'expandedtext' => $page->text,
   'editsummary' => $editSummary,
   'debug' => $debug_text;
- );
-} else {
- $result = array(
-  'expandedtext' => $page->text,
-  'editsummary' => $editSummary,
  );
 }
 


### PR DESCRIPTION
When gadget API fails, we can grab debug from json.
Maybe we should always send it back???
