### PR TITLE
Template expansion does not really work

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -116,8 +116,7 @@ final class Page {
 
     for ($i = 0; $i < count($templates); $i++) {
       if (count($templates[$i]->internal_templates) !==0) {
-        echo "Attemping to set internal_templates twice";
-        return FALSE;
+        exit("Attemping to set internal_templates twice");
       }
       $templates[$i]->internal_templates = &$templates;   
       $templates[$i]->process();

--- a/Page.php
+++ b/Page.php
@@ -115,9 +115,7 @@ final class Page {
     }
 
     for ($i = 0; $i < count($templates); $i++) {
-      if (count($templates[$i]->internal_templates) !==0) {
-        exit("Attemping to set internal_templates twice");
-      }
+      if (count($templates[$i]->internal_templates) !==0) exit("internal_templates already set.  Aborting");
       $templates[$i]->internal_templates = &$templates;  // All templates have to see all other templates 
     }
     for ($i = 0; $i < count($templates); $i++) {

--- a/Page.php
+++ b/Page.php
@@ -118,7 +118,9 @@ final class Page {
       if (count($templates[$i]->internal_templates) !==0) {
         exit("Attemping to set internal_templates twice");
       }
-      $templates[$i]->internal_templates = &$templates;   
+      $templates[$i]->internal_templates = &$templates;  // All templates have to see all other templates 
+    }
+    for ($i = 0; $i < count($templates); $i++) {
       $templates[$i]->process();
       $template_mods = $templates[$i]->modifications();
       foreach (array_keys($template_mods) as $key) {

--- a/Page.php
+++ b/Page.php
@@ -116,7 +116,8 @@ final class Page {
 
     for ($i = 0; $i < count($templates); $i++) {
       if (count($templates[$i]->internal_templates) !==0) {
-       exit("Attemping to set internal_templates twice");
+        echo "Attemping to set internal_templates twice";
+        return FALSE;
       }
       $templates[$i]->internal_templates = &$templates;   
       $templates[$i]->process();

--- a/Page.php
+++ b/Page.php
@@ -115,7 +115,7 @@ final class Page {
     }
 
     for ($i = 0; $i < count($templates); $i++) {
-      $templates[$i]->internal_templates = &$templates;   
+      $templates[$i]->set_internal_templates($templates);   
       $templates[$i]->process();
       $template_mods = $templates[$i]->modifications();
       foreach (array_keys($template_mods) as $key) {

--- a/Page.php
+++ b/Page.php
@@ -115,6 +115,7 @@ final class Page {
     }
 
     for ($i = 0; $i < count($templates); $i++) {
+      $templates[$i]->set_internal_templates($templates);   
       $templates[$i]->process();
       $template_mods = $templates[$i]->modifications();
       foreach (array_keys($template_mods) as $key) {

--- a/Page.php
+++ b/Page.php
@@ -115,7 +115,7 @@ final class Page {
     }
 
     for ($i = 0; $i < count($templates); $i++) {
-      $templates[$i]->set_internal_templates($templates);   
+      $templates[$i]->internal_templates = &$templates;   
       $templates[$i]->process();
       $template_mods = $templates[$i]->modifications();
       foreach (array_keys($template_mods) as $key) {

--- a/Page.php
+++ b/Page.php
@@ -115,7 +115,10 @@ final class Page {
     }
 
     for ($i = 0; $i < count($templates); $i++) {
-      $templates[$i]->set_internal_templates($templates);   
+      if (count($templates[$i]->internal_templates) !==0) {
+       exit("Attemping to set internal_templates twice");
+      }
+      $templates[$i]->internal_templates = &$templates;   
       $templates[$i]->process();
       $template_mods = $templates[$i]->modifications();
       foreach (array_keys($template_mods) as $key) {

--- a/Template.php
+++ b/Template.php
@@ -25,8 +25,8 @@ final class Template {
   public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes,
-            $internal_templates = array();
+            $mod_dashes
+  public    $internal_templates = array();
 
   protected function extract_templates($text) {
     $i = 0;
@@ -44,10 +44,6 @@ final class Template {
       $text = str_ireplace(sprintf(Template::PLACEHOLDER_TEXT, --$i), $template, $text);
     }
     return $text;
-  }
-
-  public function set_internal_templates(&$incoming) {
-    $internal_templates = &$incoming;
   }
   
   public function parse_text($text) {

--- a/Template.php
+++ b/Template.php
@@ -1955,7 +1955,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[  $matches[1][$i]  ]);
+        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]);
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -29,10 +29,7 @@ final class Template {
   public    $internal_templates = array();
 
   protected function extract_templates($text) {
-    if (count($this->internal_templates) !==0) {
-      exit("Attemping to extract templates twice");
-    }
-    $i = 0;
+    $i = count($this->internal_templates);
     while(preg_match(Template::REGEXP, $text, $match)) {
       $this->internal_templates[$i] = $match[0];
       $text = str_replace($match[0], sprintf(Template::PLACEHOLDER_TEXT, $i++), $text);

--- a/Template.php
+++ b/Template.php
@@ -25,7 +25,7 @@ final class Template {
   public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes
+            $mod_dashes;
   public    $internal_templates = array();
 
   protected function extract_templates($text) {

--- a/Template.php
+++ b/Template.php
@@ -25,8 +25,8 @@ final class Template {
   public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes,
-            $internal_templates = array();
+            $mod_dashes;
+  public    $internal_templates = array();
 
   protected function extract_templates($text) {
     if (count($this->internal_templates) !==0) {
@@ -38,13 +38,6 @@ final class Template {
       $text = str_replace($match[0], sprintf(Template::PLACEHOLDER_TEXT, $i++), $text);
     }
     return $text;
-  }
-  
-  public function set_internal_templates(&$templates_in) {
-    if (count($this->internal_templates) !==0) {
-      exit("Attemping to set templates again");
-    }
-    $internal_templates = &$templates_in ;
   }
 
   protected function replace_templates($text) {

--- a/Template.php
+++ b/Template.php
@@ -1941,7 +1941,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[  $matches[1][$i]  ]);
+        $subtemplate->parse_text($this->internal_templates[$i]);
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -1941,7 +1941,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[$i]);
+        $subtemplate->parse_text($this->internal_templates[  $matches[1][$i]  ]);
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -29,7 +29,7 @@ final class Template {
   public    $internal_templates = array();
 
   protected function extract_templates($text) {
-    $i = count($this->internal_templates); // Should always be zero, since already done at Page() level
+    $i = count($this->internal_templates); // Should always be zero, since if already done at Page() level this function is not called
     while(preg_match(Template::REGEXP, $text, $match)) {
       $this->internal_templates[$i] = $match[0];
       $text = str_replace($match[0], sprintf(Template::PLACEHOLDER_TEXT, $i++), $text);

--- a/Template.php
+++ b/Template.php
@@ -47,7 +47,7 @@ final class Template {
   }
 
   public function set_internal_templates(&$incoming) {
-    internal_templates = &$incoming;
+    $internal_templates = &$incoming;
   }
   
   public function parse_text($text) {

--- a/Template.php
+++ b/Template.php
@@ -45,7 +45,7 @@ final class Template {
     }
     return $text;
   }
-  
+
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {

--- a/Template.php
+++ b/Template.php
@@ -29,7 +29,7 @@ final class Template {
   public    $internal_templates = array();
 
   protected function extract_templates($text) {
-    $i = 0;
+    $i = count($this->internal_templates); // Should always be zero, but paranoid
     while(preg_match(Template::REGEXP, $text, $match)) {
       $this->internal_templates[$i] = $match[0];
       $text = str_replace($match[0], sprintf(Template::PLACEHOLDER_TEXT, $i++), $text);
@@ -1993,7 +1993,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->internal_templates[$i];
+              echo "\n    " . $this->internal_templates[$matches[1][$i]];
               break;
             }
           

--- a/Template.php
+++ b/Template.php
@@ -25,16 +25,27 @@ final class Template {
   public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes;
-  public    $internal_templates = array();
+            $mod_dashes, $internal_templates = array();
 
   protected function extract_templates($text) {
-    $i = count($this->internal_templates); // Should always be zero, but paranoid
+    if (count($this->internal_templates) !==0) {
+      echo "\n Attemping to extract templates twice\n";
+      exit(1);
+    }
+    $i = 0;
     while(preg_match(Template::REGEXP, $text, $match)) {
       $this->internal_templates[$i] = $match[0];
       $text = str_replace($match[0], sprintf(Template::PLACEHOLDER_TEXT, $i++), $text);
     }
     return $text;
+  }
+  
+  public fuction set_internal_templates(&$templates_in) {
+    if (count($this->internal_templates) !==0) {
+      echo "\n Attemping to extract templates again\n";
+      exit(1);
+    }
+    $internal_templates = &$$templates_in ;
   }
 
   protected function replace_templates($text) {

--- a/Template.php
+++ b/Template.php
@@ -49,7 +49,7 @@ final class Template {
     return $text;
   }
 
-  public function __toString() {
+  protected function __toString() { // protected becuase kind of evil
     return $this->rawtext;
   }
   

--- a/Template.php
+++ b/Template.php
@@ -41,7 +41,7 @@ final class Template {
     return $text;
   }
   
-  public fuction set_internal_templates(&$templates_in) {
+  public function set_internal_templates(&$templates_in) {
     if (count($this->internal_templates) !==0) {
       echo "\n Attemping to extract templates again\n";
       exit(1);

--- a/Template.php
+++ b/Template.php
@@ -46,6 +46,10 @@ final class Template {
     return $text;
   }
 
+  public function __toString() {
+    return $rawtext;  // ??????
+  }
+  
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {

--- a/Template.php
+++ b/Template.php
@@ -46,7 +46,7 @@ final class Template {
       echo "\n Attemping to extract templates again\n";
       exit(1);
     }
-    $internal_templates = &$$templates_in ;
+    $internal_templates = &$templates_in ;
   }
 
   protected function replace_templates($text) {

--- a/Template.php
+++ b/Template.php
@@ -29,7 +29,7 @@ final class Template {
   public    $internal_templates = array();
 
   protected function extract_templates($text) {
-    $i = count($this->internal_templates);
+    $i = count($this->internal_templates); // Should always be zero, since already done at Page() level
     while(preg_match(Template::REGEXP, $text, $match)) {
       $this->internal_templates[$i] = $match[0];
       $text = str_replace($match[0], sprintf(Template::PLACEHOLDER_TEXT, $i++), $text);

--- a/Template.php
+++ b/Template.php
@@ -47,7 +47,7 @@ final class Template {
   }
 
   public function __toString() {
-    return $rawtext;  // ??????
+    return $this->rawtext;  // ??????
   }
   
   public function parse_text($text) {

--- a/Template.php
+++ b/Template.php
@@ -1945,7 +1945,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[$i]);
+        $subtemplate->parse_text($this->internal_templates[  $matches[1][$i]  ]);
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -47,7 +47,7 @@ final class Template {
   }
 
   public function __toString() {
-    return $this->rawtext;  // ??????
+    return $this->rawtext;
   }
   
   public function parse_text($text) {

--- a/Template.php
+++ b/Template.php
@@ -30,8 +30,7 @@ final class Template {
 
   protected function extract_templates($text) {
     if (count($this->internal_templates) !==0) {
-      echo "\n Attemping to extract templates twice\n";
-      exit(1);
+      exit("Attemping to extract templates twice");
     }
     $i = 0;
     while(preg_match(Template::REGEXP, $text, $match)) {
@@ -43,8 +42,7 @@ final class Template {
   
   public function set_internal_templates(&$templates_in) {
     if (count($this->internal_templates) !==0) {
-      echo "\n Attemping to extract templates again\n";
-      exit(1);
+      exit("Attemping to set templates again");
     }
     $internal_templates = &$templates_in ;
   }

--- a/Template.php
+++ b/Template.php
@@ -25,7 +25,8 @@ final class Template {
   public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes, $internal_templates = array();
+            $mod_dashes,
+            $internal_templates = array();
 
   protected function extract_templates($text) {
     if (count($this->internal_templates) !==0) {

--- a/Template.php
+++ b/Template.php
@@ -46,6 +46,10 @@ final class Template {
     return $text;
   }
 
+  public function set_internal_templates(&$incoming) {
+    internal_templates = &$incoming;
+  }
+  
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -24,8 +24,8 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   
   protected function process_citation($text) {
     $template = new Template();
-    $template->parse_text($text);
-    $template->process();
+    $page = $this->process_page($text);
+    $template->parse_text($page->parsed_text());
     return $template;
   }
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -299,6 +299,19 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
   }
   
+  public function testId2ParamPage() {
+      $text = '{{cite book |id=ISBN 978-1234-9583-068, {{ol|12345}} }}';
+      $expanded = $this->process_page($text);//caused undefined access
+  }
+    
+  public function testId2ParamPageSuppressErrors() {
+      $text = '{{cite book |id=ISBN 978-1234-9583-068, {{ol|12345}} }}';
+      error_reporting(E_ALL^E_NOTICE);
+      $expanded_page = $this->process_page($text);
+      error_reporting(E_ALL);
+      $expanded_cite = $this->process_citation($text);
+      $this->assertEquals($expanded_cite->parsed_text(), $expanded_page->parsed_text());
+  }
   
   public function testOrigYearHandling() {
       $text = '{{cite book |year=2009 | origyear = 2000 }}';

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -296,7 +296,12 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+      
+      $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+      $this->assertEquals('{{cite book | arxiv=astr.ph/1234.5678 }}',$expanded->parsed_text());
   }
   
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -23,9 +23,12 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
   
   protected function process_citation($text) {
+    $page = new Page();
+    $page->parse_text($text);
+    $page->expand_text();
+    $expanded_text = $page->parsed_text();
     $template = new Template();
-    $page = $this->process_page($text);
-    $template->parse_text($page->parsed_text());
+    $template->parse_text($expanded_text);
     return $template;
   }
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -296,7 +296,12 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));  
+      
+      $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+      $this->assertNull($expanded-->parsed_text());  // This is wrong, but I want to see what it gives me
   }
   
   public function testId2ParamPage() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -301,7 +301,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
       $expanded = $this->process_citation($text);
       $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
-      $this->assertNull($expanded-->parsed_text());  // This is wrong, but I want to see what it gives me
+      $this->assertNull($expanded->parsed_text());  // This is wrong, but I want to see what it gives me
   }
   
   public function testId2ParamPage() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -296,12 +296,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));  
-      
-      $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
-      $expanded = $this->process_citation($text);
-      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
-      $this->assertEquals('{{cite book | arxiv=astr.ph/1234.5678 }}',$expanded->parsed_text());  // This is wrong, but I want to see what it gives me
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
   }
   
   public function testId2ParamPage() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -301,7 +301,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
       $expanded = $this->process_citation($text);
       $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
-      $this->assertNull($expanded->parsed_text());  // This is wrong, but I want to see what it gives me
+      $this->assertEquals('{{cite book | arxiv=astr.ph/1234.5678 }}',$expanded->parsed_text());  // This is wrong, but I want to see what it gives me
   }
   
   public function testId2ParamPage() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -299,19 +299,6 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
   }
   
-  public function testId2ParamPage() {
-      $text = '{{cite book |id=ISBN 978-1234-9583-068, {{ol|12345}} }}';
-      $expanded = $this->process_page($text);//caused undefined access
-  }
-    
-  public function testId2ParamPageSuppressErrors() {
-      $text = '{{cite book |id=ISBN 978-1234-9583-068, {{ol|12345}} }}';
-      error_reporting(E_ALL^E_NOTICE);
-      $expanded_page = $this->process_page($text);
-      error_reporting(E_ALL);
-      $expanded_cite = $this->process_citation($text);
-      $this->assertEquals($expanded_cite->parsed_text(), $expanded_page->parsed_text());
-  }
   
   public function testOrigYearHandling() {
       $text = '{{cite book |year=2009 | origyear = 2000 }}';


### PR DESCRIPTION
Processing as a page() leads to an illegal array access.
If you set php to ignore errors, then the final output does not actually expand any templates.
This explains why this feature works in tests suite but not in the real world.
The template needs add other templates passed to it (AS A POINTER)
Also use index instead of number

This is because we parse the whole page and when we jump into a template with process(), there are no templates left internally.

I have chopped out a couple parts of this and submitted them as separate pulls, if you want to think about this.

The only thing I am not 100% about is my choice in the  __toString() function.