### PR TITLE
Journal Capitalization in tidy()

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2335,7 +2335,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization($p->val, TRUE);
+            $p->val = title_capitalization(ucfirst($p->val), TRUE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2335,7 +2335,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization($p->val, FALSE);
+            $p->val = title_capitalization($p->val, TRUE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2335,7 +2335,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization(mb_convert_case($p->val, MB_CASE_TITLE, "UTF-8"), TRUE);
+            $p->val = title_capitalization(mb_ucwords($p->val), TRUE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2335,7 +2335,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization($p->val, TRUE);
+            $p->val = title_capitalization(mb_convert_case($p->val, MB_CASE_TITLE, "UTF-8"), TRUE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2335,7 +2335,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization(ucfirst($p->val), TRUE);
+            $p->val = title_capitalization(ucwords($p->val), TRUE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2335,7 +2335,7 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            $p->val = title_capitalization(mb_ucwords($p->val), TRUE);
+            $p->val = title_capitalization($p->val, TRUE);
             break;
           case 'edition': 
             $p->val = preg_replace("~\s+ed(ition)?\.?\s*$~i", "", $p->val);

--- a/expandFns.php
+++ b/expandFns.php
@@ -132,7 +132,7 @@ function wikify_external_text($title) {
               : $title
             );
   $title = preg_replace('~[\*]$~', '', $title);
-  $title = title_capitalization($title);
+  $title = title_capitalization($title, TRUE);
   
   $originalTags = array("<i>","</i>", '<title>', '</title>',"From the Cover: ");
   $wikiTags = array("''","''",'','',"");
@@ -180,7 +180,7 @@ function restore_italics ($text) {
  *      letter after colons and other punctuation marks to remain capitalized.
  *      If not, it won't capitalise after : etc.
  */
-function title_capitalization($in, $caps_after_punctuation = TRUE) {
+function title_capitalization($in, $caps_after_punctuation) {
   // Use 'straight quotes' per WP:MOS
   $new_case = straighten_quotes(trim($in));
   if(substr($new_case,0,2) === "[[" && substr($new_case,-2) === "]]") {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -609,11 +609,14 @@ ER -  }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
-  public function testCapsAfterColonAndPeriod() {
-      $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.
-              |title=but in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.}}';
+  public function testCapsAfterColonAndPeriodJournal() {
+      $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.}}'
       $expanded = $this->process_citation($text);
       $this->assertEquals('In Journal Titles: A Word Following Punctuation Needs Capitals. Of Course.', $expanded->get('journal'));
+  }  
+   public function testCapsAfterColonAndPeriodTitle() {
+      $text = '{{Cite journal|title=but in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.}}';
+      $expanded = $this->process_citation($text);
       $this->assertEquals('But in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.', $expanded->get('title'));
   }
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -609,16 +609,11 @@ ER -  }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
-  public function testCapsAfterColonAndPeriodJournal() {
+  public function testCapsAfterColonAndPeriodJournalTidy() {
       $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.}}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('In Journal Titles: A Word Following Punctuation Needs Capitals. Of Course.', $expanded->get('journal'));
-  }  
-   public function testCapsAfterColonAndPeriodTitle() {
-      $text = '{{Cite journal|title=but in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.}}';
-      $expanded = $this->process_citation($text);
-      $this->assertEquals('But in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.', $expanded->get('title'));
-  }
+  }      
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things
       $text = '{{cite journal|title=[[Zootimeboys]] and Girls|journal=[[Zootimeboys]] and Girls}}';
       $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -610,7 +610,7 @@ ER -  }}';
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
   public function testCapsAfterColonAndPeriodJournal() {
-      $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.}}'
+      $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.}}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('In Journal Titles: A Word Following Punctuation Needs Capitals. Of Course.', $expanded->get('journal'));
   }  

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -644,7 +644,7 @@ ER -  }}';
   }
   public function testTitleCAPS(){
       $text = 'THIS A JOURNAL';
-      $expanded = title_capitalization($text,TRUE);
+      $expanded = title_capitalization($text, TRUE);
       $this->assertEquals("This a Journal", $expanded);
   }
   public function testSpeciesCaps() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -609,6 +609,13 @@ ER -  }}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('ZooTimeKids', $expanded->get('journal'));
   }
