### PR TITLE
Remove unessesary Google Searches

### DIFF
--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -468,7 +468,7 @@ ER -  }}';
        $this->assertEquals('10.1038/ntheses.01928', $expanded->get('doi'));  
   }
    
-  public function testMakingISBN13() {
+  public function testCovertingISBN10intoISBN13() {
     $text = "{{cite book|isbn=0-9749009-0-7|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Convert with dashes

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -29,6 +29,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $expanded_text = $page->parsed_text();
     $template = new Template();
     $template->parse_text($expanded_text);
+    return $template;
   }
   
   protected function process_page($text) {  // Only used if more than just a citation template

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -468,7 +468,7 @@ ER -  }}';
        $this->assertEquals('10.1038/ntheses.01928', $expanded->get('doi'));  
   }
    
-  public function testISBNDashes() {  // Dashes, no dashes, etc.
+  public function testMakingISBN13() {  // Dashes, no dashes, etc.
     $text = "{{cite book|isbn=0-9749009-0-7|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Convert with dashes

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -468,7 +468,7 @@ ER -  }}';
        $this->assertEquals('10.1038/ntheses.01928', $expanded->get('doi'));  
   }
    
-  public function testCovertingISBN10intoISBN13() {
+  public function testConvertingISBN10intoISBN13() {
     $text = "{{cite book|isbn=0-9749009-0-7|url=https://books.google.com/books?id=to0yXzq_EkQC}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Convert with dashes

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -468,23 +468,23 @@ ER -  }}';
        $this->assertEquals('10.1038/ntheses.01928', $expanded->get('doi'));  
   }
    
-  public function testISBN() {  // Dashes, no dashes, etc.
-    $text = "{{cite book|isbn=3-902823-24-0}}";
+  public function testISBNDashes() {  // Dashes, no dashes, etc.
+    $text = "{{cite book|isbn=0-9749009-0-7|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('978-3-902823-24-3', $expanded->get('isbn'));  // Convert with dashes
-    $text = "{{cite book|isbn=978-3-902823-24-3}}";
+    $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Convert with dashes
+    $text = "{{cite book|isbn=978-0-9749009-0-2|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('978-3-902823-24-3', $expanded->get('isbn'));  // Unchanged with dashes
-    $text = "{{cite book|isbn=9783902823243}}";
+    $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Unchanged with dashes
+    $text = "{{cite book|isbn=9780974900902|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('9783902823243', $expanded->get('isbn'));   // Unchanged without dashes
-    $text = "{{cite book|isbn=3902823240}}";
+    $this->assertEquals('9780974900902', $expanded->get('isbn'));   // Unchanged without dashes
+    $text = "{{cite book|isbn=0974900907|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('978-3902823243', $expanded->get('isbn'));   // Convert without dashes
-    $text = "{{cite book|isbn=1-84309-164-X}}";
+    $this->assertEquals('978-0974900902', $expanded->get('isbn'));   // Convert without dashes
+    $text = "{{cite book|isbn=1-84309-164-X|url=https://books.google.com/books?id=GvjwAQAACAAJ&dq=1-84309-164-X&hl=en&sa=X&ved=0ahUKEwixgvfujOnXAhXmwVQKHYWpDesQ6AEIJjAA}}";
     $expanded = $this->process_citation($text);  
     $this->assertEquals('978-1-84309-164-6', $expanded->get('isbn'));  // Convert with dashes and a big X
-    $text = "{{cite book|isbn=184309164x}}";
+    $text = "{{cite book|isbn=184309164x|url=https://books.google.com/books?id=GvjwAQAACAAJ&dq=1-84309-164-X&hl=en&sa=X&ved=0ahUKEwixgvfujOnXAhXmwVQKHYWpDesQ6AEIJjAA}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-1843091646', $expanded->get('isbn'));  // Convert without dashes and a tiny x
     $text = "{{cite book|isbn=Hello Brother}}";

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -468,7 +468,7 @@ ER -  }}';
        $this->assertEquals('10.1038/ntheses.01928', $expanded->get('doi'));  
   }
    
-  public function testMakingISBN13() {  // Dashes, no dashes, etc.
+  public function testMakingISBN13() {
     $text = "{{cite book|isbn=0-9749009-0-7|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Convert with dashes

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -469,22 +469,22 @@ ER -  }}';
   }
    
   public function testCovertingISBN10intoISBN13() {
-    $text = "{{cite book|isbn=0-9749009-0-7|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
+    $text = "{{cite book|isbn=0-9749009-0-7|url=https://books.google.com/books?id=to0yXzq_EkQC}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Convert with dashes
-    $text = "{{cite book|isbn=978-0-9749009-0-2|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
+    $text = "{{cite book|isbn=978-0-9749009-0-2|url=https://books.google.com/books?id=to0yXzq_EkQC}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Unchanged with dashes
-    $text = "{{cite book|isbn=9780974900902|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
+    $text = "{{cite book|isbn=9780974900902|url=https://books.google.com/books?id=to0yXzq_EkQC}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('9780974900902', $expanded->get('isbn'));   // Unchanged without dashes
-    $text = "{{cite book|isbn=0974900907|url=https://books.google.com/books?id=to0yXzq_EkQC&printsec=frontcover&dq=isbn:0974900907#v=onepage&q&f=false}}";
+    $text = "{{cite book|isbn=0974900907|url=https://books.google.com/books?id=to0yXzq_EkQC}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0974900902', $expanded->get('isbn'));   // Convert without dashes
-    $text = "{{cite book|isbn=1-84309-164-X|url=https://books.google.com/books?id=GvjwAQAACAAJ&dq=1-84309-164-X&hl=en&sa=X&ved=0ahUKEwixgvfujOnXAhXmwVQKHYWpDesQ6AEIJjAA}}";
+    $text = "{{cite book|isbn=1-84309-164-X|url=https://books.google.com/books?id=GvjwAQAACAAJ}}";
     $expanded = $this->process_citation($text);  
     $this->assertEquals('978-1-84309-164-6', $expanded->get('isbn'));  // Convert with dashes and a big X
-    $text = "{{cite book|isbn=184309164x|url=https://books.google.com/books?id=GvjwAQAACAAJ&dq=1-84309-164-X&hl=en&sa=X&ved=0ahUKEwixgvfujOnXAhXmwVQKHYWpDesQ6AEIJjAA}}";
+    $text = "{{cite book|isbn=184309164x|url=https://books.google.com/books?id=GvjwAQAACAAJ}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-1843091646', $expanded->get('isbn'));  // Convert without dashes and a tiny x
     $text = "{{cite book|isbn=Hello Brother}}";

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -29,7 +29,6 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $expanded_text = $page->parsed_text();
     $template = new Template();
     $template->parse_text($expanded_text);
-    return $template;
   }
   
   protected function process_page($text) {  // Only used if more than just a citation template
@@ -468,7 +467,7 @@ ER -  }}';
        $this->assertEquals('10.1038/ntheses.01928', $expanded->get('doi'));  
   }
    
-  public function testConvertingISBN10intoISBN13() {
+  public function testConvertingISBN10intoISBN13() { // URLS present just to speed up tests
     $text = "{{cite book|isbn=0-9749009-0-7|url=https://books.google.com/books?id=to0yXzq_EkQC}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0-9749009-0-2', $expanded->get('isbn'));  // Convert with dashes


### PR DESCRIPTION
ISBNs search Google to get GID.  GID is then used to search Google again.
Add GIDs to citations to skip a step.  
All we really care about is ISBN10 to ISBN13 in these tests