### PR TITLE
verify get_prefix_index does not return wrong stuff

### DIFF
--- a/tests/phpunit/wikiFunctionsTest.php
+++ b/tests/phpunit/wikiFunctionsTest.php
@@ -37,6 +37,8 @@ class wikiFunctionsTest extends PHPUnit\Framework\TestCase {
     $this->assertEquals(namespace_id('Template'), $namespace);
     $results = get_prefix_index('Cite j', $namespace); // too many results if we just use 'Cite'
     $this->assertTrue(array_search('Template:Cite journal', $results) !== FALSE);
+    $results = get_prefix_index('blah blah blah blah blah Martin', $namespace); // if we get anything thats wrong
+    $this->assertTrue(empty($results));
   }
   
   public function testRedirects() {

--- a/wikiFunctions.php
+++ b/wikiFunctions.php
@@ -73,6 +73,8 @@ function get_last_revision($page){
 
 function get_prefix_index($prefix, $namespace = 0, $start = "") {
   global $bot;
+  $page_titles = array();
+  $page_ids=array();
   $vars["apfrom"]  = $start;
   $vars = Array ("action" => "query",
     "list" => "allpages",


### PR DESCRIPTION
Pass back empty array instead of NULL, when code fails - bug fix.
Also add test to verify that get_prefix_index does does not pass back anything if you ask for something that there are zero of.  Existing test just makes sure you get the item you want; while this test makes sure you do not getting extra stuff back.
This is from just looking for abc[]= stuff that might end up empty