### PR TITLE
Outdated GitHub link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We use phpunit in Travis CI to test code; please write testcase examples for new
 
 ## Submitting changes
 
-Please send a [GitHub Pull Request](https://github.com/ms609/citation-bot/pull/new/master) with a clear list of what you've done (read more about [pull requests](http://help.github.com/pull-requests/)).
+Please send a [GitHub Pull Request](https://github.com/ms609/citation-bot/pull/new/master) with a clear list of what you've done (read more about [pull requests](https://help.github.com/articles/about-pull-requests/)).
 Including a test case that demonstrates the bug you are trying to fix in the pull request would be much appreciated, to avoid errors resurfacing.
 Please follow our coding conventions (below) and make sure all of your commits are atomic (one feature per commit).
 


### PR DESCRIPTION
GitHub does not re-direct old links
Guess who’s wife had Jury Duty and was stuck at home with little to do.