### PR TITLE
fix templates within templates

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -236,7 +236,7 @@ final class Page {
       $exploded = $treat_identical_separately ? explode($match[0], $text, 2) : explode($match[0], $text);
       $text = implode(sprintf($placeholder_text, $i++), $exploded);
       $obj->occurrences = count($exploded) - 1;
-      $obj->page = &$this; // POINTER NEEDED HERE, OTHERWISE IT IS USELESS
+      $obj->page = &$this; // pointer needed here, otherwise pointless
       $objects[] = $obj;
     }
     $this->text = $text;

--- a/Page.php
+++ b/Page.php
@@ -106,7 +106,9 @@ final class Page {
     // TEMPLATES //
     $templates = $this->extract_object('Template');
     for ($i = 0; $i < count($templates); $i++) {
-       $templates[$i]->all_templates = &$templates ; // I think that this has to be pointer
+      for ($j = 0; $j < count($templates); $j++) {
+       $templates[$i]->all_templates[$j] = &$templates[$j] ; // Has to be pointer
+      }
     }
     for ($i = 0; $i < count($templates); $i++) {
       $templates[$i]->process();

--- a/Page.php
+++ b/Page.php
@@ -237,7 +237,7 @@ final class Page {
       $text = implode(sprintf($placeholder_text, $i++), $exploded);
       $obj->occurrences = count($exploded) - 1;
       $obj->page = &$this; // POINTER NEEDED HERE, OTHERWISE IT IS USELESS
-      $objects[] = &$obj;
+      $objects[] = $obj;
     }
     $this->text = $text;
     return $objects;

--- a/Page.php
+++ b/Page.php
@@ -237,10 +237,10 @@ final class Page {
       $text = implode(sprintf($placeholder_text, $i++), $exploded);
       $obj->occurrences = count($exploded) - 1;
       $obj->page = &$this; // POINTER NEEDED HERE, OTHERWISE IT IS USELESS
-      $objects[] = $obj;
+      $objects[] = &$obj;
     }
     $this->text = $text;
-    return $objects;
+    return &$objects;
   }
 
   protected function replace_object ($objects) {

--- a/Page.php
+++ b/Page.php
@@ -236,7 +236,7 @@ final class Page {
       $exploded = $treat_identical_separately ? explode($match[0], $text, 2) : explode($match[0], $text);
       $text = implode(sprintf($placeholder_text, $i++), $exploded);
       $obj->occurrences = count($exploded) - 1;
-      $obj->page = $this;
+      $obj->page = &$this; // POINTER NEEDED HERE, OTHERWISE IT IS USELESS
       $objects[] = $obj;
     }
     $this->text = $text;

--- a/Page.php
+++ b/Page.php
@@ -240,7 +240,7 @@ final class Page {
       $objects[] = &$obj;
     }
     $this->text = $text;
-    return &$objects;
+    return $objects;
   }
 
   protected function replace_object ($objects) {

--- a/Page.php
+++ b/Page.php
@@ -239,7 +239,7 @@ final class Page {
       $exploded = $treat_identical_separately ? explode($match[0], $text, 2) : explode($match[0], $text);
       $text = implode(sprintf($placeholder_text, $i++), $exploded);
       $obj->occurrences = count($exploded) - 1;
-      $obj->page = &$this; // pointer needed here, otherwise pointless
+      $obj->page = $this;
       $objects[] = $obj;
     }
     $this->text = $text;

--- a/Page.php
+++ b/Page.php
@@ -12,7 +12,7 @@ require_once('Template.php');
 
 final class Page {
 
-  public $text, $title, $modifications, $templates;
+  public $text, $title, $modifications;
 
   public function is_redirect() {
     $url = Array(
@@ -105,6 +105,9 @@ final class Page {
 
     // TEMPLATES //
     $templates = $this->extract_object('Template');
+    for ($i = 0; $i < count($templates); $i++) {
+       $templates[$i]->all_templates = &$templates ; // I think that this has to be pointer
+    }
     for ($i = 0; $i < count($templates); $i++) {
       $templates[$i]->process();
       $template_mods = $templates[$i]->modifications();

--- a/Page.php
+++ b/Page.php
@@ -106,9 +106,7 @@ final class Page {
     // TEMPLATES //
     $templates = $this->extract_object('Template');
     for ($i = 0; $i < count($templates); $i++) {
-      for ($j = 0; $j < count($templates); $j++) {
-       $templates[$i]->all_templates[$j] = &$templates[$j] ; // Has to be pointer
-      }
+       $templates[$i]->all_templates = &$templates ; // Has to be pointer
     }
     for ($i = 0; $i < count($templates); $i++) {
       $templates[$i]->process();

--- a/Page.php
+++ b/Page.php
@@ -12,7 +12,7 @@ require_once('Template.php');
 
 final class Page {
 
-  public $text, $title, $modifications;
+  public $text, $title, $modifications, $templates;
 
   public function is_redirect() {
     $url = Array(

--- a/Template.php
+++ b/Template.php
@@ -1950,7 +1950,7 @@ final class Template {
         print "\n  nebraska" ;
         print "\n " . intval($matches[1][$i]) ;
         print "\n  Texas" ;
-        $subtemplate = $this->page->templates[$matches[1][$i]];
+        $subtemplate = $this->page->templates[intval($matches[1][$i])];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -1944,12 +1944,7 @@ final class Template {
       $id = str_replace($match[0], '', $id);
     }
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
-      print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
-        print_r($matches[1][$i]);
-        print "\n  nebraska" ;
-        print "\n " . intval($matches[1][$i]) ;
-        print "\n  Texas" ;
         $subtemplate = $all_templates[intval($matches[1][$i])];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            

--- a/Template.php
+++ b/Template.php
@@ -6,6 +6,7 @@
  * Of particular note:
  *     process() is what handles the different cite/Cite templates differently.
  *     add_if_new() is generally called to add or sometimes overwrite parameters. The central
+ *     switch statement handles various parameters differently.
  *     tidy() cleans up citations and the templates, but it includes various other functions
  *       and side effects as well. Beware!
  *

--- a/Template.php
+++ b/Template.php
@@ -1945,7 +1945,7 @@ final class Template {
     }
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
-        $subtemplate = $all_templates[intval($matches[1][$i])];
+        $subtemplate = $this->all_templates[intval($matches[1][$i])];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -1980,20 +1980,20 @@ final class Template {
           
             // Specific checks for particular templates:
             if ($subtemplate_name == 'asin' && $subtemplate->has("country")) {
-              echo "\n    - {{ASIN}} country parameter not supported: can't convert.";
+              echo "\n    - {{ASIN}} country parameter not supported: cannot convert.";
               break;
             }
             if ($subtemplate_name == 'ol' && $subtemplate->has('author')) {
-              echo "\n    - {{OL}} author parameter not supported: can't convert.";
+              echo "\n    - {{OL}} author parameter not supported: cannot convert.";
               break;
             }
             if ($subtemplate_name == 'jstor' && $subtemplate->has('sici') || $subtemplate->has('issn')) {
-              echo "\n    - {{JSTOR}} named parameters are not supported: can't convert.";
+              echo "\n    - {{JSTOR}} named parameters are not supported: cannot convert.";
               break;
             }
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
-              echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
+              echo "\n    - {{OCLC}} has multiple parameters: cannot convert.";
               echo "\n    " . $subtemplate->parsed_text();
               break;
             }

--- a/Template.php
+++ b/Template.php
@@ -56,7 +56,7 @@ final class Template {
 
   // Re-assemble parsed template into string
   public function parsed_text() {
-    return'{{' . $this->name . $this->join_params() . '}}';
+    return '{{' . $this->name . $this->join_params() . '}}';
   }
 
   // Parts of each param: | [pre] [param] [eq] [value] [post]

--- a/Template.php
+++ b/Template.php
@@ -6,7 +6,6 @@
  * Of particular note:
  *     process() is what handles the different cite/Cite templates differently.
  *     add_if_new() is generally called to add or sometimes overwrite parameters. The central
- *       switch statement handles various parameters differently.
  *     tidy() cleans up citations and the templates, but it includes various other functions
  *       and side effects as well. Beware!
  *
@@ -1947,12 +1946,11 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
-        print "\n  KURT $i";
-        print "\n   KURTY $matches[1][$i]";
+        print "\n  jobby $i";
         if (isset($this->page)) print "\n karen";
         if (isset($this->page->templates)) print "\n karen love";
-        if (isset($this->page->templates[$matches[1][$i]])) print "\n patty";
-        $subtemplate = $this->page->templates[$matches[1][$i]];
+        if (isset($this->page->templates[$i])) print "\n patty";
+        $subtemplate = $this->page->templates[$i];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -2010,7 +2008,7 @@ final class Template {
                                       $subtemplate->param_value(0);
                                       
             $this->add_if_new($subtemplate_name, $subtemplate_identifier);
-            $id = str_replace($matches[0][$i], '', $id); // Could only do this if previous line evaluated to TRUE, but let's be aggressive here.
+            $id = str_replace($i, '', $id); // Could only do this if previous line evaluated to TRUE, but let's be aggressive here.
             break;
           default:
             echo "\n    - No match found for " . $subtemplate_name;

--- a/Template.php
+++ b/Template.php
@@ -1946,7 +1946,7 @@ final class Template {
     }
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
-        $subtemplate = $this->all_templates[intval($matches[1][$i])];
+        $subtemplate = $this->all_templates[$matches[1][$i]];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -1946,7 +1946,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
-        $subtemplate = $this->page->templates[$matches[0][$i]];
+        $subtemplate = $this->page->templates[$matches[1][$i]];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -1946,7 +1946,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
-        $subtemplate = $this->page->templates[$i];
+        $subtemplate = $this->page->templates[$matches[0][$i]];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -2004,7 +2004,7 @@ final class Template {
                                       $subtemplate->param_value(0);
                                       
             $this->add_if_new($subtemplate_name, $subtemplate_identifier);
-            $id = str_replace($i, '', $id); // Could only do this if previous line evaluated to TRUE, but let's be aggressive here.
+            $id = str_replace($matches[1][$i], '', $id); // Could only do this if previous line evaluated to TRUE, but let's be aggressive here.
             break;
           default:
             echo "\n    - No match found for " . $subtemplate_name;

--- a/Template.php
+++ b/Template.php
@@ -1946,8 +1946,7 @@ final class Template {
     }
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
-        $subtemplate = new Template();
-        $subtemplate->parse_text($this->page->templates[$matches[1][$i]]->parsed_text());
+        $subtemplate = $this->page->templates[$matches[1][$i]];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -1995,7 +1994,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->page->templates[$matches[1][$i]]->parsed_text();
+              echo "\n    " . $subtemplate->parsed_text();
               break;
             }
           

--- a/Template.php
+++ b/Template.php
@@ -2004,7 +2004,7 @@ final class Template {
                                       $subtemplate->param_value(0);
                                       
             $this->add_if_new($subtemplate_name, $subtemplate_identifier);
-            $id = str_replace($matches[1][$i], '', $id); // Could only do this if previous line evaluated to TRUE, but let's be aggressive here.
+            $id = str_replace($matches[0][$i], '', $id); // Could only do this if previous line evaluated to TRUE, but let's be aggressive here.
             break;
           default:
             echo "\n    - No match found for " . $subtemplate_name;

--- a/Template.php
+++ b/Template.php
@@ -21,7 +21,7 @@ final class Template {
   const REGEXP = '~\{\{(?:[^\{]|\{[^\{])+?\}\}~s';
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   protected $rawtext;
-  public $occurrences, $page;
+  public $occurrences, $page, $all_templates;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
             $mod_dashes;
@@ -1950,7 +1950,7 @@ final class Template {
         print "\n  nebraska" ;
         print "\n " . intval($matches[1][$i]) ;
         print "\n  Texas" ;
-        $subtemplate = $this->page->templates[intval($matches[1][$i])];
+        $subtemplate = $all_templates[intval($matches[1][$i])];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":

--- a/Template.php
+++ b/Template.php
@@ -25,26 +25,7 @@ final class Template {
   public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes,
-            $internal_templates = array();
-
-  protected function extract_templates($text) {
-    $i = 0;
-    while(preg_match(Template::REGEXP, $text, $match)) {
-      $this->internal_templates[$i] = $match[0];
-      $text = str_replace($match[0], sprintf(Template::PLACEHOLDER_TEXT, $i++), $text);
-    }
-    return $text;
-  }
-
-  protected function replace_templates($text) {
-    $i = count($this->internal_templates);
-    foreach (array_reverse($this->internal_templates) as $template) {
-      // Case insensitive, since placeholder might get title case, etc.
-      $text = str_ireplace(sprintf(Template::PLACEHOLDER_TEXT, --$i), $template, $text);
-    }
-    return $text;
-  }
+            $mod_dashes;
 
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
@@ -52,7 +33,6 @@ final class Template {
         warning("Template already initialized; call new Template() before calling Template::parse_text()");
     }
     $this->rawtext = $text;
-    $text = '{' . $this->extract_templates(substr($text, 1)); // Split template string, or it'll extract itself
     $pipe_pos = strpos($text, '|');
     if ($pipe_pos) {
       $this->name = substr($text, 2, $pipe_pos - 2); # Remove {{ and }}
@@ -75,7 +55,7 @@ final class Template {
 
   // Re-assemble parsed template into string
   public function parsed_text() {
-    return $this->replace_templates('{{' . $this->name . $this->join_params() . '}}');
+    return'{{' . $this->name . $this->join_params() . '}}';
   }
 
   // Parts of each param: | [pre] [param] [eq] [value] [post]
@@ -1967,7 +1947,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->internal_templates[$i]);
+        $subtemplate->parse_text($this->page->templates[$i]->parsed_text());
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -2015,7 +1995,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->internal_templates[$i];
+              echo "\n    " . $this->page->templates[$i]->parsed_text();
               break;
             }
           

--- a/Template.php
+++ b/Template.php
@@ -21,8 +21,9 @@ final class Template {
   const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_TEMPLATE %s # # #';
   const REGEXP = '~\{\{(?:[^\{]|\{[^\{])+?\}\}~s';
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
+  public $all_templates;  // Points to list of all the Template() on the Page() including this one
   protected $rawtext;
-  public $occurrences, $page, $all_templates;
+  public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
             $mod_dashes;

--- a/Template.php
+++ b/Template.php
@@ -1947,10 +1947,11 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
-        print_r($i);
-        print_r(isset($matches[1][$i]));
-        print_r(isset($this->page));
-        print_r(isset($this->templates[$matches[1][$i]]));
+        print "\n  KURT $i";
+        print "\n   KURTY $matches[1][$i]";
+        if (isset($this->page)) print "\n karen";
+        if (isset($this->page->templates)) print "\n karen love";
+        if (isset($this->page->templates[$matches[1][$i]])) print "\n patty";
         $subtemplate = $this->page->templates[$matches[1][$i]];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            

--- a/Template.php
+++ b/Template.php
@@ -1946,6 +1946,10 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
+        print_r($matches[1][$i]);
+        print "\n  nebraska" ;
+        print "\n " . intval($matches[1][$i]) ;
+        print "\n  Texas" ;
         $subtemplate = $this->page->templates[$matches[1][$i]];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            

--- a/Template.php
+++ b/Template.php
@@ -1945,6 +1945,7 @@ final class Template {
       $id = str_replace($match[0], '', $id);
     }
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
+      print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = $this->page->templates[$matches[1][$i]];
         $subtemplate_name = $subtemplate->wikiname();

--- a/Template.php
+++ b/Template.php
@@ -6,7 +6,7 @@
  * Of particular note:
  *     process() is what handles the different cite/Cite templates differently.
  *     add_if_new() is generally called to add or sometimes overwrite parameters. The central
- *     switch statement handles various parameters differently.
+ *       switch statement handles various parameters differently.
  *     tidy() cleans up citations and the templates, but it includes various other functions
  *       and side effects as well. Beware!
  *

--- a/Template.php
+++ b/Template.php
@@ -1947,7 +1947,7 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       for ($i = 0; $i < count($matches[1]); $i++) {
         $subtemplate = new Template();
-        $subtemplate->parse_text($this->page->templates[$i]->parsed_text());
+        $subtemplate->parse_text($this->page->templates[$matches[1][$i]]->parsed_text());
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            
           case "arxiv":
@@ -1995,7 +1995,7 @@ final class Template {
             if ($subtemplate_name == 'oclc' && !is_null($subtemplate->param_with_index(1))) {
               
               echo "\n    - {{OCLC}} has multiple parameters: can't convert.";
-              echo "\n    " . $this->page->templates[$i]->parsed_text();
+              echo "\n    " . $this->page->templates[$matches[1][$i]]->parsed_text();
               break;
             }
           

--- a/Template.php
+++ b/Template.php
@@ -1947,6 +1947,10 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
+        print_r($i);
+        print_r(isset($matches[1][$i]));
+        print_r(isset($this->page));
+        print_r(isset($this->templates[$matches[1][$i]]));
         $subtemplate = $this->page->templates[$matches[1][$i]];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            

--- a/Template.php
+++ b/Template.php
@@ -1946,10 +1946,6 @@ final class Template {
     if (preg_match_all('~' . sprintf(Template::PLACEHOLDER_TEXT, '(\d+)') . '~', $id, $matches)) {
       print_r($matches);
       for ($i = 0; $i < count($matches[1]); $i++) {
-        print "\n  jobby $i";
-        if (isset($this->page)) print "\n karen";
-        if (isset($this->page->templates)) print "\n karen love";
-        if (isset($this->page->templates[$i])) print "\n patty";
         $subtemplate = $this->page->templates[$i];
         $subtemplate_name = $subtemplate->wikiname();
         switch($subtemplate_name) {            

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -311,12 +311,12 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
   
   public function testNestedTemplates() {
-      $text = '{{cite book|pages=1-2| {{cnn|{{fox|{{msnbc}}|{{local}}|test}} | hello }} {{tester}} {{ random {{ inside {{tester}} }} }} |  cool stuff | not cool}}';
+      $text = '{{cite book|pages=1-2| {{cnn|{{fox|{{msnbc}}|{{local}}|test}} | hello }} {{tester}} {{ random {{ inside {{tester}} }} | id={{cite book|pages=1-2| {{cnn|{{fox|{{msnbc}}|{{local}}|test}} | hello }} {{tester}} {{ random {{ inside {{tester}} }} }}  }} |  cool stuff | not cool}}';
       $expanded = $this->process_citation($text);
       $text = str_replace("-", "–", $text); // Should not change anything other than upgrade dashes
       $this->assertEquals($text,$expanded->parsed_text());
       
-      $text = '{{cite book|quote=See {{cite book|pages=1-2}}|pages=1-3}}';
+      $text = '{{cite book|quote=See {{cite book|pages=1-2|quote=See {{cite book|pages=1-4}}}}|pages=1-3}}';
       $expanded = $this->process_citation($text);
       $text = str_replace("-", "–", $text); // Should not change anything other than upgrade dashes
       $this->assertEquals($text,$expanded->parsed_text());

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -282,7 +282,6 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
        
   public function testId2Param() {
-      return ; //  This test does not work yet!! You will get a "test makes not assertions" warning to remind you of that.
       $text = '{{cite book |id=ISBN 978-1234-9583-068, DOI 10.1234/bashifbjaksn.ch2, {{arxiv|1234.5678}} {{oclc|12354|4567}} {{oclc|1234}} {{ol|12345}} }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('978-1234-9583-068', $expanded->get('isbn'));
@@ -291,7 +290,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals('1234', $expanded->get('oclc'));
       $this->assertEquals('12345', $expanded->get('ol'));
       $this->assertNotNull($expanded->get('doi-broken-date'));
-      $this->assertEquals(1, preg_match('~' . sprintf(Template::PLACEHOLDER_TEXT, '\d+') . '~i', $expanded->get('id')));
+      $this->assertEquals(0, preg_match('~' . sprintf(Template::PLACEHOLDER_TEXT, '\d+') . '~i', $expanded->get('id')));
       
       $text = '{{cite book | id={{arxiv|id=1234.5678}}}}';
       $expanded = $this->process_citation($text);
@@ -300,9 +299,30 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));     
+      
+      $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
+      $this->assertEquals('{{cite book | arxiv=astr.ph/1234.5678 }}',$expanded->parsed_text());
+      
+      $text = '{{cite book|pages=1–2|id={{arxiv|astr.ph|1234.5678}}}}{{cite book|pages=1–3|id={{arxiv|astr.ph|1234.5678}}}}'; // Two of the same sub-template, but in different tempalates
+      $expanded = $this->process_page($text);
+      $this->assertEquals('{{cite book|pages=1–2|arxiv=astr.ph/1234.5678}}{{cite book|pages=1–3|arxiv=astr.ph/1234.5678}}',$expanded->parsed_text());
   }
   
+  public function testNestedTemplates() {
+      $text = '{{cite book|pages=1-2| {{cnn|{{fox|{{msnbc}}|{{local}}|test}} | hello }} {{tester}} {{ random {{ inside {{tester}} }} }} |  cool stuff | not cool}}';
+      $expanded = $this->process_citation($text);
+      $text = str_replace("-", "–", $text); // Should not change anything other than upgrade dashes
+      $this->assertEquals($text,$expanded->parsed_text());
+      
+      $text = '{{cite book|quote=See {{cite book|pages=1-2}}|pages=1-3}}';
+      $expanded = $this->process_citation($text);
+      $text = str_replace("-", "–", $text); // Should not change anything other than upgrade dashes
+      $this->assertEquals($text,$expanded->parsed_text());
+  }
   
+   
   public function testOrigYearHandling() {
       $text = '{{cite book |year=2009 | origyear = 2000 }}';
       $expanded = $this->process_citation($text);


### PR DESCRIPTION
Within Page() all templates are replaced. Thus there are no internal templates. This code sets the internal template list to match the global list of templates.

IT ACTUALLY WORKS 

I had to create a whole slew of tests to make sure this did not break stuff.

When merging this you definitely want to chose the forget all intermediate modifications option