### PR TITLE
Format journal names better

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2243,7 +2243,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization($p->val,FALSE);
+            $p->val = title_capitalization($p->val, FALSE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2243,7 +2243,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization($p->val);
+            $p->val = title_capitalization($p->val,FALSE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2243,7 +2243,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization($p->val, FALSE);
+            $p->val = title_capitalization($p->val, TRUE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2243,7 +2243,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization($p->val, TRUE);
+            $p->val = title_capitalization($p->val);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/expandFns.php
+++ b/expandFns.php
@@ -176,11 +176,10 @@ function restore_italics ($text) {
 }
 
 /** Returns a properly capitalised title.
- *      If $caps_after_punctuation is TRUE (or there is an abundance of periods), it allows the 
- *      letter after colons and other punctuation marks to remain capitalized.
- *      If not, it won't capitalise after : etc.
+ *      If $caps_after_all_periods is TRUE (or there is an abundance of periods), it allows the 
+ *      letter after all periods marks to remain capitalized.
  */
-function title_capitalization($in, $caps_after_punctuation = TRUE) {
+function title_capitalization($in, $caps_after_all_periods = TRUE) {
   // Use 'straight quotes' per WP:MOS
   $new_case = straighten_quotes(trim($in));
   if(substr($new_case,0,2) === "[[" && substr($new_case,-2) === "]]") {
@@ -195,14 +194,26 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
   }
   $new_case = substr(str_replace(UC_SMALL_WORDS, LC_SMALL_WORDS, $new_case . " "), 0, -1);
     
-  if ($caps_after_punctuation || (substr_count($in, '.') / strlen($in)) > .07) {
+  if ($caps_after_all_periods || (substr_count($in, '.') / strlen($in)) > .07) {
     // When there are lots of periods, then they probably mark abbrev.s, not sentance ends
     // We should therefore capitalize after each punctuation character.
     $new_case = preg_replace_callback("~[?.:!]\s+[a-z]~u" /* Capitalise after punctuation */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
-  } else { // everything but periods in case of abbreviations
+  } else { // everything but most periods
       $new_case = preg_replace_callback("~[?:!]\s+[a-z]~u" /* Capitalise after punctuation */,
+      create_function('$matches', 'return mb_strtoupper($matches[0]);'),
+      $new_case);
+      $new_case = preg_replace_callback("~[.]\s+the ~u" /* Capitalise after periods the word "the" if followed by a space */,
+      create_function('$matches', 'return mb_strtoupper($matches[0]);'),
+      $new_case);
+      $new_case = preg_replace_callback("~[.]\s+a ~u" /* Capitalise after periods the word "a" if followed by a space  */,
+      create_function('$matches', 'return mb_strtoupper($matches[0]);'),
+      $new_case);
+      $new_case = preg_replace_callback("~[.]\s+an ~u" /* Capitalise after periods the word "an" if followed by a space  */,
+      create_function('$matches', 'return mb_strtoupper($matches[0]);'),
+      $new_case);
+      $new_case = preg_replace_callback("~[.]\s+a$~u" /* Capitalise after periods the word "a" if at the end of the string since it is probably J Chem Phys A  */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
   }

--- a/expandFns.php
+++ b/expandFns.php
@@ -198,18 +198,18 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
   if ($caps_after_punctuation || (substr_count($in, '.') / strlen($in)) > .07) {
     // When there are lots of periods, then they probably mark abbrev.s, not sentance ends
     // We should therefore capitalize after each punctuation character.
-    $new_case = preg_replace_callback("~[?.:!]\s+[a-z]~" /* Capitalise after punctuation */,
+    $new_case = preg_replace_callback("~[?.:!]\s+[a-z]~uU" /* Capitalise after punctuation */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
   }
   
   $new_case = preg_replace_callback(
-    "~\w{2}'[A-Z]\b~" /* Lowercase after apostrophes */, 
+    "~\w{2}'[A-Z]\b~uU" /* Lowercase after apostrophes */, 
     create_function('$matches', 'return mb_strtolower($matches[0]);'),
     trim($new_case)
   );
   // Solitary 'a' should be lowercase
-  $new_case = preg_replace("~(\w\s+)A(\s+\w)~", "$1a$2", $new_case);
+  $new_case = preg_replace("~(\w\s+)A(\s+\w)~uU", "$1a$2", $new_case);
   
   // Catch some specific epithets, which should be lowercase
   $new_case = preg_replace_callback(

--- a/expandFns.php
+++ b/expandFns.php
@@ -198,18 +198,18 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
   if ($caps_after_punctuation || (substr_count($in, '.') / strlen($in)) > .07) {
     // When there are lots of periods, then they probably mark abbrev.s, not sentance ends
     // We should therefore capitalize after each punctuation character.
-    $new_case = preg_replace_callback("~[?.:!]\s+[a-z]~uU" /* Capitalise after punctuation */,
+    $new_case = preg_replace_callback("~[?.:!]\s+[a-z]~u" /* Capitalise after punctuation */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
   }
   
   $new_case = preg_replace_callback(
-    "~\w{2}'[A-Z]\b~uU" /* Lowercase after apostrophes */, 
+    "~\w{2}'[A-Z]\b~u" /* Lowercase after apostrophes */, 
     create_function('$matches', 'return mb_strtolower($matches[0]);'),
     trim($new_case)
   );
   // Solitary 'a' should be lowercase
-  $new_case = preg_replace("~(\w\s+)A(\s+\w)~uU", "$1a$2", $new_case);
+  $new_case = preg_replace("~(\w\s+)A(\s+\w)~u", "$1a$2", $new_case);
   
   // Catch some specific epithets, which should be lowercase
   $new_case = preg_replace_callback(

--- a/expandFns.php
+++ b/expandFns.php
@@ -201,6 +201,10 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
     $new_case = preg_replace_callback("~[?.:!]\s+[a-z]~u" /* Capitalise after punctuation */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
+  } else { // everything but periods in case of abbreviations
+      $new_case = preg_replace_callback("~[?:!]\s+[a-z]~u" /* Capitalise after punctuation */,
+      create_function('$matches', 'return mb_strtoupper($matches[0]);'),
+      $new_case)
   }
   
   $new_case = preg_replace_callback(

--- a/expandFns.php
+++ b/expandFns.php
@@ -198,18 +198,18 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
   if ($caps_after_punctuation || (substr_count($in, '.') / strlen($in)) > .07) {
     // When there are lots of periods, then they probably mark abbrev.s, not sentance ends
     // We should therefore capitalize after each punctuation character.
-    $new_case = preg_replace_callback("~[?.:!]\s+[a-z]~u" /* Capitalise after punctuation */,
+    $new_case = preg_replace_callback("~[?.:!]\s+[a-z]~" /* Capitalise after punctuation */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
   }
   
   $new_case = preg_replace_callback(
-    "~\w{2}'[A-Z]\b~u" /* Lowercase after apostrophes */, 
+    "~\w{2}'[A-Z]\b~" /* Lowercase after apostrophes */, 
     create_function('$matches', 'return mb_strtolower($matches[0]);'),
     trim($new_case)
   );
   // Solitary 'a' should be lowercase
-  $new_case = preg_replace("~(\w\s+)A(\s+\w)~u", "$1a$2", $new_case);
+  $new_case = preg_replace("~(\w\s+)A(\s+\w)~", "$1a$2", $new_case);
   
   // Catch some specific epithets, which should be lowercase
   $new_case = preg_replace_callback(

--- a/expandFns.php
+++ b/expandFns.php
@@ -204,7 +204,7 @@ function title_capitalization($in, $caps_after_punctuation = TRUE) {
   } else { // everything but periods in case of abbreviations
       $new_case = preg_replace_callback("~[?:!]\s+[a-z]~u" /* Capitalise after punctuation */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
-      $new_case)
+      $new_case);
   }
   
   $new_case = preg_replace_callback(

--- a/expandFns.php
+++ b/expandFns.php
@@ -204,16 +204,16 @@ function title_capitalization($in, $caps_after_all_periods = TRUE) {
       $new_case = preg_replace_callback("~[?:!]\s+[a-z]~u" /* Capitalise after punctuation */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
-      $new_case = preg_replace_callback("~[.]\s+the ~u" /* Capitalise after periods the word "the" if followed by a space */,
+      $new_case = preg_replace_callback("~[.]\s+the\s+~u" /* Capitalise after periods the word "the" if followed by white space */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
-      $new_case = preg_replace_callback("~[.]\s+a ~u" /* Capitalise after periods the word "a" if followed by a space  */,
+      $new_case = preg_replace_callback("~[.]\s+a\s+~u" /* Capitalise after periods the word "a" if followed by white space  */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
-      $new_case = preg_replace_callback("~[.]\s+an ~u" /* Capitalise after periods the word "an" if followed by a space  */,
+      $new_case = preg_replace_callback("~[.]\s+an\s+~u" /* Capitalise after periods the word "an" if followed by white space  */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
-      $new_case = preg_replace_callback("~[.]\s+a$~u" /* Capitalise after periods the word "a" if at the end of the string since it is probably J Chem Phys A  */,
+      $new_case = preg_replace_callback("~[.]\s+[a-z]$~u" /* Capitalise after periods a single letter if at the end of the string since it is probably J Chem Phys. C  */,
       create_function('$matches', 'return mb_strtoupper($matches[0]);'),
       $new_case);
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -577,6 +577,11 @@ ER -  }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
+  public function testCapsAfterColonAndPeriod() {
+      $text = '{{Cite journal |journal=Historical Biology: An International Journal. Of Paleobiology}}';
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('Historical Biology: An International Journal. Of Paleobiology', $expanded->get('journal'));
+  }  
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things
       $text = '{{cite journal|title=[[Zootimeboys]] and Girls|journal=[[Zootimeboys]] and Girls}}';
       $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -578,9 +578,9 @@ ER -  }}';
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
   public function testCapsAfterColonAndPeriod() {
-      $text = '{{Cite journal |journal=Historical Biology: An International Journal. Of Paleobiology}}';
+      $text = '{{Cite journal |journal=Historical biology: An international Journal. Of Paleobiology}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('Historical Biology: An International Journal. of Paleobiology', $expanded->get('journal'));
+      $this->assertEquals('Historical Biology: An International Journal. Of Paleobiology', $expanded->get('journal'));
   }  
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things
       $text = '{{cite journal|title=[[Zootimeboys]] and Girls|journal=[[Zootimeboys]] and Girls}}';

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -578,8 +578,8 @@ ER -  }}';
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
   public function testCapsAfterColonAndPeriod() {
-      $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.\n'.
-              '|title=but in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.}}';
+      $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.
+              |title=but in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.}}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('In Journal Titles: A Word Following Punctuation Needs Capitals. Of Course.', $expanded->get('journal'));
       $this->assertEquals('But in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.', $expanded->get('title'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -580,7 +580,7 @@ ER -  }}';
   public function testCapsAfterColonAndPeriod() {
       $text = '{{Cite journal |journal=Historical Biology: An International Journal. Of Paleobiology}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('Historical Biology: An International Journal. Of Paleobiology', $expanded->get('journal'));
+      $this->assertEquals('Historical Biology: An International Journal. of Paleobiology', $expanded->get('journal'));
   }  
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things
       $text = '{{cite journal|title=[[Zootimeboys]] and Girls|journal=[[Zootimeboys]] and Girls}}';

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -578,9 +578,9 @@ ER -  }}';
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
   public function testCapsAfterColonAndPeriod() {
-      $text = '{{Cite journal |journal=Historical biology: An international Journal. Of Paleobiology}}';
+      $text = '{{Cite journal |journal=Capitalization test: a word following punctuation needs capitals. Of course.}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('Historical Biology: An International Journal. Of Paleobiology', $expanded->get('journal'));
+      $this->assertEquals('Capitalization test: A word following punctuation needs capitals. Of course.', $expanded->get('journal'));
   }  
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things
       $text = '{{cite journal|title=[[Zootimeboys]] and Girls|journal=[[Zootimeboys]] and Girls}}';

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -578,9 +578,11 @@ ER -  }}';
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
   public function testCapsAfterColonAndPeriod() {
-      $text = '{{Cite journal |journal=Capitalization test: a word following punctuation needs capitals. Of course.}}';
+      $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.\n'.
+              '|title=but in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('Capitalization test: A word following punctuation needs capitals. Of course.', $expanded->get('journal'));
+      $this->assertEquals('In Journal Titles: A Word Following Punctuation Needs Capitals. Of Course.', $expanded->get('journal'));
+      $this->assertEquals('But in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.', $expanded->get('title'));
   }  
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things
       $text = '{{cite journal|title=[[Zootimeboys]] and Girls|journal=[[Zootimeboys]] and Girls}}';


### PR DESCRIPTION
everything but periods for journal titles
BUT, it does periods if there are lots of them (J. Chem. Phys. Biol. Chem. Too. Many. A.)
And the words "an" "the" "a" if followed by a whitespace
And a single letter if at the end for things like "J of Chem. Phys. C"
renamed the variable passed in to match what it does
Resolves #452 