### PR TITLE
Remove Wikilinks from journal & titles names

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2342,9 +2342,17 @@ final class Template {
               echo "\n * Initial authors exist, skipping authorlink in tidy";
             }
             break;
-          case 'title':  
-            $p->val = preg_replace("~\[\[~", "", $p->val);  // remove wikilinks - brackets in names will be escaped
-            $p->val = preg_replace("~\]\]~", "", $p->val);
+          case 'title':
+            $p->val = preg_replace_callback(  // Convert [[X]] wikilinks into X
+                      "~(\[\[)([^|]+?)(\]\])~",
+                      create_function('$matches','return $matches[2];'),
+                      $p->val
+                      );
+            $p->val = preg_replace_callback(
+                      "~(\[\[)([^|]+?)(\|)([^|]+?)(\]\])~",   // Convert [[Y|X]] wikilinks into X
+                      create_function('$matches','return $matches[4];'),
+                      $p->val
+                      );
             break;
           case 'journal': 
             $this->forget('publisher');
@@ -2352,9 +2360,17 @@ final class Template {
             if(mb_substr($p->val, 0, 2) !== "[["   ||
                mb_substr($p->val, -2) !== "]]"     ||
                mb_substr_count($p->val,'[[') !== 1 ||
-               mb_substr_count($p->val,']]') !== 1) { 
-                 $p->val = preg_replace("~\[\[~", "", $p->val);  // remove partial wikilinks
-                 $p->val = preg_replace("~\]\]~", "", $p->val);
+               mb_substr_count($p->val,']]') !== 1) { // Only remove partial wikilinks
+                  $p->val = preg_replace_callback(  // Convert [[X]] wikilinks into X
+                      "~(\[\[)([^|]+?)(\]\])~",
+                      create_function('$matches','return $matches[2];'),
+                      $p->val
+                      );
+                  $p->val = preg_replace_callback(
+                      "~(\[\[)([^|]+?)(\|)([^|]+?)(\]\])~",   // Convert [[Y|X]] wikilinks into X
+                      create_function('$matches','return $matches[4];'),
+                      $p->val
+                      );
             }
             if(substr($p->val, 0, 1) !== "[" && substr($p->val, -1) !== "]") { 
                $p->val = title_capitalization(ucwords($p->val), TRUE);

--- a/Template.php
+++ b/Template.php
@@ -2342,9 +2342,17 @@ final class Template {
               echo "\n * Initial authors exist, skipping authorlink in tidy";
             }
             break;
+          case 'title':  
+            $p->val = preg_replace("~\[\[~", "", $p->val);  // remove wikilinks - brackets in names will be escaped
+            $p->val = preg_replace("~\]\]~", "", $p->val);
+            break;
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
+            if(substr($p->val, 0, 2) !== "[[" || substr($p->val, -2) !== "]]") { 
+                $p->val = preg_replace("~\[\[~", "", $p->val);  // remove partial wikilinks
+                $p->val = preg_replace("~\]\]~", "", $p->val);
+            }
             if(substr($p->val, 0, 1) !== "[" && substr($p->val, -1) !== "]") { 
                $p->val = title_capitalization(ucwords($p->val), TRUE);
             }

--- a/Template.php
+++ b/Template.php
@@ -2349,9 +2349,12 @@ final class Template {
           case 'journal': 
             $this->forget('publisher');
           case 'periodical': 
-            if(substr($p->val, 0, 2) !== "[[" || substr($p->val, -2) !== "]]") { 
-                $p->val = preg_replace("~\[\[~", "", $p->val);  // remove partial wikilinks
-                $p->val = preg_replace("~\]\]~", "", $p->val);
+            if(mb_substr($p->val, 0, 2) !== "[["   ||
+               mb_substr($p->val, -2) !== "]]"     ||
+               mb_substr_count($p->val,'[[') !== 1 ||
+               mb_substr_count($p->val,']]') !== 1) { 
+                 $p->val = preg_replace("~\[\[~", "", $p->val);  // remove partial wikilinks
+                 $p->val = preg_replace("~\]\]~", "", $p->val);
             }
             if(substr($p->val, 0, 1) !== "[" && substr($p->val, -1) !== "]") { 
                $p->val = title_capitalization(ucwords($p->val), TRUE);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -188,9 +188,11 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $this->assertEquals('{{Cite journal| journal=My Journal}}', $expanded->parsed_text());
   }
 
-  public function testRemoveJournalWikilinks() {
+  public function testRemoveWikilinks() {
     $expanded = $this->process_citation("{{Cite journal|journal=[[Pure Evil]]}}");
-    $this->assertEquals('[[Pure Evil]]', $expanded->get('journal'));
+    $this->assertEquals('[[Pure Evil]]', $expanded->get('journal')); // leave fully linked journals
+    $expanded = $this->process_citation("{{Cite journal|journal=[[Pure]] and [[Evil]]}}");
+    $this->assertEquals('Pure and Evil', $expanded->get('journal')); // leave fully linked journals
     $expanded = $this->process_citation("{{Cite journal|journal=Dark Lord of the Sith [[Pure Evil]]}}");
     $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('journal'));
     $expanded = $this->process_citation("{{Cite journal|title=[[Pure Evil]]}}");

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -190,9 +190,14 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
 
   public function testRemoveJournalWikilinks() {
     $expanded = $this->process_citation("{{Cite journal|journal=[[Pure Evil]]}}");
-    $this->assertEquals('Pure Evil', $expanded->get('journal'));
+    $this->assertEquals('[[Pure Evil]]', $expanded->get('journal'));
     $expanded = $this->process_citation("{{Cite journal|journal=Dark Lord of the Sith [[Pure Evil]]}}");
     $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('journal'));
+    $expanded = $this->process_citation("{{Cite journal|title=[[Pure Evil]]}}");
+    $this->assertEquals('Pure Evil', $expanded->get('title'));
+    $expanded = $this->process_citation("{{Cite journal|title=[[Dark]] Lord of the [[Sith]] [[Pure Evil]]}}");
+    $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('title'));
+  
   }
       
   public function testJournalCapitalization() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -654,8 +654,8 @@ ER -  }}';
   public function testExistingWikiText() { // checks for formating in tidy() not breaking things
       $text = '{{cite journal|title=[[Zootimeboys]] and Girls|journal=[[Zootimeboys]] and Girls}}';
       $expanded = $this->process_citation($text);
-      $this->assertEquals('[[Zootimeboys]] and Girls', $expanded->get('journal'));
-      $this->assertEquals('[[Zootimeboys]] and Girls', $expanded->get('title'));
+      $this->assertEquals('Zootimeboys and Girls', $expanded->get('journal'));
+      $this->assertEquals('Zootimeboys and Girls', $expanded->get('title'));
   }
   public function testNewWikiText() { // checks for new information that looks like wiki text and needs escaped
       $text = '{{Cite journal|doi=10.1021/jm00193a001}}';  // This has greek letters, [, ], (, and ).

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -187,7 +187,14 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     // ISSN is removed when journal is added.  Is this the desired behaviour? ##TODO!
     $this->assertEquals('{{Cite journal| journal=My Journal}}', $expanded->parsed_text());
   }
-  
+
+  public function testRemoveJournalWikilinks() {
+    $expanded = $this->process_citation("{{Cite journal|journal=[[Pure Evil]]}}");
+    $this->assertEquals('Pure Evil', $expanded->get('journal'));
+    $expanded = $this->process_citation("{{Cite journal|journal=Dark Lord of the Sith [[Pure Evil]]}}");
+    $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('journal'));
+  }
+      
   public function testJournalCapitalization() {
     $expanded = $this->process_citation("{{Cite journal|pmid=9858585}}");
     $this->assertEquals('Molecular and Cellular Biology', $expanded->get('journal'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -197,7 +197,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('journal'));
     $expanded = $this->process_citation("{{Cite journal|title=[[Pure Evil]]}}");
     $this->assertEquals('Pure Evil', $expanded->get('title'));
-    $expanded = $this->process_citation("{{Cite journal|title=[[Dark]] Lord of the [[Sith]] [[Pure Evil]]}}");
+    $expanded = $this->process_citation("{{Cite journal|title=[[Dark]] Lord of the [[Sith (Star Wars)|Sith]] [[Pure Evil]]}}");
     $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('title'));
   
   }


### PR DESCRIPTION
The only thing we leave is if the entire name of a journal is a wikilink