### PR TITLE
initalize expected user input to NULL

### DIFF
--- a/category.php
+++ b/category.php
@@ -1,7 +1,7 @@
 #!/usr/bin/php
 <?php
 // $Id$
-// error_reporting(E_ALL^E_NOTICE);
+error_reporting(E_ALL^E_NOTICE);
 $argument["cat"]=NULL;
 foreach ($argv as $arg) {
   if (substr($arg, 0, 2) == "--") {

--- a/category.php
+++ b/category.php
@@ -1,8 +1,8 @@
 #!/usr/bin/php
 <?php
 // $Id$
-error_reporting(E_ALL^E_NOTICE);
-
+// error_reporting(E_ALL^E_NOTICE);
+$argument["cat"]=NULL;
 foreach ($argv as $arg) {
   if (substr($arg, 0, 2) == "--") {
     $argument[substr($arg, 2)] = 1;


### PR DESCRIPTION
I was just looking for $a[]= stuff in source code and I found this.
Just static analysis; not based upon a crash or anything. 
error_reporting(E_ALL^E_NOTICE); means this change is not actually needed, but makes for better code.