### PR TITLE
Stop curl from printing output

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -654,7 +654,7 @@ final class Template {
         $ch = curl_init($encoded_url);
         curl_setopt($ch, CURLOPT_HEADER, 1);
         curl_setopt($ch, CURLOPT_NOBODY, 1);
-        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop curl from printing non-errors to stdout
+        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop curl from printing everything to standard out
         if (curl_exec($ch)) {
           $redirect_url = curl_getinfo($ch, CURLINFO_REDIRECT_URL);
           if (strpos($redirect_url, "jstor.org/stable/")) {
@@ -2463,8 +2463,8 @@ final class Template {
         curl_setup($ch, str_replace("&amp;", "&", $url));
         curl_setopt($ch, CURLOPT_NOBODY, 1);
         curl_setopt($ch, CURLOPT_HEADER, FALSE);
+        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop curl from printing everything to standard out
         curl_exec($ch);
-        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop curl from printing non-errors to standard out
         switch(curl_getinfo($ch, CURLINFO_HTTP_CODE)){
           case "404":
             global $p;

--- a/Template.php
+++ b/Template.php
@@ -654,6 +654,7 @@ final class Template {
         $ch = curl_init($encoded_url);
         curl_setopt($ch, CURLOPT_HEADER, 1);
         curl_setopt($ch, CURLOPT_NOBODY, 1);
+        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop curl from talking to stdout
         if (curl_exec($ch)) {
           $redirect_url = curl_getinfo($ch, CURLINFO_REDIRECT_URL);
           if (strpos($redirect_url, "jstor.org/stable/")) {
@@ -2463,6 +2464,7 @@ final class Template {
         curl_setopt($ch, CURLOPT_NOBODY, 1);
         curl_setopt($ch, CURLOPT_HEADER, FALSE);
         curl_exec($ch);
+        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop stdout
         switch(curl_getinfo($ch, CURLINFO_HTTP_CODE)){
           case "404":
             global $p;

--- a/Template.php
+++ b/Template.php
@@ -654,7 +654,7 @@ final class Template {
         $ch = curl_init($encoded_url);
         curl_setopt($ch, CURLOPT_HEADER, 1);
         curl_setopt($ch, CURLOPT_NOBODY, 1);
-        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop curl from talking to stdout
+        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop curl from printing non-errors to stdout
         if (curl_exec($ch)) {
           $redirect_url = curl_getinfo($ch, CURLINFO_REDIRECT_URL);
           if (strpos($redirect_url, "jstor.org/stable/")) {
@@ -2464,7 +2464,7 @@ final class Template {
         curl_setopt($ch, CURLOPT_NOBODY, 1);
         curl_setopt($ch, CURLOPT_HEADER, FALSE);
         curl_exec($ch);
-        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop stdout
+        curl_setopt($ch, CURLOPT_VERBOSE, 0); // stop curl from printing non-errors to standard out
         switch(curl_getinfo($ch, CURLINFO_HTTP_CODE)){
           case "404":
             global $p;


### PR DESCRIPTION
CURL is printing standard out to log files 
This information is all present in the CURL data we parse, including errors etc.