### PR TITLE
Parse all tests as a page

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -115,6 +115,7 @@ final class Page {
     }
 
     for ($i = 0; $i < count($templates); $i++) {
+      $templates[$i]->internal_templates = &$templates;
       $templates[$i]->process();
       $template_mods = $templates[$i]->modifications();
       foreach (array_keys($template_mods) as $key) {

--- a/Template.php
+++ b/Template.php
@@ -25,8 +25,8 @@ final class Template {
   public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes,
-            $internal_templates = array();
+            $mod_dashes;
+  public    $internal_templates = array();
 
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
@@ -1922,7 +1922,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[$i]);
+        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]);
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -1970,7 +1970,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->internal_templates[$i];
+              echo "\n    " . $this->internal_templates[$matches[1][$i]];
               break;
             }
           

--- a/Template.php
+++ b/Template.php
@@ -46,7 +46,7 @@ final class Template {
     return $text;
   }
 
-  public function parse_text($text) {
+  protected function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {
         warning("Template already initialized; call new Template() before calling Template::parse_text()");
@@ -74,7 +74,7 @@ final class Template {
   }
 
   // Re-assemble parsed template into string
-  public function parsed_text() {
+  protected function parsed_text() {
     return $this->replace_templates('{{' . $this->name . $this->join_params() . '}}');
   }
 
@@ -92,7 +92,7 @@ final class Template {
     }
   }
 
-  public function parameter_names_to_lowercase() {
+  protected function parameter_names_to_lowercase() {
     if (is_array($this->param)) {
       $keys = array_keys($this->param);
       for ($i=0; $i < count($keys); $i++) {
@@ -235,7 +235,7 @@ final class Template {
     ));
   }
 
-  public function blank($param) {
+  protected function blank($param) {
     if (!$param) return ;
     if (empty($this->param)) return TRUE;
     if (!is_array($param)) $param = array($param);
@@ -250,7 +250,7 @@ final class Template {
    * If the parameter is useful for expansion (e.g. a doi), immediately uses the new
    * data to further expand the citation
    */
-  public function add_if_new($param_name, $value) {
+  protected function add_if_new($param_name, $value) {
     if (trim($value) == '') {
       return FALSE;
     }
@@ -877,7 +877,7 @@ final class Template {
   }
 
   ### Obtain data from external database
-  public function expand_by_arxiv() {
+  protected function expand_by_arxiv() {
     if ($this->wikiname() == 'cite arxiv') {
       $arxiv_param = 'eprint';
       $this->rename('arxiv', 'eprint');
@@ -1053,7 +1053,7 @@ final class Template {
     }
   }
 
-  public function expand_by_doi($force = FALSE) {
+  protected function expand_by_doi($force = FALSE) {
     $doi = $this->get_without_comments_and_placeholders('doi');
     if ($doi && ($force || $this->incomplete())) {
       if (preg_match('~^10\.2307/(\d+)$~', $doi)) {
@@ -1126,7 +1126,7 @@ final class Template {
     }
   }
   
-  public function expand_by_jstor() {
+  protected function expand_by_jstor() {
     if ($this->blank('jstor')) return FALSE;
     $jstor = $this->get('jstor');
     if (preg_match("~[^0-9]~", $jstor) === 1) return FALSE ; // Only numbers in stable jstors
@@ -1176,7 +1176,7 @@ final class Template {
     return TRUE;
   }
 
-  public function expand_by_pubmed($force = FALSE) {
+  protected function expand_by_pubmed($force = FALSE) {
     if (!$force && !$this->incomplete()) return;
     if ($pm = $this->get('pmid')) {
       $identifier = 'pmid';
@@ -2111,7 +2111,7 @@ final class Template {
     return $ret;
   }
 
-  public function wikiname() {
+  protected function wikiname() {
     return trim(mb_strtolower(str_replace('_', ' ', $this->name)));
   }
 
@@ -2386,7 +2386,7 @@ final class Template {
  *   Functions to retrieve values that may be specified 
  *   in various ways
  ********************************************************/
-  public function display_authors($newval = FALSE) {
+  protected function display_authors($newval = FALSE) {
     if ($newval && is_int($newval)) {
       $this->forget('displayauthors');
       echo "\n ~ Setting display-authors to $newval" . tag();
@@ -2399,7 +2399,7 @@ final class Template {
     return is_int(1 * $da) ? $da : FALSE;
   }
 
-  public function number_of_authors() {
+  protected function number_of_authors() {
     $max = 0;
     if ($this->param) foreach ($this->param as $p) {
       if (preg_match('~(?:author|last|first|forename|initials|surname)(\d+)~', $p->param, $matches))
@@ -2409,7 +2409,7 @@ final class Template {
   }
   
   // Retreive properties of template
-  public function first_author() {
+  protected function first_author() {
     foreach (array('author', 'author1', 'authors', 'vauthors') as $auth_param) {
       $author = $this->get($auth_param);
       if ($author) return $author;
@@ -2425,7 +2425,7 @@ final class Template {
     return NULL;
   }
 
-  public function first_surname() {
+  protected function first_surname() {
     // Fetch the surname of the first author only
     if (preg_match("~[^.,;\s]{2,}~u", $this->first_author(), $first_author)) {
       return $first_author[0];
@@ -2447,7 +2447,7 @@ final class Template {
   }
 
   // Amend parameters
-  public function rename($old_param, $new_param, $new_value = FALSE) {
+  protected function rename($old_param, $new_param, $new_value = FALSE) {
     foreach ($this->param as $p) {
       if ($p->param == $old_param) {
         $p->param = $new_param;
@@ -2472,15 +2472,15 @@ final class Template {
     return NULL;
   }
   
-  public function param_with_index($i) {
+  protected function param_with_index($i) {
     return (isset($this->param[$i])) ? $this->param[$i] : NULL;
   }
   
-  public function param_value($i) { // May return error if no param with index $i
+  protected function param_value($i) { // May return error if no param with index $i
     return $this->param_with_index($i)->val;
   }
   
-  public function get_without_comments_and_placeholders($name) {
+  protected function get_without_comments_and_placeholders($name) {
     $ret = $this->get($name);
     $ret = preg_replace('~<!--.*?-->~su', '', $ret); // Comments
     $ret = preg_replace('~# # # CITATION_BOT_PLACEHOLDER.*?# # #~sui', '', $ret); // Other place holders already escaped.  Case insensitive
@@ -2502,12 +2502,12 @@ final class Template {
   public function has($par) {return (bool) strlen($this->get($par));}
   public function lacks($par) {return !$this->has($par);}
 
-  public function add($par, $val) {
+  protected function add($par, $val) {
     echo "\n   + Adding $par" .tag();
     return $this->set($par, $val);
   }
   
-  public function set($par, $val) {
+  protected function set($par, $val) {
     if (($pos = $this->get_param_key($par)) !== NULL) {
       return $this->param[$pos]->val = $val;
     }
@@ -2541,7 +2541,7 @@ final class Template {
     return TRUE;
   }
 
-  public function append_to($par, $val) {
+  protected function append_to($par, $val) {
     $pos = $this->get_param_key($par);
     if ($pos) {
       return $this->param[$pos]->val = $this->param[$pos]->val . $val;
@@ -2550,7 +2550,7 @@ final class Template {
     }
   }
 
-  public function forget ($par) {
+  protected function forget ($par) {
     if ($par == 'url') {
       $this->forget('format');
       $this->forget('accessdate');

--- a/Template.php
+++ b/Template.php
@@ -2458,7 +2458,7 @@ final class Template {
     }
   }
 
-  protected function get($name) {
+  public function get($name) {
     // NOTE $this->param and $p->param are different and refer to different types!
     // $this->param is an array of Parameter objects
     // $parameter_i->param is the parameter name within the Parameter object

--- a/Template.php
+++ b/Template.php
@@ -2111,7 +2111,7 @@ final class Template {
     return $ret;
   }
 
-  protected function wikiname() {
+  public function wikiname() {
     return trim(mb_strtolower(str_replace('_', ' ', $this->name)));
   }
 

--- a/Template.php
+++ b/Template.php
@@ -32,9 +32,9 @@ final class Template {
   public function get_rawtext() {
     $text = $this->parsed_text();
     $i = count($this->internal_templates);
-    foreach (array_reverse($this->internal_templates) as $template) {		
-      // Case insensitive, since placeholder might get title case, etc.		
-      $text = str_ireplace(sprintf(Template::PLACEHOLDER_TEXT, --$i), $template, $text);		
+    foreach (array_reverse($this->internal_templates) as $template) {
+      // Case insensitive, since placeholder might get title case, etc.
+      $text = str_ireplace(sprintf(Template::PLACEHOLDER_TEXT, --$i), $template->get_rawtext(), $text);
     }
     return $text;
   }

--- a/Template.php
+++ b/Template.php
@@ -46,7 +46,7 @@ final class Template {
     return $text;
   }
 
-  protected function parse_text($text) {
+  public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {
         warning("Template already initialized; call new Template() before calling Template::parse_text()");
@@ -952,7 +952,7 @@ final class Template {
     return FALSE;
   }
 
-  public function expand_by_adsabs() {
+  protected function expand_by_adsabs() {
     // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/search.md
     global $SLOW_MODE;
     if ($SLOW_MODE || $this->has('bibcode')) {
@@ -2095,7 +2095,7 @@ final class Template {
 }
 
   // TODO this is not called from anywhere - it used to be.  Where is it useful?
-  public function remove_non_ascii() {
+  protected function remove_non_ascii() {
     for ($i = 0; $i < count($this->param); $i++) {
       $this->param[$i]->val = preg_replace('/[^\x20-\x7e]/', '', $this->param[$i]->val); // Remove illegal non-ASCII characters such as invisible spaces
     }
@@ -2311,7 +2311,7 @@ final class Template {
     }
   }
 
-  public function check_url() {
+  protected function check_url() {
     // Check that the URL functions, and mark as dead if not.
     /*  Disable; to re-enable, we should log possible 404s and check back later.
      * Also, dead-link notifications should be placed ''after'', not within, the template.
@@ -2434,14 +2434,14 @@ final class Template {
     }
   }
 
-  public function page() {
+  protected function page() {
     $page = $this->get('pages');
     return ($page ? $page : $this->get('page'));
   }
 
-  public function name() {return trim($this->name);}
+  protected function name() {return trim($this->name);}
 
-  public function page_range() {
+  protected function page_range() {
     preg_match("~(\w?\w?\d+\w?\w?)(?:\D+(\w?\w?\d+\w?\w?))?~", $this->page(), $pagenos);
     return $pagenos;
   }
@@ -2458,7 +2458,7 @@ final class Template {
     }
   }
 
-  public function get($name) {
+  protected function get($name) {
     // NOTE $this->param and $p->param are different and refer to different types!
     // $this->param is an array of Parameter objects
     // $parameter_i->param is the parameter name within the Parameter object
@@ -2499,8 +2499,8 @@ final class Template {
     return NULL;
   }
 
-  public function has($par) {return (bool) strlen($this->get($par));}
-  public function lacks($par) {return !$this->has($par);}
+  protected function has($par) {return (bool) strlen($this->get($par));}
+  protected function lacks($par) {return !$this->has($par);}
 
   protected function add($par, $val) {
     echo "\n   + Adding $par" .tag();
@@ -2605,7 +2605,7 @@ final class Template {
     return (bool) count($this->modifications('modifications'));
   }
   
-  public function isbn10Toisbn13 ($isbn10) {
+  protected function isbn10Toisbn13 ($isbn10) {
        $isbn10 = trim($isbn10);  // Remove leading and trailing spaces
        $isbn10 = str_replace(array('—','―','–','−','‒'),'-', $isbn10); // Standardize dahses : en dash, horizontal bar, em dash, minus sign, figure dash, to hyphen.
        if (preg_match("~[^0-9Xx\-]~",$isbn10) === 1)  return $isbn10;  // Contains invalid characters

--- a/Template.php
+++ b/Template.php
@@ -28,31 +28,12 @@ final class Template {
             $mod_dashes,
             $internal_templates = array();
 
-  protected function extract_templates($text) {
-    $i = 0;
-    while(preg_match(Template::REGEXP, $text, $match)) {
-      $this->internal_templates[$i] = $match[0];
-      $text = str_replace($match[0], sprintf(Template::PLACEHOLDER_TEXT, $i++), $text);
-    }
-    return $text;
-  }
-
-  protected function replace_templates($text) {
-    $i = count($this->internal_templates);
-    foreach (array_reverse($this->internal_templates) as $template) {
-      // Case insensitive, since placeholder might get title case, etc.
-      $text = str_ireplace(sprintf(Template::PLACEHOLDER_TEXT, --$i), $template, $text);
-    }
-    return $text;
-  }
-
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {
         warning("Template already initialized; call new Template() before calling Template::parse_text()");
     }
     $this->rawtext = $text;
-    $text = '{' . $this->extract_templates(substr($text, 1)); // Split template string, or it'll extract itself
     $pipe_pos = strpos($text, '|');
     if ($pipe_pos) {
       $this->name = substr($text, 2, $pipe_pos - 2); # Remove {{ and }}
@@ -75,7 +56,7 @@ final class Template {
 
   // Re-assemble parsed template into string
   public function parsed_text() {
-    return $this->replace_templates('{{' . $this->name . $this->join_params() . '}}');
+    return'{{' . $this->name . $this->join_params() . '}}';
   }
 
   // Parts of each param: | [pre] [param] [eq] [value] [post]

--- a/Template.php
+++ b/Template.php
@@ -28,7 +28,7 @@ final class Template {
             $mod_dashes;
   public    $internal_templates = array();
   
-  public get_rawtext() {
+  public function get_rawtext() {
     return $this->rawtext;
   }
   

--- a/Template.php
+++ b/Template.php
@@ -28,6 +28,11 @@ final class Template {
             $mod_dashes;
   public    $internal_templates = array();
 
+ 
+  public function get_rawtext() {
+    return $this->rawtext;
+  }
+
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {
@@ -54,6 +59,7 @@ final class Template {
     }
   }
 
+  
   // Re-assemble parsed template into string
   public function parsed_text() {
     return'{{' . $this->name . $this->join_params() . '}}';
@@ -1922,7 +1928,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]);
+        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]->get_rawtext());
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -1970,7 +1976,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->internal_templates[$matches[1][$i]];
+              echo "\n    " . $this->internal_templates[$matches[1][$i]]->get_rawtext();
               break;
             }
           

--- a/Template.php
+++ b/Template.php
@@ -28,6 +28,10 @@ final class Template {
             $mod_dashes;
   public    $internal_templates = array();
   
+  public get_rawtext() {
+    return $this->rawtext;
+  }
+  
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {
@@ -1923,7 +1927,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]->parsed_text());
+        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]->get_rawtext());
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -1971,7 +1975,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->internal_templates[$matches[1][$i]]->parsed_text();
+              echo "\n    " . $this->internal_templates[$matches[1][$i]]->get_rawtext();
               break;
             }
           

--- a/Template.php
+++ b/Template.php
@@ -27,18 +27,7 @@ final class Template {
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
             $mod_dashes;
   public    $internal_templates = array();
-
- 
-  public function get_rawtext() {
-    $text = $this->parsed_text();
-    $i = count($this->internal_templates);
-    foreach (array_reverse($this->internal_templates) as $template) {
-      // Case insensitive, since placeholder might get title case, etc.
-      $text = str_ireplace(sprintf(Template::PLACEHOLDER_TEXT, --$i), $template->get_rawtext(), $text);
-    }
-    return $text;
-  }
-
+  
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
     if ($this->rawtext) {
@@ -1934,7 +1923,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]->get_rawtext());
+        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]->parsed_text());
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -1982,7 +1971,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->internal_templates[$matches[1][$i]]->get_rawtext();
+              echo "\n    " . $this->internal_templates[$matches[1][$i]]->parsed_text();
               break;
             }
           

--- a/Template.php
+++ b/Template.php
@@ -30,7 +30,13 @@ final class Template {
 
  
   public function get_rawtext() {
-    return $this->rawtext;
+    $text = $this->parsed_text();
+    $i = count($this->internal_templates);
+    foreach (array_reverse($this->internal_templates) as $template) {		
+      // Case insensitive, since placeholder might get title case, etc.		
+      $text = str_ireplace(sprintf(Template::PLACEHOLDER_TEXT, --$i), $template, $text);		
+    }
+    return $text;
   }
 
   public function parse_text($text) {

--- a/Template.php
+++ b/Template.php
@@ -92,7 +92,7 @@ final class Template {
     }
   }
 
-  protected function parameter_names_to_lowercase() {
+  public function parameter_names_to_lowercase() {
     if (is_array($this->param)) {
       $keys = array_keys($this->param);
       for ($i=0; $i < count($keys); $i++) {
@@ -235,7 +235,7 @@ final class Template {
     ));
   }
 
-  protected function blank($param) {
+  public function blank($param) {
     if (!$param) return ;
     if (empty($this->param)) return TRUE;
     if (!is_array($param)) $param = array($param);
@@ -250,7 +250,7 @@ final class Template {
    * If the parameter is useful for expansion (e.g. a doi), immediately uses the new
    * data to further expand the citation
    */
-  protected function add_if_new($param_name, $value) {
+  public function add_if_new($param_name, $value) {
     if (trim($value) == '') {
       return FALSE;
     }
@@ -877,7 +877,7 @@ final class Template {
   }
 
   ### Obtain data from external database
-  protected function expand_by_arxiv() {
+  public function expand_by_arxiv() {
     if ($this->wikiname() == 'cite arxiv') {
       $arxiv_param = 'eprint';
       $this->rename('arxiv', 'eprint');
@@ -952,7 +952,7 @@ final class Template {
     return FALSE;
   }
 
-  protected function expand_by_adsabs() {
+  public function expand_by_adsabs() {
     // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/search.md
     global $SLOW_MODE;
     if ($SLOW_MODE || $this->has('bibcode')) {
@@ -1053,7 +1053,7 @@ final class Template {
     }
   }
 
-  protected function expand_by_doi($force = FALSE) {
+  public function expand_by_doi($force = FALSE) {
     $doi = $this->get_without_comments_and_placeholders('doi');
     if ($doi && ($force || $this->incomplete())) {
       if (preg_match('~^10\.2307/(\d+)$~', $doi)) {
@@ -1126,7 +1126,7 @@ final class Template {
     }
   }
   
-  protected function expand_by_jstor() {
+  public function expand_by_jstor() {
     if ($this->blank('jstor')) return FALSE;
     $jstor = $this->get('jstor');
     if (preg_match("~[^0-9]~", $jstor) === 1) return FALSE ; // Only numbers in stable jstors
@@ -1176,7 +1176,7 @@ final class Template {
     return TRUE;
   }
 
-  protected function expand_by_pubmed($force = FALSE) {
+  public function expand_by_pubmed($force = FALSE) {
     if (!$force && !$this->incomplete()) return;
     if ($pm = $this->get('pmid')) {
       $identifier = 'pmid';
@@ -2095,7 +2095,7 @@ final class Template {
 }
 
   // TODO this is not called from anywhere - it used to be.  Where is it useful?
-  protected function remove_non_ascii() {
+  public function remove_non_ascii() {
     for ($i = 0; $i < count($this->param); $i++) {
       $this->param[$i]->val = preg_replace('/[^\x20-\x7e]/', '', $this->param[$i]->val); // Remove illegal non-ASCII characters such as invisible spaces
     }
@@ -2311,7 +2311,7 @@ final class Template {
     }
   }
 
-  protected function check_url() {
+  public function check_url() {
     // Check that the URL functions, and mark as dead if not.
     /*  Disable; to re-enable, we should log possible 404s and check back later.
      * Also, dead-link notifications should be placed ''after'', not within, the template.
@@ -2386,7 +2386,7 @@ final class Template {
  *   Functions to retrieve values that may be specified 
  *   in various ways
  ********************************************************/
-  protected function display_authors($newval = FALSE) {
+  public function display_authors($newval = FALSE) {
     if ($newval && is_int($newval)) {
       $this->forget('displayauthors');
       echo "\n ~ Setting display-authors to $newval" . tag();
@@ -2399,7 +2399,7 @@ final class Template {
     return is_int(1 * $da) ? $da : FALSE;
   }
 
-  protected function number_of_authors() {
+  public function number_of_authors() {
     $max = 0;
     if ($this->param) foreach ($this->param as $p) {
       if (preg_match('~(?:author|last|first|forename|initials|surname)(\d+)~', $p->param, $matches))
@@ -2409,7 +2409,7 @@ final class Template {
   }
   
   // Retreive properties of template
-  protected function first_author() {
+  public function first_author() {
     foreach (array('author', 'author1', 'authors', 'vauthors') as $auth_param) {
       $author = $this->get($auth_param);
       if ($author) return $author;
@@ -2425,7 +2425,7 @@ final class Template {
     return NULL;
   }
 
-  protected function first_surname() {
+  public function first_surname() {
     // Fetch the surname of the first author only
     if (preg_match("~[^.,;\s]{2,}~u", $this->first_author(), $first_author)) {
       return $first_author[0];
@@ -2434,20 +2434,20 @@ final class Template {
     }
   }
 
-  protected function page() {
+  public function page() {
     $page = $this->get('pages');
     return ($page ? $page : $this->get('page'));
   }
 
-  protected function name() {return trim($this->name);}
+  public function name() {return trim($this->name);}
 
-  protected function page_range() {
+  public function page_range() {
     preg_match("~(\w?\w?\d+\w?\w?)(?:\D+(\w?\w?\d+\w?\w?))?~", $this->page(), $pagenos);
     return $pagenos;
   }
 
   // Amend parameters
-  protected function rename($old_param, $new_param, $new_value = FALSE) {
+  public function rename($old_param, $new_param, $new_value = FALSE) {
     foreach ($this->param as $p) {
       if ($p->param == $old_param) {
         $p->param = $new_param;
@@ -2472,15 +2472,15 @@ final class Template {
     return NULL;
   }
   
-  protected function param_with_index($i) {
+  public function param_with_index($i) {
     return (isset($this->param[$i])) ? $this->param[$i] : NULL;
   }
   
-  protected function param_value($i) { // May return error if no param with index $i
+  public function param_value($i) { // May return error if no param with index $i
     return $this->param_with_index($i)->val;
   }
   
-  protected function get_without_comments_and_placeholders($name) {
+  public function get_without_comments_and_placeholders($name) {
     $ret = $this->get($name);
     $ret = preg_replace('~<!--.*?-->~su', '', $ret); // Comments
     $ret = preg_replace('~# # # CITATION_BOT_PLACEHOLDER.*?# # #~sui', '', $ret); // Other place holders already escaped.  Case insensitive
@@ -2499,15 +2499,15 @@ final class Template {
     return NULL;
   }
 
-  protected function has($par) {return (bool) strlen($this->get($par));}
-  protected function lacks($par) {return !$this->has($par);}
+  public function has($par) {return (bool) strlen($this->get($par));}
+  public function lacks($par) {return !$this->has($par);}
 
-  protected function add($par, $val) {
+  public function add($par, $val) {
     echo "\n   + Adding $par" .tag();
     return $this->set($par, $val);
   }
   
-  protected function set($par, $val) {
+  public function set($par, $val) {
     if (($pos = $this->get_param_key($par)) !== NULL) {
       return $this->param[$pos]->val = $val;
     }
@@ -2541,7 +2541,7 @@ final class Template {
     return TRUE;
   }
 
-  protected function append_to($par, $val) {
+  public function append_to($par, $val) {
     $pos = $this->get_param_key($par);
     if ($pos) {
       return $this->param[$pos]->val = $this->param[$pos]->val . $val;
@@ -2550,7 +2550,7 @@ final class Template {
     }
   }
 
-  protected function forget ($par) {
+  public function forget ($par) {
     if ($par == 'url') {
       $this->forget('format');
       $this->forget('accessdate');
@@ -2605,7 +2605,7 @@ final class Template {
     return (bool) count($this->modifications('modifications'));
   }
   
-  protected function isbn10Toisbn13 ($isbn10) {
+  public function isbn10Toisbn13 ($isbn10) {
        $isbn10 = trim($isbn10);  // Remove leading and trailing spaces
        $isbn10 = str_replace(array('—','―','–','−','‒'),'-', $isbn10); // Standardize dahses : en dash, horizontal bar, em dash, minus sign, figure dash, to hyphen.
        if (preg_match("~[^0-9Xx\-]~",$isbn10) === 1)  return $isbn10;  // Contains invalid characters

--- a/Template.php
+++ b/Template.php
@@ -74,7 +74,7 @@ final class Template {
   }
 
   // Re-assemble parsed template into string
-  protected function parsed_text() {
+  public function parsed_text() {
     return $this->replace_templates('{{' . $this->name . $this->join_params() . '}}');
   }
 

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -199,7 +199,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('doi-broken-date'));
     $text = '{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}';
-    $expanded = $this->process_citation($text);
+    $expanded = $this->process_page($text);
     $this->assertEquals('{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}', $expanded->parsed_text());
   }
 
@@ -586,7 +586,7 @@ ER -  }}';
     
    public function testOverwriteBlanks() {
        $text = '{{cite journal|url=http://www.jstor.org/stable/1234567890|jstor=}}';
-       $expanded = $this->process_citation($text);
+       $expanded = $this->process_page($text);
        $this->assertEquals('{{cite journal|jstor=1234567890}}', $expanded->parsed_text());
    }
 
@@ -635,7 +635,7 @@ ER -  }}';
 
    public function testIgnoreUnkownCiteTemplates() {
     $text = "{{Cite headcheese| http://google.com | title  I am a title | auhtor = Other, A. N. | issue- 9 | vol. 22 pp. 5-6|doi=10.bad/bad }}";
-    $expanded = $this->process_citation($text);
+    $expanded = $this->process_page($text);
     $this->assertEquals($text, $expanded->parsed_text());
   } 
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -280,6 +280,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
        
   public function testId2Param() {
+      return; // these tests fail
       $text = '{{cite book |id=ISBN 978-1234-9583-068, DOI 10.1234/bashifbjaksn.ch2, {{arxiv|1234.5678}} 
         {{oclc|12354|4567}} {{oclc|1234}} {{ol|12345}} }}';
       $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -207,7 +207,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{cite journal|doi=10.1038/nature12373}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('4221854', $expanded->get('pmc'));
-    
+    // $this->assertEquals('{{MC Hammer says to not touch this}}', $expanded->get('doi')); This does not work right because we are not doing a "PAGE"
     $text = '{{cite journal|doi=10.1038/nature08244}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('0904.1532', $expanded->get('arxiv'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -288,7 +288,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals('1234', $expanded->get('oclc'));
       $this->assertEquals('12345', $expanded->get('ol'));
       $this->assertNotNull($expanded->get('doi-broken-date'));
-      $this->assertEquals(1, preg_match('~' . sprintf(Template::PLACEHOLDER_TEXT, '\d+') . '~i', $expanded->get('id')));
+      $this->assertEquals('{{oclc|12354|4567}}',$expanded->get('id'));
       
       $text = '{{cite book | id={{arxiv|id=1234.5678}}}}';
       $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -280,7 +280,6 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
        
   public function testId2Param() {
-      return; // these tests fail
       $text = '{{cite book |id=ISBN 978-1234-9583-068, DOI 10.1234/bashifbjaksn.ch2, {{arxiv|1234.5678}} 
         {{oclc|12354|4567}} {{oclc|1234}} {{ol|12345}} }}';
       $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -23,10 +23,8 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
   
   protected function process_citation($text) {
-    $page = new Page();
-    $page->parse_text($text);
-    $page->expand_text();    
     $template = new Template();
+    $page = process_page($text) 
     $template->parse_text($page->parsed_text());
     return $template;
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -198,9 +198,8 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{cite journal|doi= {{MC Hammer says to not touch this}} }}';
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('doi-broken-date'));
-    // $this->assertEquals('{{MC Hammer says to not touch this}}', $expanded->get('doi')); This does not work right because we are not doing a "PAGE"
     $text = '{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}';
-    $expanded = $this->process_page($text);
+    $expanded = $this->process_citation($text);
     $this->assertEquals('{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}', $expanded->parsed_text());
   }
 
@@ -230,7 +229,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   
   public function testCommentHandling() {
     $text = "{{cite book|pages=3333 <!-- yes --> }} {{cite book <!-- no --> | pages=3<nowiki>-</nowiki>6}}";
-    $expanded_page = $this->process_page($text);
+    $expanded_page = $this->process_citation($text);
     $this->assertEquals($text, $expanded_page->parsed_text());
   }
   
@@ -587,7 +586,7 @@ ER -  }}';
     
    public function testOverwriteBlanks() {
        $text = '{{cite journal|url=http://www.jstor.org/stable/1234567890|jstor=}}';
-       $expanded = $this->process_page($text);
+       $expanded = $this->process_citation($text);
        $this->assertEquals('{{cite journal|jstor=1234567890}}', $expanded->parsed_text());
    }
 
@@ -636,7 +635,7 @@ ER -  }}';
 
    public function testIgnoreUnkownCiteTemplates() {
     $text = "{{Cite headcheese| http://google.com | title  I am a title | auhtor = Other, A. N. | issue- 9 | vol. 22 pp. 5-6|doi=10.bad/bad }}";
-    $expanded = $this->process_page($text);
+    $expanded = $this->process_citation($text);
     $this->assertEquals($text, $expanded->parsed_text());
   } 
   
@@ -669,3 +668,4 @@ ER -  }}';
   Test adding a doi-is-broken modifier to a broken DOI.
   */    
 }
+proc

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -23,9 +23,11 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
   
   protected function process_citation($text) {
+    $page = new Page();
+    $page->parse_text($text);
+    $page->expand_text();    
     $template = new Template();
-    $template->parse_text($text);
-    $template->process();
+    $template->parse_text($page->parsed_text());
     return $template;
   }
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -669,4 +669,3 @@ ER -  }}';
   Test adding a doi-is-broken modifier to a broken DOI.
   */    
 }
-

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -198,6 +198,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{cite journal|doi= {{MC Hammer says to not touch this}} }}';
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('doi-broken-date'));
+    // $this->assertEquals('{{MC Hammer says to not touch this}}', $expanded->get('doi')); This does not work right because we are not doing a "PAGE"
     $text = '{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}';
     $expanded = $this->process_page($text);
     $this->assertEquals('{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}', $expanded->parsed_text());
@@ -207,7 +208,6 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{cite journal|doi=10.1038/nature12373}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('4221854', $expanded->get('pmc'));
-    // $this->assertEquals('{{MC Hammer says to not touch this}}', $expanded->get('doi')); This does not work right because we are not doing a "PAGE"
     $text = '{{cite journal|doi=10.1038/nature08244}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('0904.1532', $expanded->get('arxiv'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -296,7 +296,12 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+      
+      $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+      $this->assertEquals('{{cite book | arxiv=astr.ph/1234.5678 }}',$expanded->parsed_text());
   }
   
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -24,7 +24,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   
   protected function process_citation($text) {
     $template = new Template();
-    $page = process_page($text) 
+    $page = process_page($text);
     $template->parse_text($page->parsed_text());
     return $template;
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -229,7 +229,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   
   public function testCommentHandling() {
     $text = "{{cite book|pages=3333 <!-- yes --> }} {{cite book <!-- no --> | pages=3<nowiki>-</nowiki>6}}";
-    $expanded_page = $this->process_citation($text);
+    $expanded_page = $this->process_page($text);
     $this->assertEquals($text, $expanded_page->parsed_text());
   }
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -24,7 +24,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   
   protected function process_citation($text) {
     $template = new Template();
-    $page = process_page($text);
+    $page = $this->process_page($text);
     $template->parse_text($page->parsed_text());
     return $template;
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -208,6 +208,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{cite journal|doi=10.1038/nature12373}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('4221854', $expanded->get('pmc'));
+    
     $text = '{{cite journal|doi=10.1038/nature08244}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('0904.1532', $expanded->get('arxiv'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -668,4 +668,4 @@ ER -  }}';
   Test adding a doi-is-broken modifier to a broken DOI.
   */    
 }
-proc
+


### PR DESCRIPTION
Fixes tests that work here, but do not work on Wikipedia.
Tests are only real if they are tested as a page(), not a template().
This uses page() for processing, then converts into a template() for its get() function.
This breaks testId2Param Breaks, but there is another pull for that.
Lastly, you still have to call process_page directly for tests which are more than just a single template.


Processing as a page() leads to an illegal array access.
If you set php to ignore errors, then the final output does not actually expand any templates.
This explains why this feature works in tests suite but not in the real world.
The template needs add other templates passed to it (AS A POINTER)
Also use index instead of number

This is because we parse the whole page and when we jump into a template with process(), there are no templates left internally.