### PR TITLE
support two templates that are the same

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1941,7 +1941,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[$i]);
+        $subtemplate->parse_text($this->internal_templates[$matches[1][$i]]);
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -1989,7 +1989,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->internal_templates[$i];
+              echo "\n    " . $this->internal_templates[$matches[1][$i]];
               break;
             }
           

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -296,7 +296,12 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+
+      $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+      $this->assertEquals('{{cite book | arxiv=astr.ph/1234.5678 }}',$expanded->parsed_text());
   }
   
   

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -296,7 +296,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));    
 
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
       $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -296,7 +296,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));    
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
 
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
       $expanded = $this->process_citation($text);


### PR DESCRIPTION
Fixes: case with two templates that are the same.
Use index not number
This is included in another pull, but it stands alone, since that other one is big

Without this, you get

1) TemplateTest::testId2Param
Undefined offset: 1
/home/travis/build/ms609/citation-bot/Template.php:1954
/home/travis/build/ms609/citation-bot/Template.php:139
/home/travis/build/ms609/citation-bot/tests/phpunit/TemplateTest.php:28
/home/travis/build/ms609/citation-bot/tests/phpunit/TemplateTest.php:302

Because we set
const TREAT_IDENTICAL_SEPARATELY = FALSE;

It has replaced templates 0 and 1, but only replacement 0 actually is in the array