### PR TITLE
better jstor SICI verification

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -614,6 +614,8 @@ final class Template {
           if (is_null($url_sent)) {
             $this->set('url', $url); // Save it
           }
+        } else {
+          return FALSE;
         }
       }
       if (strpos($url, "plants.jstor.org")) {

--- a/Template.php
+++ b/Template.php
@@ -619,7 +619,7 @@ final class Template {
         }
       }
       if (strpos($url, "plants.jstor.org")) {
-        #Skip.  We can't do anything more with the plants, unfortunately.
+        return FALSE; #Skip.  We can't do anything more with the plants, unfortunately.
       } elseif (preg_match("~(?|(\d{6,})$|(\d{6,})[^\d%\-])~", $url, $match)) {
         if (is_null($url_sent)) {
           $this->forget('url');

--- a/Template.php
+++ b/Template.php
@@ -609,7 +609,7 @@ final class Template {
       if (strpos($url, "sici")) {  //  Outdated
         $this->use_sici() ;  // Grab what we can before getting rid off it
         $headers_test = get_headers($url, 1);
-        if(!empty($headers_test['Location'])) {
+        if(!empty($headers_test['Location']) && strpos($headers_test['Location'],"jstor.org/stable/") !== FALSE) {
           $url = $headers_test['Location']; // Redirect
           if (is_null($url_sent)) {
             $this->set('url', $url); // Save it

--- a/Template.php
+++ b/Template.php
@@ -609,7 +609,7 @@ final class Template {
       if (strpos($url, "sici")) {  //  Outdated
         $this->use_sici() ;  // Grab what we can before getting rid off it
         $headers_test = get_headers($url, 1);
-        if(!empty($headers_test['Location']) && strpos($headers_test['Location'],"jstor.org/stable/") !== FALSE) {
+        if(!empty($headers_test['Location']) && strpos($headers_test['Location'],"jstor.org/stable/")) {
           $url = $headers_test['Location']; // Redirect
           if (is_null($url_sent)) {
             $this->set('url', $url); // Save it

--- a/Template.php
+++ b/Template.php
@@ -615,11 +615,11 @@ final class Template {
             $this->set('url', $url); // Save it
           }
         } else {
-          return FALSE;
+          return FALSE;  // We do not want this URL incorrectly parsed below, or even waste time trying.
         }
       }
       if (strpos($url, "plants.jstor.org")) {
-        return FALSE; # We can't do anything more with the plants, unfortunately.
+        return FALSE; # We can't do anything with the plants
       } elseif (preg_match("~(?|(\d{6,})$|(\d{6,})[^\d%\-])~", $url, $match)) {
         if (is_null($url_sent)) {
           $this->forget('url');
@@ -632,8 +632,9 @@ final class Template {
         }
         if (strpos($this->name, 'web')) $this->name = 'Cite journal';
         return TRUE;
+      } else {
+        return FALSE; // Jstor URL yielded nothing
       }
-      return FALSE; 
     } else {
       if (preg_match(BIBCODE_REGEXP, urldecode($url), $bibcode)) {
         if ($this->blank('bibcode')) {

--- a/Template.php
+++ b/Template.php
@@ -606,7 +606,7 @@ final class Template {
     
     // JSTOR
     if (strpos($url, "jstor.org") !== FALSE) {
-      if (strpos($url, "sici")) {  //  Outdated
+      if (strpos($url, "sici")) {  //  Outdated url style
         $this->use_sici();         // Grab what we can before getting rid off it
         $headers_test = get_headers($url, 1);
         if(!empty($headers_test['Location']) && strpos($headers_test['Location'], "jstor.org/stable/")) {
@@ -633,7 +633,7 @@ final class Template {
         if (strpos($this->name, 'web')) $this->name = 'Cite journal';
         return TRUE;
       }
-      
+      return FALSE; 
     } else {
       if (preg_match(BIBCODE_REGEXP, urldecode($url), $bibcode)) {
         if ($this->blank('bibcode')) {

--- a/Template.php
+++ b/Template.php
@@ -607,23 +607,20 @@ final class Template {
     // JSTOR
     if (strpos($url, "jstor.org") !== FALSE) {
       if (strpos($url, "sici")) {  //  Outdated
-        $sici_url = TRUE;
         $this->use_sici();         // Grab what we can before getting rid off it
         $headers_test = get_headers($url, 1);
-        if(!empty($headers_test['Location']) && strpos($headers_test['Location'],"jstor.org/stable/")) {
+        if(!empty($headers_test['Location']) && strpos($headers_test['Location'], "jstor.org/stable/")) {
           $url = $headers_test['Location']; // Redirect
           if (is_null($url_sent)) {
             $this->set('url', $url); // Save it
-            $sici_url = FALSE;
           }
         } else {
           return FALSE;
         }
       }
       if (strpos($url, "plants.jstor.org")) {
-
         return FALSE; # We can't do anything more with the plants, unfortunately.
-      } elseif (!$sici_url && preg_match("~(?|(\d{6,})$|(\d{6,})[^\d%\-])~", $url, $match)) {
+      } elseif (preg_match("~(?|(\d{6,})$|(\d{6,})[^\d%\-])~", $url, $match)) {
         if (is_null($url_sent)) {
           $this->forget('url');
         }

--- a/Template.php
+++ b/Template.php
@@ -619,7 +619,7 @@ final class Template {
         }
       }
       if (strpos($url, "plants.jstor.org")) {
-        return FALSE; # We can't do anything with the plants
+        return FALSE; # Plants database, not journal
       } elseif (preg_match("~(?|(\d{6,})$|(\d{6,})[^\d%\-])~", $url, $match)) {
         if (is_null($url_sent)) {
           $this->forget('url');


### PR DESCRIPTION
Bug fix:  A SICI might not resolve and would get passed on and parsed as stable url and that’s the wrong number.  One time the SICI failed on me and I got a bad jstor ID, this way you do nothing 

More paranoid: Also double check url before assuming redirect is stable url