### PR TITLE
Prefer Books.Google.Com to GoogleAPIs.Com

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1364,20 +1364,20 @@ final class Template {
         if ( !ctype_alnum($oclc) ) $oclc='' ;
       }
       if ($isbn) {  // Try Books.Google.Com
-          $google_book_url='https://books.google.com/books?isbn='.$isbn;
-          $google_content = @file_get_contents($google_book_url);
-          if ($google_content !== FALSE) {
-            preg_match_all('~books.google.com/books\?id=............&amp~',$google_content,$google_results);
+        $google_book_url='https://books.google.com/books?isbn='.$isbn;
+        $google_content = @file_get_contents($google_book_url);
+        if ($google_content !== FALSE) {
+          preg_match_all('~books.google.com/books\?id=............&amp~',$google_content,$google_results);
+          $google_results = $google_results[0];
+          $google_results = array_unique($google_results);
+          if (count($google_results) === 1) {
             $google_results = $google_results[0];
-            $google_results = array_unique($google_results);
-            if (count($google_results) === 1) {
-              $google_results = $google_results[0];
-              $gid = substr($google_results,26,-4);
-              $url = 'https://books.google.com/books?id=' . $gid;
-              if ($this->blank('url')) $this->add('url', $url);
-              $google_books_worked = TRUE;
-            }
-         }
+            $gid = substr($google_results,26,-4);
+            $url = 'https://books.google.com/books?id=' . $gid;
+            if ($this->blank('url')) $this->add('url', $url);
+            $google_books_worked = TRUE;
+          }
+        }
       }
       if ( !$google_books_worked ) { // Try Google API instead 
         if ($isbn) {

--- a/Template.php
+++ b/Template.php
@@ -1346,6 +1346,66 @@ final class Template {
   
   protected function expand_by_google_books() {
     $url = $this->get('url');
+    if (!$url || !preg_match("~books\.google\.[\w\.]+/.*\bid=([\w\d\-]+)~", $url, $gid)) { // No Google URL yet.
+      $google_books_worked = FALSE ;
+      $isbn= $this->get('isbn');
+      $lccn= $this->get('lccn');
+      $oclc= $this->get('oclc');
+      if ($isbn) {
+        $isbn = str_replace(array(" ","-"), "", $isbn);
+        if (preg_match("~[^0-9Xx]~",$isbn) === 1) $isbn='' ;
+        if (strlen($isbn) !== 13 && strlen($isbn) !== 10) $isbn='' ;
+      }
+      if ($lccn) {
+        $lccn = str_replace(array(" ","-"), "", $lccn);
+        if (preg_match("~[^0-9]~",$lccn) === 1) $lccn='' ;
+      }
+      if ($oclc) {
+        if ( !ctype_alnum($oclc) ) $oclc='' ;
+      }
+      if ($isbn) {  // Try Books.Google.Com
+          $google_book_url='https://books.google.com/books?isbn='.$isbn;
+          $google_content = @file_get_contents($google_book_url);
+          if ($google_content !== FALSE) {
+            preg_match_all('~books.google.com/books\?id=............&amp~',$google_content,$google_results);
+            $google_results = $google_results[0];
+            $google_results = array_unique($google_results);
+            if (count($google_results) === 1) {
+              $google_results = $google_results[0];
+              $gid = substr($google_results,26,-4);
+              $url = 'https://books.google.com/books?id=' . $gid;
+              if ($this->blank('url')) $this->add('url', $url);
+              $google_books_worked = TRUE;
+            }
+         }
+      }
+      if ( !$google_books_worked ) { // Try Google API instead 
+        if ($isbn) {
+          $url_token = "isbn:" . $isbn;
+        } elseif ($oclc) {
+          $url_token = "oclc:" . $oclc;
+        } elseif ($lccn) {
+          $url_token = "lccn:" . $lccn;
+        } else {
+          return FALSE; // No data to use
+        }
+        $string = @file_get_contents("https://www.googleapis.com/books/v1/volumes?q=" . $url_token . GOOGLE_KEY);
+        if ($string === FALSE) {
+            echo "\n Google APIs search failed for $url_token \n";
+            return FALSE;
+        }
+        $result = @json_decode($string, false);
+        if (isset($result) && isset($result->totalItems) && $result->totalItems === 1 && isset($result->items[0]) && isset($result->items[0]->id) ) {
+          $gid=$result->items[0]->id;
+          $url = 'https://books.google.com/books?id=' . $gid;
+          if ($this->blank('url')) $this->add('url', $url );
+        } else {
+          echo "\n Google APIs search failed with $url_token \n";
+          return FALSE;
+        }
+      }
+    }
+    // Now we parse a Google Books URL
     if ($url && preg_match("~books\.google\.[\w\.]+/.*\bid=([\w\d\-]+)~", $url, $gid)) {
       $removed_redundant = 0;
       $hash = '';
@@ -1378,69 +1438,6 @@ final class Template {
       }
       $this->google_book_details($gid[1]);
       return TRUE;
-    }
-    // Use Google API to get GID instead based upon ISBN, LCCN, or OCLC
-    $isbn= $this->get('isbn');
-    $lccn= $this->get('lccn');
-    $oclc= $this->get('oclc');
-    if ($isbn) {
-        $isbn = str_replace(array(" ","-"), "", $isbn);
-        if (preg_match("~[^0-9Xx]~",$isbn) === 1) $isbn='' ;
-        if (strlen($isbn) !== 13 && strlen($isbn) !== 10) $isbn='' ;
-    }
-    if ($lccn) {
-        $lccn = str_replace(array(" ","-"), "", $lccn);
-        if (preg_match("~[^0-9]~",$lccn) === 1) $lccn='' ;
-    }
-    if ($oclc) {
-        if ( !ctype_alnum($oclc) ) $oclc='' ;
-    }
-    if ($isbn) {
-        $url_token = "isbn:" . $isbn;
-    } elseif ($oclc) {
-        $url_token = "oclc:" . $oclc;
-    } elseif ($lccn) {
-        $url_token = "lccn:" . $lccn;
-    } else {
-        return FALSE; // No data to use
-    }
-    $string = @file_get_contents("https://www.googleapis.com/books/v1/volumes?q=" . $url_token . GOOGLE_KEY);
-    if($isbn) $string = FALSE ;// TESTING!!!!!
-    if ($string === FALSE) {
-        if ($isbn) {
-          $google_book_url='https://books.google.com/books?isbn='.$isbn;
-          $google_content = @file_get_contents($google_book_url);
-          if ($google_content === FALSE) {
-            echo "\n Google APIs search failed for $url_token \n";
-            return FALSE;
-          }
-          preg_match_all('~books.google.com/books\?id=............&amp~',$google_content,$google_results);
-          $google_results = $google_results[0];
-          $google_results = array_unique($google_results);
-          if (count($google_results) !== 1) {
-            echo "\n Google APIs search failed for $url_token \n";
-            return FALSE;
-          }
-          $google_results = $google_results[0];
-          $gid = substr($google_results,26,-4);
-          $this->google_book_details($gid);
-          if ($this->blank('url')) $this->add('url', 'https://books.google.com/books?id=' . $gid );
-          return TRUE;
-        } else {
-            echo "\n Google APIs search failed for $url_token \n";
-            return FALSE;
-        }
-    } else {
-      $result = @json_decode($string, false);
-        if (isset($result) && isset($result->totalItems) && $result->totalItems === 1 && isset($result->items[0]) && isset($result->items[0]->id) ) {
-          $gid=$result->items[0]->id;
-          $this->google_book_details($gid);
-          if ($this->blank('url')) $this->add('url', 'https://books.google.com/books?id=' . $gid );
-          return TRUE;
-      } else {
-        echo "\n Google APIs search failed with $url_token \n";
-        return FALSE;
-      }
     }
   }
 

--- a/Template.php
+++ b/Template.php
@@ -1425,6 +1425,10 @@ final class Template {
           $this->google_book_details($gid);
           if ($this->blank('url')) $this->add('url', 'https://books.google.com/books?id=' . $gid );
           return TRUE;
+        } else {
+            echo "\n Google APIs search failed for $url_token \n";
+            return FALSE;
+        }
     } else {
       $result = @json_decode($string, false);
         if (isset($result) && isset($result->totalItems) && $result->totalItems === 1 && isset($result->items[0]) && isset($result->items[0]->id) ) {

--- a/Template.php
+++ b/Template.php
@@ -1404,7 +1404,7 @@ final class Template {
     } else {
         return FALSE; // No data to use
     }
-    $string = @file_get_contents("https://www.googleapis.com/books/v1/volumes?q=" . $url_token . GOOGLE_KEY);
+    $string = FALSE ; /////   TESTING  @file_get_contents("https://www.googleapis.com/books/v1/volumes?q=" . $url_token . GOOGLE_KEY);
     if ($string === FALSE) {
         if ($isbn) {
           $google_book_url='https://books.google.com/books?isbn='.$isbn;

--- a/Template.php
+++ b/Template.php
@@ -1404,7 +1404,8 @@ final class Template {
     } else {
         return FALSE; // No data to use
     }
-    $string = FALSE ; /////   TESTING  @file_get_contents("https://www.googleapis.com/books/v1/volumes?q=" . $url_token . GOOGLE_KEY);
+    $string = @file_get_contents("https://www.googleapis.com/books/v1/volumes?q=" . $url_token . GOOGLE_KEY);
+    if($isbn) $string = FALSE ;// TESTING!!!!!
     if ($string === FALSE) {
         if ($isbn) {
           $google_book_url='https://books.google.com/books?isbn='.$isbn;


### PR DESCRIPTION
Some research shows that:
1.  the Google Books API has a "You must use an API key" license.  This is because the API is a very rich method for polling the Google Database.  Also, it has the ability to maintain personal libraries, interface with bookstores, etc..
2.  Books.Google.Com has a very liberal license.  
3.  We already use Books.Google.Com for {{citation|url=books.google.......+}}
4.  For ISBNs, we can get away with Books.Google.com
5.  Still need API for LCCN and OLCN
6.  I have applied for a bigger quota, but have not heard back
