### PR TITLE
do not coverage test category.php

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
         <file>./gadgetapi.php</file>
         <file>./login.php</file>
         <file>./Snoopy.class.php</file>
+        <file>./category.php</file>
       </exclude>
     </whitelist>
   </filter>


### PR DESCRIPTION
Fixes category.php being flagged as no code coverage.
It is a program that connects humans to the bot, not the bot.
Really hard to test without doing a bunch of real edits.