### PR TITLE
Remove unused variables

### DIFF
--- a/Comment.php
+++ b/Comment.php
@@ -8,7 +8,6 @@ final class Comment {
   const REGEXP = '~<!--.*?-->~us';
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   protected $rawtext;
-  public $occurrences, $page;
 
   public function parse_text($text) {
     $this->rawtext = $text;
@@ -24,7 +23,6 @@ final class Nowiki {
   const REGEXP = '~<nowiki>.*?</nowiki>~us'; 
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   protected $rawtext;
-  public $occurrences, $page;
   
   public function parse_text($text) {
     $this->rawtext = $text;

--- a/Page.php
+++ b/Page.php
@@ -235,8 +235,6 @@ final class Page {
       $obj->parse_text($match[0]);
       $exploded = $treat_identical_separately ? explode($match[0], $text, 2) : explode($match[0], $text);
       $text = implode(sprintf($placeholder_text, $i++), $exploded);
-      $obj->occurrences = count($exploded) - 1;
-      $obj->page = $this;
       $objects[] = $obj;
     }
     $this->text = $text;

--- a/Template.php
+++ b/Template.php
@@ -22,7 +22,6 @@ final class Template {
   const REGEXP = '~\{\{(?:[^\{]|\{[^\{])+?\}\}~s';
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   protected $rawtext;
-  public $occurrences, $page;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
             $mod_dashes,


### PR DESCRIPTION
Fixed unused variables.
Also, $page would have to be set with a pointer to actually work anyway.
This is all leftover from the old Item() class, I think.
The red X on the code coverage is because the code coverage base and the dev code base are so different that a fair comparison is hard, I think