### PR TITLE
Fix edit summary

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -127,10 +127,10 @@ class Page {
 
   public function edit_summary() {
     $auto_summary = "";
-    if (isset($this->modifications["changeonly"]) && count($this->modifications['changeonly']) !== 0) {
+    if (isset($this->modifications["changeonly"]) && (count($this->modifications['changeonly']) !== 0)) {
       $auto_summary .= "Alter: " . implode(", ", $this->modifications["changeonly"]) . ". ";
     }
-    if (isset($this->modifications['additions']) && count($this->modifications['additions']) !== 0) {
+    if (isset($this->modifications['additions']) && (count($this->modifications['additions']) !== 0)) {
       $addns = $this->modifications["additions"];
       $auto_summary .= "Add: ";
       $min_au = 9999;
@@ -156,7 +156,7 @@ class Page {
     $auto_summary .= (isset($this->modifications["deletions"]) && (count($this->modifications["deletions"]) !==0))
       ? "Removed parameters. "
       : ""
-      ) . ((isset($this->modifications["dashes"]) && (count($this->modifications["dashes"]) !== 0))
+      ) . (isset($this->modifications["dashes"]) && (count($this->modifications["dashes"]) !== 0))
       ? "Formatted [[WP:ENDASH|dashes]]. "
       : ""
     );

--- a/Page.php
+++ b/Page.php
@@ -153,10 +153,10 @@ class Page {
       $auto_summary .= "Removed accessdate with no specified URL. ";
       unset($this->modifications["deletions"][$pos]);
     }
-    $auto_summary .= (isset($this->modifications["deletions"]) && (count($this->modifications["deletions"]) !==0))
+    $auto_summary .= ((isset($this->modifications["deletions"]) && (count($this->modifications["deletions"]) !==0))
       ? "Removed parameters. "
       : ""
-      ) . (isset($this->modifications["dashes"]) && (count($this->modifications["dashes"]) !== 0))
+      ) . ((isset($this->modifications["dashes"]) && (count($this->modifications["dashes"]) !== 0))
       ? "Formatted [[WP:ENDASH|dashes]]. "
       : ""
     );

--- a/Page.php
+++ b/Page.php
@@ -156,7 +156,7 @@ class Page {
     $auto_summary .= ((isset($this->modifications["deletions"]) && (count($this->modifications["deletions"]) !==0))
       ? "Removed parameters. "
       : ""
-      ) . ((isset($this->modifications["dashes"]) && (count($this->modifications["dashes"]) !== 0))
+      ) . (isset($this->modifications["dashes"])
       ? "Formatted [[WP:ENDASH|dashes]]. "
       : ""
     );

--- a/Page.php
+++ b/Page.php
@@ -127,10 +127,10 @@ class Page {
 
   public function edit_summary() {
     $auto_summary = "";
-    if (isset($this->modifications["changeonly"]) && (count($this->modifications['changeonly']) !== 0)) {
+    if ((count($this->modifications['changeonly']) !== 0)) {
       $auto_summary .= "Alter: " . implode(", ", $this->modifications["changeonly"]) . ". ";
     }
-    if (isset($this->modifications['additions']) && (count($this->modifications['additions']) !== 0)) {
+    if ((count($this->modifications['additions']) !== 0)) {
       $addns = $this->modifications["additions"];
       $auto_summary .= "Add: ";
       $min_au = 9999;
@@ -147,13 +147,13 @@ class Page {
         $auto_summary = substr($auto_summary, 0, -2) . '. ';
       }
     }
-    if (isset($this->modifications["deletions"])
+    if ((count($this->modifications["deletions"]) !== 0)
     && ($pos = array_search('accessdate', $this->modifications["deletions"])) !== FALSE
     ) {
       $auto_summary .= "Removed accessdate with no specified URL. ";
       unset($this->modifications["deletions"][$pos]);
     }
-    $auto_summary .= ((isset($this->modifications["deletions"]) && (count($this->modifications["deletions"]) !==0))
+    $auto_summary .= (((count($this->modifications["deletions"]) !==0))
       ? "Removed parameters. "
       : ""
       ) . (($this->modifications["dashes"])

--- a/Page.php
+++ b/Page.php
@@ -127,10 +127,10 @@ class Page {
 
   public function edit_summary() {
     $auto_summary = "";
-    if ((count($this->modifications['changeonly']) !== 0)) {
+    if (count($this->modifications["changeonly"]) !== 0) {
       $auto_summary .= "Alter: " . implode(", ", $this->modifications["changeonly"]) . ". ";
     }
-    if ((count($this->modifications['additions']) !== 0)) {
+    if (count($this->modifications['additions']) !== 0) {
       $addns = $this->modifications["additions"];
       $auto_summary .= "Add: ";
       $min_au = 9999;

--- a/Page.php
+++ b/Page.php
@@ -153,10 +153,10 @@ class Page {
       $auto_summary .= "Removed accessdate with no specified URL. ";
       unset($this->modifications["deletions"][$pos]);
     }
-    $auto_summary .= (($this->modifications["deletions"])
+    $auto_summary .= (isset($this->modifications["deletions"]) && (count($this->modifications["deletions"]) !==0))
       ? "Removed parameters. "
       : ""
-      ) . (($this->modifications["dashes"])
+      ) . ((isset($this->modifications["dashes"]) && (count($this->modifications["dashes"]) !== 0))
       ? "Formatted [[WP:ENDASH|dashes]]. "
       : ""
     );

--- a/Page.php
+++ b/Page.php
@@ -127,10 +127,10 @@ class Page {
 
   public function edit_summary() {
     $auto_summary = "";
-    if (isset($this->modifications["changeonly"])) {
+    if (isset($this->modifications["changeonly"]) && count($this->modifications['changeonly']) !== 0) {
       $auto_summary .= "Alter: " . implode(", ", $this->modifications["changeonly"]) . ". ";
     }
-    if (isset($this->modifications['additions'])) {
+    if (isset($this->modifications['additions']) && count($this->modifications['additions']) !== 0) {
       $addns = $this->modifications["additions"];
       $auto_summary .= "Add: ";
       $min_au = 9999;

--- a/Page.php
+++ b/Page.php
@@ -153,7 +153,7 @@ class Page {
       $auto_summary .= "Removed accessdate with no specified URL. ";
       unset($this->modifications["deletions"][$pos]);
     }
-    $auto_summary .= (((count($this->modifications["deletions"]) !==0))
+    $auto_summary .= ((count($this->modifications["deletions"]) !==0)
       ? "Removed parameters. "
       : ""
       ) . (($this->modifications["dashes"])

--- a/Page.php
+++ b/Page.php
@@ -156,7 +156,7 @@ class Page {
     $auto_summary .= ((isset($this->modifications["deletions"]) && (count($this->modifications["deletions"]) !==0))
       ? "Removed parameters. "
       : ""
-      ) . (isset($this->modifications["dashes"])
+      ) . (($this->modifications["dashes"])
       ? "Formatted [[WP:ENDASH|dashes]]. "
       : ""
     );

--- a/Template.php
+++ b/Template.php
@@ -2784,12 +2784,6 @@ final class Template {
       }
     }
     $ret['dashes'] = $this->mod_dashes;
-
-    if(isset($ret['modifications']) && (count($ret['modifications'])===0)) unset($ret['modifications']);
-    if(isset($ret['additions']) && (count($ret['additions'])===0)) unset($ret['additions']);
-    if(isset($ret['deletions']) && (count($ret['deletions'])===0)) unset($ret['deletions']);
-    if(isset($ret['changeonly']) && (count($ret['changeonly'])===0)) unset($ret['changeonly']);
-
     if (in_array($type, array_keys($ret))) return $ret[$type];
     return $ret;
   }

--- a/Template.php
+++ b/Template.php
@@ -2768,10 +2768,9 @@ final class Template {
     }
 
     $old = ($this->initial_param) ? $this->initial_param : array();
-    if ($this->initial_name !== $this->name) {
-      $old[] = $this->initial_name;
-      $new[] = $this->name;
-    }
+    
+    $old['template type'] = trim($this->initial_name);
+    $new['template type'] = trim($this->name);
 
     if ($new) {
       if ($old) {

--- a/Template.php
+++ b/Template.php
@@ -25,7 +25,7 @@ final class Template {
   protected $rawtext;
 
   protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes;
+            $mod_dashes, $initial_name;
 
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any
@@ -41,6 +41,7 @@ final class Template {
       $this->name = substr($text, 2, -2);
       $this->param = NULL;
     }
+    $initial_name = $this->name;
 
     // extract initial parameters/values from Parameters in $this->param
     if ($this->param) foreach ($this->param as $p) {
@@ -2767,6 +2768,11 @@ final class Template {
     }
 
     $old = ($this->initial_param) ? $this->initial_param : array();
+    if ($this->intial_name !== $this->name) {
+      $old[] = $this->intial_name;
+      $new[] = $this->name;
+    }
+
     if ($new) {
       if ($old) {
         $ret['modifications'] = array_keys(array_diff_assoc ($new, $old));

--- a/Template.php
+++ b/Template.php
@@ -24,8 +24,8 @@ final class Template {
   public $all_templates;  // Points to list of all the Template() on the Page() including this one
   protected $rawtext;
 
-  protected $name, $param, $initial_param, $initial_author_params, $citation_template, 
-            $mod_dashes, $initial_name;
+  protected $name, $param, $initial_param, $initial_author_params, $initial_name,
+            $citation_template, $mod_dashes;
 
   public function parse_text($text) {
     $this->initial_author_params = null; // Will be populated later if there are any

--- a/Template.php
+++ b/Template.php
@@ -2778,6 +2778,9 @@ final class Template {
         $ret['additions'] = array_diff(array_keys($new), array_keys($old));
         $ret['deletions'] = array_diff(array_keys($old), array_keys($new));
         $ret['changeonly'] = array_diff($ret['modifications'], $ret['additions']);
+        foreach ($ret['deletions'] as $inds=>$vals) {
+          if ($vals === '') unset($ret['deletions'][$inds]); // If we get rid of double pipe that appears as a deletion, not misc.
+        }
       } else {
         $ret['additions'] = array_keys($new);
         $ret['modifications'] = array_keys($new);

--- a/Template.php
+++ b/Template.php
@@ -41,7 +41,7 @@ final class Template {
       $this->name = substr($text, 2, -2);
       $this->param = NULL;
     }
-    $initial_name = $this->name;
+    $this->$initial_name = $this->name;
 
     // extract initial parameters/values from Parameters in $this->param
     if ($this->param) foreach ($this->param as $p) {

--- a/Template.php
+++ b/Template.php
@@ -41,7 +41,7 @@ final class Template {
       $this->name = substr($text, 2, -2);
       $this->param = NULL;
     }
-    $this->$initial_name = $this->name;
+    $this->initial_name = $this->name;
 
     // extract initial parameters/values from Parameters in $this->param
     if ($this->param) foreach ($this->param as $p) {

--- a/Template.php
+++ b/Template.php
@@ -2784,6 +2784,9 @@ final class Template {
       }
     }
     $ret['dashes'] = $this->mod_dashes;
+    foreach ($ret as $r) {
+        if (count($r) === 0) unset($r); // Remove ones that are empty
+    }
     if (in_array($type, array_keys($ret))) return $ret[$type];
     return $ret;
   }

--- a/Template.php
+++ b/Template.php
@@ -2784,9 +2784,12 @@ final class Template {
       }
     }
     $ret['dashes'] = $this->mod_dashes;
-    foreach ($ret as $r) {
-        if (count($r) === 0) unset($r); // Remove ones that are empty
-    }
+
+    if(isset($ret['modifications']) && (count($ret['modifications'])===0)) unset($ret['modifications']);
+    if(isset($ret['additions']) && (count($ret['additions'])===0)) unset($ret['additions']);
+    if(isset($ret['deletions']) && (count($ret['deletions'])===0)) unset($ret['deletions']);
+    if(isset($ret['changeonly']) && (count($ret['changeonly'])===0)) unset($ret['changeonly']);
+
     if (in_array($type, array_keys($ret))) return $ret[$type];
     return $ret;
   }

--- a/Template.php
+++ b/Template.php
@@ -2768,8 +2768,8 @@ final class Template {
     }
 
     $old = ($this->initial_param) ? $this->initial_param : array();
-    if ($this->intial_name !== $this->name) {
-      $old[] = $this->intial_name;
+    if ($this->initial_name !== $this->name) {
+      $old[] = $this->initial_name;
       $new[] = $this->name;
     }
 

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -29,6 +29,11 @@ class PageTest extends PHPUnit\Framework\TestCase {
     return $page;
   }
 
+  public function testPageChangeSummary() {
+      $page = $this->process_page('{{cite journal|isbn=123456789|chapter=chapter name|title=book name}}');
+      $this->assertNull($page->edit_summary()); // Actually not NULL, just want to see it.  We alter journal to book
+  }
+
   public function testBotRead() {
     if (getenv('TRAVIS_PULL_REQUEST')) {
       echo "\n[Test skipped] in pull requests, to protect Bot secrets";

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -5,7 +5,7 @@
  */
 error_reporting(E_ALL);
 // backward compatibility
-if (!class_exists('\PHPUnit\Framework\TestCase') &&https://github.com/ms609/citation-bot/pull/511/files
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
     class_exists('\PHPUnit_Framework_TestCase')) {
     class_alias('\PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
 }

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -30,8 +30,10 @@ class PageTest extends PHPUnit\Framework\TestCase {
   }
 
   public function testPageChangeSummary() {
-      $page = $this->process_page('{{cite journal|chapter=chapter name|title=book name}}');
+      $page = $this->process_page('{{cite journal|chapter=chapter name|title=book name}}'); // Change to book from journal
       $this->assertEquals('Alter: template type. You can [[WP:UCB|use this bot]] yourself. [[WP:DBUG|Report bugs here]].',$page->edit_summary());
+      $page = $this->process_page('{{cite book|chapter=chapter name||quote=a quote}}'); // Just lose extra pipe
+      $this->assertEquals('Misc citation tidying.  You can [[WP:UCB|use this bot]] yourself. [[WP:DBUG|Report bugs here]].',$page->edit_summary());
   }
 
   public function testBotRead() {

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -32,8 +32,8 @@ class PageTest extends PHPUnit\Framework\TestCase {
   public function testPageChangeSummary() {
       $page = $this->process_page('{{cite journal|chapter=chapter name|title=book name}}'); // Change to book from journal
       $this->assertEquals('Alter: template type. You can [[WP:UCB|use this bot]] yourself. [[WP:DBUG|Report bugs here]].',$page->edit_summary());
-      $page = $this->process_page('{{cite book|chapter=chapter name||quote=a quote}}'); // Just lose extra pipe
-      $this->assertEquals('Misc citation tidying.  You can [[WP:UCB|use this bot]] yourself. [[WP:DBUG|Report bugs here]].',$page->edit_summary());
+      $page = $this->process_page('{{cite book||quote=a quote}}'); // Just lose extra pipe
+      $this->assertEquals('Misc citation tidying. You can [[WP:UCB|use this bot]] yourself. [[WP:DBUG|Report bugs here]].',$page->edit_summary());
   }
 
   public function testBotRead() {

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -5,7 +5,7 @@
  */
 error_reporting(E_ALL);
 // backward compatibility
-if (!class_exists('\PHPUnit\Framework\TestCase') &&
+if (!class_exists('\PHPUnit\Framework\TestCase') &&https://github.com/ms609/citation-bot/pull/511/files
     class_exists('\PHPUnit_Framework_TestCase')) {
     class_alias('\PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
 }
@@ -31,7 +31,7 @@ class PageTest extends PHPUnit\Framework\TestCase {
 
   public function testPageChangeSummary() {
       $page = $this->process_page('{{cite journal|chapter=chapter name|title=book name}}');
-      $this->assertEquals('Alter: template type. Add. You can [[WP:UCB|use this bot]] yourself. [[WP:DBUG|Report bugs here]].',$page->edit_summary());
+      $this->assertEquals('Alter: template type. You can [[WP:UCB|use this bot]] yourself. [[WP:DBUG|Report bugs here]].',$page->edit_summary());
   }
 
   public function testBotRead() {

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -30,8 +30,8 @@ class PageTest extends PHPUnit\Framework\TestCase {
   }
 
   public function testPageChangeSummary() {
-      $page = $this->process_page('{{cite journal|isbn=123456789|chapter=chapter name|title=book name}}');
-      $this->assertNull($page->edit_summary()); // Actually not NULL, just want to see it.  We alter journal to book
+      $page = $this->process_page('{{cite journal|chapter=chapter name|title=book name}}');
+      $this->assertEquals('Alter: template type. Add. You can [[WP:UCB|use this bot]] yourself. [[WP:DBUG|Report bugs here]].',$page->edit_summary());
   }
 
   public function testBotRead() {


### PR DESCRIPTION
Keep track of template type before and after and add to arrays.
Check if set arrays are empty before using, instead of just checking for existence.
Remove empty elements from deletions array (they come from deleting empty element of double pipe)