### PR TITLE
Fix get_identifiers_from_url() return codes

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -739,17 +739,21 @@ final class Template {
       } elseif (preg_match("~^https?://d?x?\.?doi\.org/([^\?]*)~", $url, $match)) {
         quiet_echo("\n   ~ URL is hard-coded DOI; converting to use DOI parameter.");
         if (strpos($this->name, 'web')) $this->name = 'Cite journal';
-        if (is_null($url_sent)) {
-          $this->forget('url');
+        if ($this->add_if_new("doi", urldecode($match[1])) ) { // Will expand from DOI when added
+          if (is_null($url_sent)) {
+            $this->forget('url');
+          }
+          return TRUE;
+        } else {
+          return FALSE;  // Did not add properly, so use as URL
         }
-        $this->add_if_new("doi", urldecode($match[1])); // Will expand from DOI when added
-        return TRUE;   
       } elseif (extract_doi($url)[1]) {
-        
-        quiet_echo("\n   ~ Recognized DOI in URL; dropping URL");
-        $this->add_if_new('doi', extract_doi($url)[1]);
-        return TRUE;
-        
+        if ($this->add_if_new('doi', extract_doi($url)[1])) {
+           quiet_echo("\n   ~ Recognized DOI in URL; dropping URL");
+           return TRUE;
+        } else {
+           return FALSE; // Did not add properly, so use as URL
+        }
       } elseif (preg_match("~\barxiv\.org/.*(?:pdf|abs)/(.+)$~", $url, $match)) {
         
         /* ARXIV

--- a/Template.php
+++ b/Template.php
@@ -710,7 +710,8 @@ final class Template {
           if (is_null($url_sent)) {
             $this->forget('url');
           }
-          return $this->add_if_new("bibcode", urldecode($bibcode[1]));
+          $this->add_if_new("bibcode", urldecode($bibcode[1]));
+          return TRUE;
         }
         
       } elseif (preg_match("~^https?://www\.pubmedcentral\.nih\.gov/articlerender.fcgi\?.*\bartid=(\d+)"
@@ -722,7 +723,8 @@ final class Template {
           if (is_null($url_sent)) {
             $this->forget('url');
           }
-          return $this->add_if_new("pmc", $match[1] . $match[2]);
+          $this->add_if_new("pmc", $match[1] . $match[2]);
+          return TRUE;
         }
       } elseif (preg_match("~^https?://europepmc\.org/articles/pmc(\d+)~", $url, $match)) {
         if (strpos($this->name, 'web')) $this->name = 'Cite journal';
@@ -731,7 +733,8 @@ final class Template {
           if (is_null($url_sent)) {
             $this->forget('url');
           }
-          return $this->add_if_new("pmc", $match[1]);
+          $this->add_if_new("pmc", $match[1]);
+          return TRUE;
         }
       } elseif (preg_match("~^https?://d?x?\.?doi\.org/([^\?]*)~", $url, $match)) {
         quiet_echo("\n   ~ URL is hard-coded DOI; converting to use DOI parameter.");
@@ -739,12 +742,13 @@ final class Template {
         if (is_null($url_sent)) {
           $this->forget('url');
         }
-        return $this->add_if_new("doi", urldecode($match[1])); // Will expand from DOI when added
-        
+        $this->add_if_new("doi", urldecode($match[1])); // Will expand from DOI when added
+        return TRUE;   
       } elseif (extract_doi($url)[1]) {
         
         quiet_echo("\n   ~ Recognized DOI in URL; dropping URL");
-        return $this->add_if_new('doi', extract_doi($url)[1]);
+        $this->add_if_new('doi', extract_doi($url)[1]);
+        return TRUE;
         
       } elseif (preg_match("~\barxiv\.org/.*(?:pdf|abs)/(.+)$~", $url, $match)) {
         
@@ -758,7 +762,8 @@ final class Template {
           if (is_null($url_sent)) {
             $this->forget('url');
           }
-          return $this->add_if_new("arxiv", $arxiv_id[0]);
+          $this->add_if_new("arxiv", $arxiv_id[0]);
+          return TRUE;
         }
         if (strpos($this->name, 'web')) $this->name = 'Cite arxiv';
         
@@ -768,7 +773,8 @@ final class Template {
           $this->forget('url');
         }
         if (strpos($this->name, 'web')) $this->name = 'Cite journal';
-        return $this->add_if_new('pmid', $match[1]);
+        $this->add_if_new('pmid', $match[1]);
+        return TRUE;
         
       } elseif (preg_match("~^https?://www\.amazon(?P<domain>\.[\w\.]{1,7})/.*dp/(?P<id>\d+X?)~", $url, $match)) {
         
@@ -778,22 +784,26 @@ final class Template {
             $this->forget('url');
           }
           if ($this->blank('asin')) {
-            return $this->add_if_new('asin', $match['id']);
+            $this->add_if_new('asin', $match['id']);
+            return TRUE;
           }
         } else {
           $this->set('id', $this->get('id') . " {{ASIN|{$match['id']}|country=" . str_replace(array(".co.", ".com.", "."), "", $match['domain']) . "}}");
           if (is_null($url_sent)) {
             $this->forget('url'); // will forget accessdate too
           }
+          return TRUE;
         }
       } elseif (preg_match("~^https?://hdl\.handle\.net/([^\?]*)~", $url, $match)) {
           if (is_null($url_sent)) {
              $this->forget('url');
           }
           if (preg_match("~\bweb\b~", $this->name)) $this->name = 'Cite journal';  // Better template choice.  Often journal/paper
-          return $this->add_if_new('hdl', $match[1]);
+          $this->add_if_new('hdl', $match[1]);
+          return TRUE;
       }
     }
+    return FALSE;
   }
 
   protected function get_doi_from_text() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -274,7 +274,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       
     $text = '{{cite journal | vauthors = Benzie IF | title = Evolution of dietary antioxidants | journal = Comparative Biochemistry and Physiology A | volume = 136 | issue = 1 | pages = 113–26 | date = September 2003 | pmid = 14527634 | doi = 10.1016/S1095-6433(02)00368-9 | hdl = 10397/34754 | url = http://hdl.handle.net/10397/34754 }}';
     $expanded = $this->process_citation($text);
-    $this->assertNull($expanded->get('hdl')); // Do not add HDL URL if already has Arxiv
+    $this->assertNull($expanded->get('url')); // Do not add HDL URL if already has hdl=
       
     $text = '{{cite journal|doi=10.1038//TODO}}';
     /*

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -271,7 +271,11 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{Cite journal | doi = 10.1063/1.4962420| title = Calculating vibrational spectra of molecules using tensor train decomposition| journal = J. Chem. Phys. | volume = 145| year = 2016| issue = 145| pages = 124101| last1 = Rakhuba| first1 = Maxim | last2 = Oseledets | first2 = Ivan| bibcode = 2016JChPh.145l4101R| arxiv =1605.08422}}';
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('url')); // Do not add Arxiv URL if already has Arxiv
-
+      
+    $text = '{{cite journal | vauthors = Benzie IF | title = Evolution of dietary antioxidants | journal = Comparative Biochemistry and Physiology A | volume = 136 | issue = 1 | pages = 113–26 | date = September 2003 | pmid = 14527634 | doi = 10.1016/S1095-6433(02)00368-9 | hdl = 10397/34754 | url = http://hdl.handle.net/10397/34754 }}';
+    $expanded = $this->process_citation($text);
+    $this->assertNull($expanded->get('hdl')); // Do not add HDL URL if already has Arxiv
+      
     $text = '{{cite journal|doi=10.1038//TODO}}';
     /*
     $this->assertEquals('http://some.url', $expanded->get('url'));


### PR DESCRIPTION
The get_identifiers_from_url() return code is ONLY checked when adding a new URL in add_if_new().

Current code returns TRUE if the URL was converted into something else.
Proposed code also returns TRUE if the URL could have been converted, but the item already existed.
As it is code could add handle url for example even if hdl= was already set.