### PR TITLE
Prefer landing page url to url

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1603,20 +1603,21 @@ final class Template {
           // The best location is already linked to by the doi link
           return TRUE;
         }
-        if (preg_match("~^https?://europepmc\.org/articles/pmc(\d+)~", $best_location->url, $match) || preg_match("~^https?://www\.pubmedcentral\.nih\.gov/articlerender.fcgi\?.*\bartid=(\d+)"
-                      . "|^https?://www\.ncbi\.nlm\.nih\.gov/pmc/articles/PMC(\d+)~", $best_location->url, $match)) {
+        if (preg_match("~^https?://europepmc\.org/articles/pmc(\d+)~", $best_location->url_for_landing_page, $match) || preg_match("~^https?://www\.pubmedcentral\.nih\.gov/articlerender.fcgi\?.*\bartid=(\d+)"
+                      . "|^https?://www\.ncbi\.nlm\.nih\.gov/pmc/articles/PMC(\d+)~", $best_location->url_for_landing_page, $match)) {
           if ($this->has('pmc') ) {
              // The best location is already linked to by the PMC link
              return TRUE;
           }
         }
-        if (preg_match("~\barxiv\.org/.*(?:pdf|abs)/(.+)$~", $best_location->url, $match)) {
+        if (preg_match("~\barxiv\.org/.*(?:pdf|abs)/(.+)$~", $best_location->url_for_landing_page, $match)) {
           if ($this->has('arxiv') || $this->has('eprint')) {
              // The best location is already linked to by the ARXIV link
              return TRUE;
           }
         }
-        $this->add_if_new('url', $best_location->url);  // Will check for PMCs etc hidden in URL
+        if (
+        $this->add_if_new('url', $best_location->url_for_landing_page);  // Will check for PMCs etc hidden in URL
         if ($this->has('url')) {  // The above line might have eaten the URL and upgraded it
           $headers_test = @get_headers($this->get('url'), 1);
           if($headers_test ===FALSE) {

--- a/Template.php
+++ b/Template.php
@@ -1616,7 +1616,6 @@ final class Template {
              return TRUE;
           }
         }
-        if (
         $this->add_if_new('url', $best_location->url_for_landing_page);  // Will check for PMCs etc hidden in URL
         if ($this->has('url')) {  // The above line might have eaten the URL and upgraded it
           $headers_test = @get_headers($this->get('url'), 1);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -249,8 +249,8 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   public function testOpenAccessLookup() {
     $text = '{{cite journal|doi=10.1206/0003-0082(2008)3610[1:nrofwf]2.0.co;2}}';
     $expanded = $this->process_citation($text);
-    $this->assertEquals('http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.1001.5321',$expanded->get('url'));
-    $this->assertEquals('2008',$expanded->get('year')); // DOI does work though
+    $this->assertEquals('http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.1001.5321', $expanded->get('url'));
+    $this->assertEquals('2008', $expanded->get('year')); // DOI does work though
       
     $text = '{{cite journal | vauthors = Bjelakovic G, Nikolova D, Gluud LL, Simonetti RG, Gluud C | title = Antioxidant supplements for prevention of mortality in healthy participants and patients with various diseases | journal = The Cochrane Database of Systematic Reviews | volume = 3 | issue = 3 | pages = CD007176 | date = 14 March 2012 | pmid = 22419320 | doi = 10.1002/14651858.CD007176.pub2 }}';
     $expanded = $this->process_citation($text);
@@ -336,7 +336,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     // Double-check pages expansion
     $text = "{{Cite journal|pp. 1-5}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('1–5',$expanded->get('pages'));
+    $this->assertEquals('1–5', $expanded->get('pages'));
   }
        
   public function testId2Param() {
@@ -361,23 +361,23 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
       $expanded = $this->process_citation($text);
       $this->assertEquals('astr.ph/1234.5678', $expanded->get('arxiv'));
-      $this->assertEquals('{{cite book | arxiv=astr.ph/1234.5678 }}',$expanded->parsed_text());
+      $this->assertEquals('{{cite book | arxiv=astr.ph/1234.5678 }}', $expanded->parsed_text());
       
       $text = '{{cite book|pages=1–2|id={{arxiv|astr.ph|1234.5678}}}}{{cite book|pages=1–3|id={{arxiv|astr.ph|1234.5678}}}}'; // Two of the same sub-template, but in different tempalates
       $expanded = $this->process_page($text);
-      $this->assertEquals('{{cite book|pages=1–2|arxiv=astr.ph/1234.5678}}{{cite book|pages=1–3|arxiv=astr.ph/1234.5678}}',$expanded->parsed_text());
+      $this->assertEquals('{{cite book|pages=1–2|arxiv=astr.ph/1234.5678}}{{cite book|pages=1–3|arxiv=astr.ph/1234.5678}}', $expanded->parsed_text());
   }
   
   public function testNestedTemplates() {
       $text = '{{cite book|pages=1-2| {{cnn|{{fox|{{msnbc}}|{{local}}|test}} | hello }} {{tester}} {{ random {{ inside {{tester}} }} | id={{cite book|pages=1-2| {{cnn|{{fox|{{msnbc}}|{{local}}|test}} | hello }} {{tester}} {{ random {{ inside {{tester}} }} }}  }} |  cool stuff | not cool}}';
       $expanded = $this->process_citation($text);
       $text = str_replace("-", "–", $text); // Should not change anything other than upgrade dashes
-      $this->assertEquals($text,$expanded->parsed_text());
+      $this->assertEquals($text, $expanded->parsed_text());
       
       $text = '{{cite book|quote=See {{cite book|pages=1-2|quote=See {{cite book|pages=1-4}}}}|pages=1-3}}';
       $expanded = $this->process_citation($text);
       $text = str_replace("-", "–", $text); // Should not change anything other than upgrade dashes
-      $this->assertEquals($text,$expanded->parsed_text());
+      $this->assertEquals($text, $expanded->parsed_text());
   }
   
    
@@ -440,11 +440,11 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   public function testInPress() {
     $text = '{{Cite journal|pmid=9858585|date =in press}}';
     $expanded = $this->process_citation($text);
-    $this->assertEquals('1999',$this->getDateAndYear($expanded));
+    $this->assertEquals('1999', $this->getDateAndYear($expanded));
 
     $text = '{{cite journal|pmid=9858585|year=in press}}';
     $expanded = $this->process_citation($text);
-    $this->assertEquals('1999',$this->getDateAndYear($expanded));
+    $this->assertEquals('1999', $this->getDateAndYear($expanded));
   }
   
  public function testISODates() {
@@ -591,7 +591,7 @@ ER -  }}';
   public function testHearst () {
        $text = '{{cite book|url=http://books.google.com/books?id=p-IDAAAAMBAJ&lpg=PA195&dq=Popular%20Science%201930%20plane%20%22Popular%20Mechanics%22&pg=PA194#v=onepage&q&f=true}}';
        $expanded = $this->process_citation($text);
-       $this->assertEquals('Hearst Magazines',$expanded->get('publisher'));
+       $this->assertEquals('Hearst Magazines', $expanded->get('publisher'));
        $this->assertNull($expanded->get('last1'));
        $this->assertNull($expanded->get('last'));
        $this->assertNull($expanded->get('author'));
@@ -602,7 +602,7 @@ ER -  }}';
   public function testLinefeeds(){
        $text = '{{cite arXiv|eprint=hep-th/0303241}}';
        $expanded = $this->process_citation($text);
-       $this->assertEquals('Pascual Jordan, his contributions to quantum mechanics and his legacy in contemporary local quantum physics',$expanded->get('title'));
+       $this->assertEquals('Pascual Jordan, his contributions to quantum mechanics and his legacy in contemporary local quantum physics', $expanded->get('title'));
   }
    public function testInternalCaps() { // checks for title formating in tidy() not breaking things
       $text = '{{cite journal|journal=ZooTimeKids}}';
@@ -694,7 +694,7 @@ ER -  }}';
   public function testIgnoreJstorPlants() {
     $text='{{Cite journal| url=http://plants.jstor.org/stable/10.5555/al.ap.specimen.nsw225972 |title=Holotype of Persoonia terminalis L.A.S.Johnson & P.H.Weston [family PROTEACEAE]}}';
     $expanded = $this->process_citation($text);
-    $this->assertEquals('http://plants.jstor.org/stable/10.5555/al.ap.specimen.nsw225972',$expanded->get('url'));
+    $this->assertEquals('http://plants.jstor.org/stable/10.5555/al.ap.specimen.nsw225972', $expanded->get('url'));
     $this->assertNull($expanded->get('jstor'));
   }
    
@@ -752,7 +752,7 @@ ER -  }}';
    public function testJustAnISBN() {
        $text = '{{cite book |isbn=0471186368}}';
        $expanded = $this->process_citation($text);
-       $this->assertEquals('Explosives engineering',$expanded->get('title'));
+       $this->assertEquals('Explosives engineering', $expanded->get('title'));
        $this->assertNull($expanded->get('url'));
    }
     
@@ -760,7 +760,7 @@ ER -  }}';
     $this->requires_secrets(function() {
        $text = '{{cite book | oclc=9334453}}';
        $expanded = $this->process_citation($text);
-       $this->assertEquals('The Shreveport Plan: A Long-range Guide for the Future Development of Metropolitan Shreveport',$expanded->get('title'));
+       $this->assertEquals('The Shreveport Plan: A Long-range Guide for the Future Development of Metropolitan Shreveport', $expanded->get('title'));
     });
    }
 
