### PR TITLE
Expand ISBN, LCCN, OCLC with Google API

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -11,7 +11,6 @@ const TEMP_PLACEHOLDER = "# # # CITATION_BOT_PLACEHOLDER_TEMPORARY %s # # #";
 const TO_EN_DASH = "--?|\&mdash;|\xe2\x80\x94|\?\?\?"; // regexp for replacing to ndashes using mb_ereg_replace
 const EN_DASH = "\xe2\x80\x93"; // regexp for replacing to ndashes using mb_ereg_replace
 const WIKI_ROOT = "https://en.wikipedia.org/w/index.php?";
-const ISBN_KEY = "268OHQMW";
 const API_ROOT = "https://en.wikipedia.org/w/api.php"; // wiki's API endpoint
 const TEMPLATE_REGEXP = "~\{\{\s*([^\|\}]+)([^\{]|\{[^\{])*?\}\}~";
 const BRACESPACE = "!BOTCODE-spaceBeforeTheBrace";

--- a/credentials/crossref.login
+++ b/credentials/crossref.login
@@ -2,3 +2,6 @@
 const CROSSREFUSERNAME = 'martins@gmail.com';
 const NYTUSERNAME   = 'citation_bot';
 const ADSABSAPIKEY  = 'Dl6Dp2GU1rOl3Nu3OkfAhee6ywC42rC5wh9dtpUk'; # Replace this with a working key
+const ISBN_KEY = '268OHQMW';  // Does not work anymore
+// const GOOGLE_KEY = 'AIzaSyBNhyC5a5EirreJEDQ1muw0ZBAmSMs8R4E' ; // only works from tool labs
++const GOOGLE_KEY = 'AIzaSyCsAWkdToE60KgPTt9oQagSpMkv_ReJL6o' ; // Only works on test servers

--- a/credentials/crossref.login
+++ b/credentials/crossref.login
@@ -4,4 +4,4 @@ const NYTUSERNAME   = 'citation_bot';
 const ADSABSAPIKEY  = 'Dl6Dp2GU1rOl3Nu3OkfAhee6ywC42rC5wh9dtpUk'; # Replace this with a working key
 const ISBN_KEY = '268OHQMW';  // Does not work anymore
 // const GOOGLE_KEY = 'AIzaSyBNhyC5a5EirreJEDQ1muw0ZBAmSMs8R4E' ; // only works from tool labs
-+const GOOGLE_KEY = 'AIzaSyCsAWkdToE60KgPTt9oQagSpMkv_ReJL6o' ; // Only works on test servers
+const GOOGLE_KEY = 'AIzaSyCsAWkdToE60KgPTt9oQagSpMkv_ReJL6o' ; // Only works on test servers

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -609,6 +609,24 @@ ER -  }}';
        $this->assertNotNull($expanded->get('accessdate'));
    }
 
+   public function testJustAnISBN() {
+       $text = '{{cite book |isbn=0471186368}}';
+       $expanded = $this->process_citation($text);
+       $this->assertEquals('Explosives engineering',$expanded->get('title'));
+   }
+    
+   public function testJustAnOCLC() {
+       $text = '{{cite book | oclc=9334453}}';
+       $expanded = $this->process_citation($text);
+       $this->assertEquals('The Shreveport Plan: A Long-range Guide for the Future Development of Metropolitan Shreveport',$expanded->get('title'));
+   }
+
+   public function testJustAnLCCN() {
+       $text = '{{cite book | lccn=2009925036}}';
+       $expanded = $this->process_citation($text);
+       $this->assertEquals('Alternative Energy for Dummies',$expanded->get('title'));
+   }
+
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors
   Test finding a DOI and using it to expand a paper [See testLongAuthorLists - Arxiv example?]


### PR DESCRIPTION
Fixes:   ISBNDB charges too much,  so use Google to process ISBN 