### PR TITLE
Better operator choice

### DIFF
--- a/doibot.php
+++ b/doibot.php
@@ -52,7 +52,7 @@ print "\n\n Expanding '" . htmlspecialchars($title) . "'; " . ($ON ? "will" : "w
 $my_page = new Page();
 if ($my_page->get_text_from($_REQUEST["page"])) {
   $text_expanded = $my_page->expand_text();
-  if ($text_expanded and $ON) {
+  if ($text_expanded && $ON) {
     while (!$my_page->write() && $attempts < 2) {
       ++$attempts;
     }


### PR DESCRIPTION
It does not matter in this case, but good coding means we should swap it.
$this = true;
$that = false;
$truthiness = $this and $that;
$truthiness is true in the above case. :-( because "=" evaluates before "and"
And now I present you will the pickiest pull request ever........