### PR TITLE
Bot now handles empty templates better

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2014,7 +2014,6 @@ class Template extends Item {
   if (!isset($this->param)) return ;
   $mistake_corrections = array_values(COMMON_MISTAKES);
   $mistake_keys = array_keys(COMMON_MISTAKES);
-  $parameters_used = array();
   if ($this->param) {
     foreach ($this->param as $p) {
       $parameters_used[] = $p->param;

--- a/Template.php
+++ b/Template.php
@@ -2012,6 +2012,7 @@ class Template extends Item {
   // check each parameter name against the list of accepted names (loaded in expand.php).
   // It will correct any that appear to be mistyped.
   if (!isset($this->param)) return ;
+  $parameters_used=array();
   $mistake_corrections = array_values(COMMON_MISTAKES);
   $mistake_keys = array_keys(COMMON_MISTAKES);
   if ($this->param) {

--- a/Template.php
+++ b/Template.php
@@ -2011,6 +2011,7 @@ class Template extends Item {
   protected function correct_param_spelling() {
   // check each parameter name against the list of accepted names (loaded in expand.php).
   // It will correct any that appear to be mistyped.
+  if (!isset($this->param)) return ;
   $mistake_corrections = array_values(COMMON_MISTAKES);
   $mistake_keys = array_keys(COMMON_MISTAKES);
   $parameters_used = array();

--- a/Template.php
+++ b/Template.php
@@ -2013,6 +2013,7 @@ class Template extends Item {
   // It will correct any that appear to be mistyped.
   $mistake_corrections = array_values(COMMON_MISTAKES);
   $mistake_keys = array_keys(COMMON_MISTAKES);
+  $parameters_used = array();
   if ($this->param) {
     foreach ($this->param as $p) {
       $parameters_used[] = $p->param;

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -651,9 +651,9 @@ ER -  }}';
    }
     
    public function testEmptyCitations() {
-       $text = 'bad things like {{cite journal}}{{cite book|||}} should not crahs bot';
+       $text = 'bad things like {{cite journal}}{{cite book|||}} should not crash bot'; // bot removed pipes
        $expanded = $this->process_page($text);
-       $this->assertEquals($text, $expanded->parsed_text());
+       $this->assertEquals('bad things like {{cite journal}}{{cite book}} should not crash bot', $expanded->parsed_text());
    }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -649,7 +649,12 @@ ER -  }}';
        $expanded = $this->process_citation($text);
        $this->assertEquals('Alternative Energy for Dummies',$expanded->get('title'));
    }
-
+    
+   public function testEmptyCitations() {
+       $text = 'bad things like {{cite journal}}{{cite book|||}} should not crahs bot';
+       $expanded = $this->process_page($text);
+       $this->assertEquals($text, $expanded->parsed_text());
+   }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors
   Test finding a DOI and using it to expand a paper [See testLongAuthorLists - Arxiv example?]


### PR DESCRIPTION
Adds test to check for proper handling of incomplete templates.  Existing code tried to access non-existent array when a citation template had zero parts to it.