### PR TITLE
Return empty array instead of array with one bogus element

### DIFF
--- a/tests/phpunit/wikiFunctionsTest.php
+++ b/tests/phpunit/wikiFunctionsTest.php
@@ -26,6 +26,7 @@ final class wikiFunctionsTest extends PHPUnit\Framework\TestCase {
   */
   public function testCategoryMembers() {
     $this->assertTrue(count(category_members('Stub-Class cricket articles')) > 10);
+    $this->assertEquals(0,count(category_members('Stub-Class cricket zero tastic articles should be empty')));
   }
   
   public function testWhatTranscludes() {

--- a/wikiFunctions.php
+++ b/wikiFunctions.php
@@ -9,7 +9,7 @@ function category_members($cat){
     "list" => "categorymembers",
   );
   $qc = "query-continue";
-  $list = NULL;
+  $list = array();
 
   do {
     set_time_limit(40);
@@ -22,7 +22,7 @@ function category_members($cat){
       echo 'Error reading API from ' . htmlspecialchars($url) . "\n\n";
     }
   } while ($vars["cmcontinue"] = (string) $res->$qc->categorymembers["cmcontinue"]);
-  return $list ? $list : [' '];
+  return $list;
 }
 
 // Returns an array; Array ("title1", "title2" ... );


### PR DESCRIPTION
Empty categories return a bogus page of name ‘ ‘
This changes that to an empty array()
I noticed that the category script was doing one “page” even for empty categories 