+  public function testCapsAfterColonAndPeriod() {
+      $text = '{{Cite journal |journal=In Journal Titles: a word following punctuation needs capitals. Of course.
+              |title=but in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.}}';
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('In Journal Titles: A Word Following Punctuation Needs Capitals. Of Course.', $expanded->get('journal'));
+      $this->assertEquals('But in a title: a word following punctuation remains lowercase. Of course, periods still demand uppercase.', $expanded->get('title'));
+  }
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things
       $text = '{{cite journal|title=[[Zootimeboys]] and Girls|journal=[[Zootimeboys]] and Girls}}';
       $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -644,7 +644,7 @@ ER -  }}';
   }
   public function testTitleCAPS(){
       $text = 'THIS A JOURNAL';
-      $expanded = title_capitalization($text);
+      $expanded = title_capitalization($text,TRUE);
       $this->assertEquals("This a Journal", $expanded);
   }
   public function testSpeciesCaps() {

--- a/tests/phpunit/expandFnsTest.php
+++ b/tests/phpunit/expandFnsTest.php
@@ -19,9 +19,9 @@ final class expandFnsTest extends PHPUnit\Framework\TestCase {
   }
   
   public function testCapitalization() {
-    $this->assertEquals('Molecular and Cellular Biology', title_capitalization(title_case('Molecular and cellular biology')));
-    $this->assertEquals('z/Journal', title_capitalization(title_case('z/Journal')));
-    $this->assertEquals('The Journal of Journals', title_capitalization('The Journal Of Journals')); // The, not the
+    $this->assertEquals('Molecular and Cellular Biology', title_capitalization(title_case('Molecular and cellular biology'),TRUE));
+    $this->assertEquals('z/Journal', title_capitalization(title_case('z/Journal'),TRUE));
+    $this->assertEquals('The Journal of Journals', title_capitalization('The Journal Of Journals'), TRUE); // The, not the
   }
 
   public function testDoiRegExp() {

--- a/tests/phpunit/expandFnsTest.php
+++ b/tests/phpunit/expandFnsTest.php
@@ -19,14 +19,20 @@ final class expandFnsTest extends PHPUnit\Framework\TestCase {
   }
   
   public function testCapitalization() {
-    $this->assertEquals('Molecular and Cellular Biology', title_capitalization(title_case('Molecular and cellular biology'),TRUE));
-    $this->assertEquals('z/Journal', title_capitalization(title_case('z/Journal'),TRUE));
-    $this->assertEquals('The Journal of Journals', title_capitalization('The Journal Of Journals', TRUE)); // The, not the
+    $this->assertEquals('Molecular and Cellular Biology', 
+                        title_capitalization(title_case('Molecular and cellular biology'), TRUE));
+    $this->assertEquals('z/Journal', 
+                        title_capitalization(title_case('z/Journal'), TRUE));
+    $this->assertEquals('The Journal of Journals', // The, not the
+                        title_capitalization('The Journal Of Journals', TRUE));
   }
 
   public function testDoiRegExp() {
-    $this->assertEquals('10.1111/j.1475-4983.2012.01203.x', extract_doi('http://onlinelibrary.wiley.com/doi/10.1111/j.1475-4983.2012.01203.x/full')[1]);
-    $this->assertEquals('10.1111/j.1475-4983.2012.01203.x', extract_doi('http://onlinelibrary.wiley.com/doi/10.1111/j.1475-4983.2012.01203.x/abstract')[1]);
-    $this->assertEquals('10.1016/j.physletb.2010.03.064', extract_doi(' 10.1016%2Fj.physletb.2010.03.064')[1]);
+    $this->assertEquals('10.1111/j.1475-4983.2012.01203.x', 
+                        extract_doi('http://onlinelibrary.wiley.com/doi/10.1111/j.1475-4983.2012.01203.x/full')[1]);
+    $this->assertEquals('10.1111/j.1475-4983.2012.01203.x', 
+                        extract_doi('http://onlinelibrary.wiley.com/doi/10.1111/j.1475-4983.2012.01203.x/abstract')[1]);
+    $this->assertEquals('10.1016/j.physletb.2010.03.064', 
+                        extract_doi(' 10.1016%2Fj.physletb.2010.03.064')[1]);
   }  
 }

--- a/tests/phpunit/expandFnsTest.php
+++ b/tests/phpunit/expandFnsTest.php
@@ -21,7 +21,7 @@ final class expandFnsTest extends PHPUnit\Framework\TestCase {
   public function testCapitalization() {
     $this->assertEquals('Molecular and Cellular Biology', title_capitalization(title_case('Molecular and cellular biology'),TRUE));
     $this->assertEquals('z/Journal', title_capitalization(title_case('z/Journal'),TRUE));
-    $this->assertEquals('The Journal of Journals', title_capitalization('The Journal Of Journals'), TRUE); // The, not the
+    $this->assertEquals('The Journal of Journals', title_capitalization('The Journal Of Journals', TRUE)); // The, not the
   }
 
   public function testDoiRegExp() {


### PR DESCRIPTION
Also made punctuation arguments non-optional to encourage thinking about it

ucwords only uppercases words, does not lowercase the other letters I the word Which is what we need. 