### PR TITLE
Ignore honorifics in author names and add tests

### DIFF
--- a/DOItools.php
+++ b/DOItools.php
@@ -112,8 +112,7 @@ function format_author($author){
 	// Requires an author who is formatted as SURNAME, FORENAME or SURNAME FORENAME or FORENAME SURNAME. Substitute initials for forenames if nec.
   $surname = NULL;
   // Google sometimes has these
-  $author = str_ireplace("(sir.)", "", $author);
-  $author = str_ireplace("(sir)", "", $author);
+  $author = preg_replace("~ ?\((?i)sir(?-i)\.?\)~", "", $author);
 
   if (substr(trim($author), -1) === ".") {
      $ends_with_period = TRUE;

--- a/DOItools.php
+++ b/DOItools.php
@@ -111,6 +111,10 @@ function format_author($author){
 
 	// Requires an author who is formatted as SURNAME, FORENAME or SURNAME FORENAME or FORENAME SURNAME. Substitute initials for forenames if nec.
   $surname = NULL;
+  // Google sometimes has these
+  $author=str_ireplace("(sir.)","",$author);  // Google sometimes has these
+  $author=str_ireplace("(sir)","",$author);
+
   if (substr(trim($author), -1) === ".") {
      $ends_with_period = TRUE;
   } else {

--- a/DOItools.php
+++ b/DOItools.php
@@ -112,8 +112,8 @@ function format_author($author){
 	// Requires an author who is formatted as SURNAME, FORENAME or SURNAME FORENAME or FORENAME SURNAME. Substitute initials for forenames if nec.
   $surname = NULL;
   // Google sometimes has these
-  $author=str_ireplace("(sir.)","",$author);
-  $author=str_ireplace("(sir)","",$author);
+  $author = str_ireplace("(sir.)", "", $author);
+  $author = str_ireplace("(sir)", "", $author);
 
   if (substr(trim($author), -1) === ".") {
      $ends_with_period = TRUE;

--- a/DOItools.php
+++ b/DOItools.php
@@ -112,7 +112,7 @@ function format_author($author){
 	// Requires an author who is formatted as SURNAME, FORENAME or SURNAME FORENAME or FORENAME SURNAME. Substitute initials for forenames if nec.
   $surname = NULL;
   // Google sometimes has these
-  $author=str_ireplace("(sir.)","",$author);  // Google sometimes has these
+  $author=str_ireplace("(sir.)","",$author);
   $author=str_ireplace("(sir)","",$author);
 
   if (substr(trim($author), -1) === ".") {

--- a/Template.php
+++ b/Template.php
@@ -1621,7 +1621,7 @@ final class Template {
               in_array(strtolower($author_ending),AUTHORS_ARE_PUBLISHERS_ENDINGS) === TRUE) {
             $this->add_if_new("publisher" , (str_replace("___", ":", $author)));
           } else {
-            $this->add_if_new("author" . ++$i, format_author(str_replace("___", ":", $author)));
+            $this->add_if_new("author" . ++$i, format_author(str_ireplace("(sir)","",str_replace("___", ":", $author))));
           }
         }
       }

--- a/Template.php
+++ b/Template.php
@@ -1621,7 +1621,7 @@ final class Template {
               in_array(strtolower($author_ending),AUTHORS_ARE_PUBLISHERS_ENDINGS) === TRUE) {
             $this->add_if_new("publisher" , (str_replace("___", ":", $author)));
           } else {
-            $this->add_if_new("author" . ++$i, str_replace("___", ":", $author)));
+            $this->add_if_new("author" . ++$i, format_author(str_replace("___", ":", $author)));
           }
         }
       }

--- a/Template.php
+++ b/Template.php
@@ -1621,7 +1621,7 @@ final class Template {
               in_array(strtolower($author_ending),AUTHORS_ARE_PUBLISHERS_ENDINGS) === TRUE) {
             $this->add_if_new("publisher" , (str_replace("___", ":", $author)));
           } else {
-            $this->add_if_new("author" . ++$i, format_author(str_ireplace("(sir)","",str_replace("___", ":", $author))));
+            $this->add_if_new("author" . ++$i, str_replace("___", ":", $author)));
           }
         }
       }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -724,7 +724,7 @@ ER -  }}';
  public function testApproxInTitle(){
     $text = "{{Cite arxiv|eprint=1801.03103}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('I am a title',$expanded->get('title'));
+    $this->assertEquals('A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc',$expanded->get('title'));
  }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -721,7 +721,7 @@ ER -  }}';
     $this->assertNull($expanded->get('isbn')); // This citation used to crash code in ISBN search.  Mostly checking "something" to make Travis CI happy
  }
 
