### PR TITLE
fix function name typos & add test for it

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -791,14 +791,10 @@ final class Template {
       $this->add_if_new('pmid', $results[0]);
     } else {
       echo " nothing found.";
-      if (mb_strtolower($this->name) == "citation" && $this->blank('journal')) {
+      if ($this->wikiname() == "citation" && $this->blank('journal') && $this->blank('isbn') && $this->has('title')) {
         // Check for ISBN, but only if it's a citation.  We should not risk a FALSE positive by searching for an ISBN for a journal article!
-        if ($this->blank('isbn') && $title = $this->get("title")) { 
           echo "\n - Checking for ISBN";
           $this->add_if_new("isbn", $this->find_isbn());
-        } else {
-          else echo "\n  Already has an ISBN. ";
-        }
       }
     }
   }

--- a/Template.php
+++ b/Template.php
@@ -791,10 +791,11 @@ final class Template {
       $this->add_if_new('pmid', $results[0]);
     } else {
       echo " nothing found.";
-      if ($this->wikiname() == "citation" && $this->blank('journal') && $this->blank('isbn') && $this->has('title')) {
+      if ($this->wikiname() == "citation" && $this->blank('journal')) {
         // Check for ISBN, but only if it's a citation.  We should not risk a FALSE positive by searching for an ISBN for a journal article!
-          echo "\n - Checking for ISBN";
-          $this->add_if_new("isbn", $this->find_isbn());
+        if ($this->find_isbn()) {
+          echo "\n * Found ISBN " . htmlspecialchars($this->get('isbn'));
+        }
       }
     }
   }

--- a/Template.php
+++ b/Template.php
@@ -794,7 +794,7 @@ final class Template {
       if (mb_strtolower($this->name) == "citation" && $this->blank('journal')) {
         // Check for ISBN, but only if it's a citation.  We should not risk a FALSE positive by searching for an ISBN for a journal article!
         echo "\n - Checking for ISBN";
-        if ($this->blank('isbn') && $title = $this->get("title")) $this->add_if_new("isbn", findISBN( $title, $this->first_author()));
+        if ($this->blank('isbn') && $title = $this->get("title")) $this->add_if_new("isbn", $this->find_isbn( $title, $this->first_author()));
         else echo "\n  Already has an ISBN. ";
       }
     }

--- a/Template.php
+++ b/Template.php
@@ -793,9 +793,12 @@ final class Template {
       echo " nothing found.";
       if (mb_strtolower($this->name) == "citation" && $this->blank('journal')) {
         // Check for ISBN, but only if it's a citation.  We should not risk a FALSE positive by searching for an ISBN for a journal article!
-        echo "\n - Checking for ISBN";
-        if ($this->blank('isbn') && $title = $this->get("title")) $this->add_if_new("isbn", $this->find_isbn( $title, $this->first_author()));
-        else echo "\n  Already has an ISBN. ";
+        if ($this->blank('isbn') && $title = $this->get("title")) { 
+          echo "\n - Checking for ISBN";
+          $this->add_if_new("isbn", $this->find_isbn());
+        } else {
+          else echo "\n  Already has an ISBN. ";
+        }
       }
     }
   }

--- a/WikipediaBot.php
+++ b/WikipediaBot.php
@@ -187,7 +187,7 @@ class WikipediaBot {
     
     if ((!is_null($lastRevId) && $myPage->lastrevid != $lastRevId)
      || (!is_null($startedEditing) && strtotime($baseTimeStamp) > strtotime($startedEditing))) {
-      triggeer_error("Possible edit conflict detected. Aborting.", E_USER_WARNING);
+      trigger_error("Possible edit conflict detected. Aborting.", E_USER_WARNING);
       return FALSE;
     }
     if (stripos($text, "CITATION_BOT_PLACEHOLDER") != FALSE)  {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -716,7 +716,7 @@ ER -  }}';
     $this->assertNull($expanded->get('journal'));  // if we get a journal, the the data is updated and test probably no longer gets bad data
  }
     
- public fucntion testCitationTemplateWithoutJournal() {
+ public function testCitationTemplateWithoutJournal() {
     $text = '{{citation|url=http://www.word-detective.com/2011/03/mexican-standoff/|title=Mexican standoff|work=The Word Detective|accessdate=2013-03-21}}';
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('isbn')); // This citation used to crash code in ISBN search.  Mostly checking "something" to make Travis CI happy

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -715,6 +715,12 @@ ER -  }}';
     $this->assertEquals(FALSE, stripos('1711', $volume));
     $this->assertNull($expanded->get('journal'));  // if we get a journal, the the data is updated and test probably no longer gets bad data
  }
+    
+ public fucntion testCitationTemplateWithoutJournal() {
+    $text = '{{citation|url=http://www.word-detective.com/2011/03/mexican-standoff/|title=Mexican standoff|work=The Word Detective|accessdate=2013-03-21}}';
+    $expanded = $this->process_citation($text);
+    $this->assertNull($expanded->get('isbn')); // This citation used to crash code in ISBN search.  Mostly checking "something" to make Travis CI happy
+ }
 
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors


### PR DESCRIPTION
{{citation}} templates that are not journals died because of this typo.
Also, no longer say "checking for ISBN" on citations that already have one.
Also find_isbn's arguments have changed, etc.