@@ -768,7 +768,7 @@ ER -  }}';
     $this->requires_secrets(function() {
       $text = '{{cite book | lccn=2009925036}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('Alternative Energy for Dummies',$expanded->get('title'));
+      $this->assertEquals('Alternative Energy for Dummies', $expanded->get('title'));
     });
   }
     
@@ -794,7 +794,7 @@ ER -  }}';
     $this->assertNull($expanded->get('isbn')); // This citation used to crash code in ISBN search.  Mostly checking "something" to make Travis CI happy
  }
 
- public function testLatexMathInTitle() { // This contains Math stuff that should be z∼10, but we just verify that we do not make it worse at this time.  See https://tex.stackexchange.com/questions/55701/how-do-i-write-sim-approximately-with-the-correct-spacing
+ public function testLatexMathInTitle() { // This contains Math stuff that should be z~10, but we just verify that we do not make it worse at this time.  See https://tex.stackexchange.com/questions/55701/how-do-i-write-sim-approximately-with-the-correct-spacing
     $text = "{{Cite arxiv|eprint=1801.03103}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc', $expanded->get('title'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -249,7 +249,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   public function testOpenAccessLookup() {
     $text = '{{cite journal|doi=10.1206/0003-0082(2008)3610[1:nrofwf]2.0.co;2}}';
     $expanded = $this->process_citation($text);
-    $this->assertNull($expanded->get('url')); // current gives dead url 
+    $this->assertEquals('http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.1001.5321',$expanded->get('url'));
     $this->assertEquals('2008',$expanded->get('year')); // DOI does work though
       
     $text = '{{cite journal | vauthors = Bjelakovic G, Nikolova D, Gluud LL, Simonetti RG, Gluud C | title = Antioxidant supplements for prevention of mortality in healthy participants and patients with various diseases | journal = The Cochrane Database of Systematic Reviews | volume = 3 | issue = 3 | pages = CD007176 | date = 14 March 2012 | pmid = 22419320 | doi = 10.1002/14651858.CD007176.pub2 }}';


### PR DESCRIPTION
The other URL seems to not always be reliable.  Just plain "url" seems to involve some post-processing on their part (which is not always right):
https://api.oadoi.org/v2/10.1671/0272-4634(2002)022[0058:ADATDF]2.0.CO;2?email=not@telling.com
This also seems to be more likely to point to the description page instead of the final pdf, which is probably better since most people just want that.
Also, it gives a url more often.  See the test that is updated.