- public function testApproxInTitle() { // This contains Math stuff that should be z∼10.  See https://tex.stackexchange.com/questions/55701/how-do-i-write-sim-approximately-with-the-correct-spacing
+ public function testLatexMathInTitle() { // This contains Math stuff that should be z∼10, but we just verify that we do not make it worse at this time.  See https://tex.stackexchange.com/questions/55701/how-do-i-write-sim-approximately-with-the-correct-spacing
     $text = "{{Cite arxiv|eprint=1801.03103}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc',$expanded->get('title'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -731,7 +731,7 @@ ER -  }}';
  public function testHornorificInTitle() { // compaints about this
     $text = "{{cite book|title=Letter from Sir Frederick Trench to the Viscount Duncannon on his proposal for a quay on the north bank of the Thames|url=https://books.google.com/books?id=oNBbAAAAQAAJ|year=1841}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('Trench',$expanded->get('last1'));
+    $this->assertEquals('Trench', $expanded->get('last1'));
     $this->assertEquals('Frederick William', $expanded->get('first1')); 
  }
 

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -724,7 +724,7 @@ ER -  }}';
  public function testLatexMathInTitle() { // This contains Math stuff that should be z∼10, but we just verify that we do not make it worse at this time.  See https://tex.stackexchange.com/questions/55701/how-do-i-write-sim-approximately-with-the-correct-spacing
     $text = "{{Cite arxiv|eprint=1801.03103}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc',$expanded->get('title'));
+    $this->assertEquals('A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc', $expanded->get('title'));
  }
 
 
@@ -732,13 +732,13 @@ ER -  }}';
     $text = "{{cite book|title=Letter from Sir Frederick Trench to the Viscount Duncannon on his proposal for a quay on the north bank of the Thames|url=https://books.google.com/books?id=oNBbAAAAQAAJ|year=1841}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('Trench',$expanded->get('last1'));
-    $this->assertEquals('Frederick William',$expanded->get('first1')); 
+    $this->assertEquals('Frederick William', $expanded->get('first1')); 
  }
 
  public function testPageRange() {
      $text = '{{Citation|doi=10.3406/befeo.1954.5607}}' ;
      $expanded = $this->process_citation($text);
-     $this->assertEquals('405–554',$expanded->get('pages'));
+     $this->assertEquals('405–554', $expanded->get('pages'));
  }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -731,8 +731,8 @@ ER -  }}';
  public function testHornorificInTitle() { // compaints about this
     $text = "{{cite book|title=Letter from Sir Frederick Trench to the Viscount Duncannon on his proposal for a quay on the north bank of the Thames|url=https://books.google.com/books?id=oNBbAAAAQAAJ|year=1841}}}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('LAST1',$expanded->get('last1'));
-    $this->assertEquals('FIRST1',$expanded->get('first1')); 
+    $this->assertEquals('Trench',$expanded->get('last1'));
+    $this->assertEquals('Frederick W.',$expanded->get('first1')); 
  }
 
  public function testPageRange() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -721,7 +721,7 @@ ER -  }}';
     $this->assertNull($expanded->get('isbn')); // This citation used to crash code in ISBN search.  Mostly checking "something" to make Travis CI happy
  }
     
- public function testApproxInTitle(){
+ public function testApproxInTitle(){ // This contains Math stuff that should be z∼10.  See https://tex.stackexchange.com/questions/55701/how-do-i-write-sim-approximately-with-the-correct-spacing
     $text = "{{Cite arxiv|eprint=1801.03103}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc',$expanded->get('title'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -729,10 +729,10 @@ ER -  }}';
 
 
  public function testHornorificInTitle() { // compaints about this
-    $text = "{{cite book|title=Letter from Sir Frederick Trench to the Viscount Duncannon on his proposal for a quay on the north bank of the Thames|url=https://books.google.com/books?id=oNBbAAAAQAAJ|year=1841}}}}";
+    $text = "{{cite book|title=Letter from Sir Frederick Trench to the Viscount Duncannon on his proposal for a quay on the north bank of the Thames|url=https://books.google.com/books?id=oNBbAAAAQAAJ|year=1841}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('Trench',$expanded->get('last1'));
-    $this->assertEquals('Frederick W.',$expanded->get('first1')); 
+    $this->assertEquals('Frederick William',$expanded->get('first1')); 
  }
 
  public function testPageRange() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -720,7 +720,12 @@ ER -  }}';
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('isbn')); // This citation used to crash code in ISBN search.  Mostly checking "something" to make Travis CI happy
  }
-
+    
+ public function testApproxInTitle(){
+    $text = "{{Cite arix|eprint=1801.03103}}";
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('I am a title',$expanded->get('title'));
+ }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors
   Test finding a DOI and using it to expand a paper [See testLongAuthorLists - Arxiv example?]

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -722,7 +722,7 @@ ER -  }}';
  }
     
  public function testApproxInTitle(){
-    $text = "{{Cite arix|eprint=1801.03103}}";
+    $text = "{{Cite arxiv|eprint=1801.03103}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('I am a title',$expanded->get('title'));
  }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -727,6 +727,14 @@ ER -  }}';
     $this->assertEquals('A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc',$expanded->get('title'));
  }
 
+
+ public function testHornorificInTitle() { // compaints about this
+    $text = "{{cite book|title=Letter from Sir Frederick Trench to the Viscount Duncannon on his proposal for a quay on the north bank of the Thames|url=https://books.google.com/books?id=oNBbAAAAQAAJ|year=1841}}}}";
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('LAST1',$expanded->get('last1'));
+    $this->assertEquals('FIRST1',$expanded->get('first1')); 
+ }
+
  public function testPageRange() {
      $text = '{{Citation|doi=10.3406/befeo.1954.5607}}' ;
      $expanded = $this->process_citation($text);


### PR DESCRIPTION
We do not handle Latex math in titles (I do not know how we could).  Add test to make sure that do not make it worse than it already is.

Remove (sir) and (sir.) from authors and add test for it

