### PR TITLE
standardize get_doi_from_crossref

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -568,9 +568,7 @@ final class Template {
         if ($this->blank($param_name)) {
           $this->add($param_name, sanitize_string($value));
           $this->expand_by_pubmed();
-          if ($this->blank('doi')) {
-            $this->get_doi_from_crossref();
-          }
+          $this->get_doi_from_crossref();
           return TRUE;
         }
       return FALSE;
@@ -1548,7 +1546,7 @@ final class Template {
         break;
       }
     }
-    if ($xml && $this->blank('doi')) $this->get_doi_from_crossref();
+    if ($xml) $this->get_doi_from_crossref();
   }
 
   protected function use_sici() {


### PR DESCRIPTION
Do not check is DOI is set before calling get_doi_from_crossref().
This is checked inside.  
This basically makes the calls to get_doi_from_crossref() consistent about not checking.
We generally do not check, so this now follows our “standards”