### PR TITLE
Reject placeholder DOI data

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1143,6 +1143,7 @@ final class Template {
       }
       $crossRef = $this->query_crossref($doi);
       if ($crossRef) {
+        if (strtolower($crossRef->article_title) === 'oup accepted manuscript') return FALSE ; // OUP accepted manuscript is placeholder
         echo "\n - Expanding from crossRef record" . tag();
 
         if ($crossRef->volume_title && $this->blank('journal')) {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -129,6 +129,12 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $this->assertEquals('cite journal', $expanded->wikiname());
     $this->assertEquals('10.1111/j.1475-4983.2012.01203.x', $expanded->get('doi'));
   }
+    
+  public function testDoiMetaData() {
+    $text = "{{cite journal |doi= 10.1093/mnras/stx3343}}";
+    $expanded = $this->process_citation($text);
+    $this->assertNull($expanded->get('title')); // Some point this will start working, and the test will need removed. But it verifies patch for now
+  }
   
   public function testDoiExpansionBook() {
     $text = "{{cite book|doi=10.1007/978-981-10-3180-9_1}}";


### PR DESCRIPTION
Fixes oup accepted manuscript placeholder data from being used
Also includes a test -- at some point this will break, but it verifies path for now
Ready to merge I believe 