### PR TITLE
Do no touch unknown templates

### DIFF
--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -632,6 +632,12 @@ ER -  }}';
        $this->assertNotNull($expanded->get('accessdate'));
    }
 
+   public function testIgnoreUnkownCiteTemplates() {
+    $text = "{{Cite headcheese| http://google.com | title  I am a title | auhtor = Other, A. N. | issue- 9 | vol. 22 pp. 5-6 }}";
+    $expanded = $this->process_page($text);
+    $this->assertEquals($text, $expanded->parsed_text());
+  } 
+  
    public function testJustAnISBN() {
        $text = '{{cite book |isbn=0471186368}}';
        $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -633,7 +633,7 @@ ER -  }}';
    }
 
    public function testIgnoreUnkownCiteTemplates() {
-    $text = "{{Cite headcheese| http://google.com | title  I am a title | auhtor = Other, A. N. | issue- 9 | vol. 22 pp. 5-6 }}";
+    $text = "{{Cite headcheese| http://google.com | title  I am a title | auhtor = Other, A. N. | issue- 9 | vol. 22 pp. 5-6|doi=10.bad/bad }}";
     $expanded = $this->process_page($text);
     $this->assertEquals($text, $expanded->parsed_text());
   } 


### PR DESCRIPTION
Adds test to make sure we do not at some time in the future accidentally start processing random cite templates.  This is defensive programming.  I just do not want in the future an errant semi-colon or bracket cause us to suddenly start modifying cite patent or something similar.
