### PR TITLE
Store publisher endings in an array, not a bunch of if statements

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1389,7 +1389,7 @@ class Template extends Item {
       foreach ($xml->dc___creator as $author) {
         if( in_array(strtolower($author), BAD_AUTHORS) === FALSE) {
           $author_parts  = explode(" ",$author);
-          $author_ending = ' ' . end($author_parts);
+          $author_ending = end($author_parts);
           if( in_array(strtolower($author),       AUTHORS_ARE_PUBLISHERS        ) === TRUE ||
               in_array(strtolower($author_ending),AUTHORS_ARE_PUBLISHERS_ENDINGS) === TRUE) {
             $this->add_if_new("publisher" , (str_replace("___", ":", $author)));

--- a/Template.php
+++ b/Template.php
@@ -1388,8 +1388,8 @@ class Template extends Item {
     if ($this->blank("editor") && $this->blank("editor1") && $this->blank("editor1-last") && $this->blank("editor-last") && $this->blank("author") && $this->blank("author1") && $this->blank("last") && $this->blank("last1") && $this->blank("publisher")) { // Too many errors in gBook database to add to existing data.   Only add if blank.
       foreach ($xml->dc___creator as $author) {
         if( in_array(strtolower($author), BAD_AUTHORS) === FALSE) {
-          $author_ends   = explode(" ",$author);
-          $author_ending = ' ' . end($author_ends);
+          $author_parts  = explode(" ",$author);
+          $author_ending = ' ' . end($author_parts);
           if( in_array(strtolower($author),       AUTHORS_ARE_PUBLISHERS        ) === TRUE ||
               in_array(strtolower($author_ending),AUTHORS_ARE_PUBLISHERS_ENDINGS) === TRUE) {
             $this->add_if_new("publisher" , (str_replace("___", ":", $author)));

--- a/Template.php
+++ b/Template.php
@@ -1388,15 +1388,10 @@ class Template extends Item {
     if ($this->blank("editor") && $this->blank("editor1") && $this->blank("editor1-last") && $this->blank("editor-last") && $this->blank("author") && $this->blank("author1") && $this->blank("last") && $this->blank("last1") && $this->blank("publisher")) { // Too many errors in gBook database to add to existing data.   Only add if blank.
       foreach ($xml->dc___creator as $author) {
         if( in_array(strtolower($author), BAD_AUTHORS) === FALSE) {
-          if( in_array(strtolower($author), AUTHORS_ARE_PUBLISHERS) === TRUE  ||
-             substr(strtolower($author),-4)  === " inc" || 
-             substr(strtolower($author),-5)  === " inc." ||
-             substr(strtolower($author),-10) === " magazines" || 
-             substr(strtolower($author),-6)  === " press" ||
-             substr(strtolower($author),-6)  === " books" ||
-             substr(strtolower($author),-11) === " publishing" ||
-             substr(strtolower($author),-11) === " publishers" ||
-             substr(strtolower($author),-12) === " corporation") {
+          $author_ends   = explode(" ",$author);
+          $author_ending = ' ' . end($author_ends);
+          if( in_array(strtolower($author),       AUTHORS_ARE_PUBLISHERS        ) === TRUE ||
+              in_array(strtolower($author_ending),AUTHORS_ARE_PUBLISHERS_ENDINGS) === TRUE) {
             $this->add_if_new("publisher" , (str_replace("___", ":", $author)));
           } else {
             $this->add_if_new("author" . ++$i, format_author(str_replace("___", ":", $author)));

--- a/constants.php
+++ b/constants.php
@@ -29,6 +29,7 @@ const DOT_DECODE = array("/", "[", "{", "}", "]", "<", ">", ";", "(", ")");
 // Use lower case for all of these, and then compare to a lower cased version
 const BAD_AUTHORS = array("unknown","missing");
 const AUTHORS_ARE_PUBLISHERS = array(); // Things from google like "hearst magazines", "time inc", "nielsen business media, inc" that the catch alls do not detect
+const AUTHORS_ARE_PUBLISHERS_ENDINGS = array("inc.","inc","magazines","press","publishing","publishers","publishing","books","corporation");
 const HAS_NO_VOLUME = array("zookeys");  // Some journals have issues only, no volume numbers
 const BAD_TITLES = array("unknown","missing");
 

--- a/constants.php
+++ b/constants.php
@@ -29,9 +29,9 @@ const DOT_DECODE = array("/", "[", "{", "}", "]", "<", ">", ";", "(", ")");
 // Use lower case for all of these, and then compare to a lower cased version
 const BAD_AUTHORS = array("unknown","missing");
 const AUTHORS_ARE_PUBLISHERS = array(); // Things from google like "hearst magazines", "time inc", "nielsen business media, inc" that the catch alls do not detect
-const AUTHORS_ARE_PUBLISHERS_ENDINGS = array(" inc."," inc"," magazines"," press"," publishing"," publishers"," publishing"," books"," corporation");
+const AUTHORS_ARE_PUBLISHERS_ENDINGS = array("inc.", "inc", "magazines", "press", "publishing", "publishers", "publishing", "books", "corporation");
 const HAS_NO_VOLUME = array("zookeys");  // Some journals have issues only, no volume numbers
-const BAD_TITLES = array("unknown","missing");
+const BAD_TITLES = array("unknown", "missing");
 
 // dontCap is am array of strings that should not be capitalized in their titlecase format; 
 // unCapped is their correct capitalization. Remember to enclose any word in spaces.

--- a/constants.php
+++ b/constants.php
@@ -29,7 +29,7 @@ const DOT_DECODE = array("/", "[", "{", "}", "]", "<", ">", ";", "(", ")");
 // Use lower case for all of these, and then compare to a lower cased version
 const BAD_AUTHORS = array("unknown","missing");
 const AUTHORS_ARE_PUBLISHERS = array(); // Things from google like "hearst magazines", "time inc", "nielsen business media, inc" that the catch alls do not detect
-const AUTHORS_ARE_PUBLISHERS_ENDINGS = array("inc.","inc","magazines","press","publishing","publishers","publishing","books","corporation");
+const AUTHORS_ARE_PUBLISHERS_ENDINGS = array(" inc."," inc"," magazines"," press"," publishing"," publishers"," publishing"," books"," corporation");
 const HAS_NO_VOLUME = array("zookeys");  // Some journals have issues only, no volume numbers
 const BAD_TITLES = array("unknown","missing");
 

--- a/constants.php
+++ b/constants.php
@@ -27,7 +27,7 @@ const DOT_DECODE = array("/", "[", "{", "}", "]", "<", ">", ";", "(", ")");
 
 // Some data we get from outside sources is bad or at least mis-defined
 // Use lower case for all of these, and then compare to a lower cased version
-const BAD_AUTHORS = array("unknown","missing");
+const BAD_AUTHORS = array("unknown", "missing");
 const AUTHORS_ARE_PUBLISHERS = array(); // Things from google like "hearst magazines", "time inc", "nielsen business media, inc" that the catch alls do not detect
 const AUTHORS_ARE_PUBLISHERS_ENDINGS = array("inc.", "inc", "magazines", "press", "publishing", "publishers", "books", "corporation");
 const HAS_NO_VOLUME = array("zookeys");  // Some journals have issues only, no volume numbers

--- a/constants.php
+++ b/constants.php
@@ -29,7 +29,7 @@ const DOT_DECODE = array("/", "[", "{", "}", "]", "<", ">", ";", "(", ")");
 // Use lower case for all of these, and then compare to a lower cased version
 const BAD_AUTHORS = array("unknown","missing");
 const AUTHORS_ARE_PUBLISHERS = array(); // Things from google like "hearst magazines", "time inc", "nielsen business media, inc" that the catch alls do not detect
-const AUTHORS_ARE_PUBLISHERS_ENDINGS = array("inc.", "inc", "magazines", "press", "publishing", "publishers", "publishing", "books", "corporation");
+const AUTHORS_ARE_PUBLISHERS_ENDINGS = array("inc.", "inc", "magazines", "press", "publishing", "publishers", "books", "corporation");
 const HAS_NO_VOLUME = array("zookeys");  // Some journals have issues only, no volume numbers
 const BAD_TITLES = array("unknown", "missing");
 


### PR DESCRIPTION
Fixes the ever growing list of publisher endings getting out of control in code base by making it an array of publisher endings.  Because we use "explode()" we know that there is a space in front of them, so we do not have to worry about some ones last name being "Splinc" being caught as "inc".  If your last name happens to be "magazines" or "inc", then sorry.