### PR TITLE
Fix PubMed Searching

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -947,11 +947,10 @@ final class Template {
       );
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
-        $query .= " AND (" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key])";
+        $query .= " AND (" . str_replace("%E2%80%93", "-", ($val)) . "[$key])";
       }
     }
     $query = substr($query, 5);
-    str_replace("%2F", "/", $query);
     $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=$query";
     print_r($url);
     $xml = @simplexml_load_file($url);

--- a/Template.php
+++ b/Template.php
@@ -184,7 +184,7 @@ final class Template {
           $this->handle_et_al();
         }
 
-        $this->expand_by_pubmed(); //partly to try to find DOI
+        $this->expand_by_pubmed($this->blank('pmid') && $this->has('pmc')); //partly to try to find DOI
 
         if ($this->expand_by_google_books()) {
           echo "\n * Expanded from Google Books API";

--- a/Template.php
+++ b/Template.php
@@ -947,7 +947,11 @@ final class Template {
       );
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
-        $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", urlencode($val)) . "\"" . "[$key])";
+        if ($key === "doi") {
+           $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", ($val)) . "\"" . "[$key])";
+        } else {
+           $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", urlencode($val)) . "\"" . "[$key])";
+        }
       }
     }
     $query = substr($query, 5);

--- a/Template.php
+++ b/Template.php
@@ -947,7 +947,7 @@ final class Template {
       );
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
-        if ($key === "doi") {
+        if ($key === "AID") {
            $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", ($val)) . "\"" . "[$key])";
         } else {
            $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", urlencode($val)) . "\"" . "[$key])";

--- a/Template.php
+++ b/Template.php
@@ -578,7 +578,7 @@ final class Template {
       case 'pmid':
         if ($this->blank($param_name)) {
           $this->add($param_name, sanitize_string($value));
-          $this->expand_by_pubmed();
+          $this->expand_by_pubmed($this->blank('pmc') || $this->blank('doi'));  //Force = TRUE if missing DOI or PMC
           $this->get_doi_from_crossref();
           return TRUE;
         }

--- a/Template.php
+++ b/Template.php
@@ -947,11 +947,11 @@ final class Template {
       );
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
-        $query .= " AND (" . str_replace("%E2%80%93", "-", ($val)) . "[$key])";
+        $query .= " AND (" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key])";
       }
     }
     $query = substr($query, 5);
-    $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=$query";
+    $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=" . $query;
     print_r($url);
     $xml = @simplexml_load_file($url);
     print_r($xml);

--- a/Template.php
+++ b/Template.php
@@ -930,7 +930,7 @@ final class Template {
     $query = '';
     foreach ($terms as $term) {
       $key_index = array(
-        'doi' =>  '',
+        'doi' =>  'AID',
         'author1' =>  'Author',
         'author' =>  'Author',
         'issue' =>  'Issue',
@@ -952,6 +952,7 @@ final class Template {
     }
     $query = substr($query, 5);
     $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=$query";
+    print_r($url);
     $xml = @simplexml_load_file($url);
     print_r($xml);
     if ($xml === FALSE) {

--- a/Template.php
+++ b/Template.php
@@ -930,7 +930,7 @@ final class Template {
     $query = '';
     foreach ($terms as $term) {
       $key_index = array(
-        'doi' =>  'AID',
+        'doi' =>  '',
         'author1' =>  'Author',
         'author' =>  'Author',
         'issue' =>  'Issue',

--- a/Template.php
+++ b/Template.php
@@ -947,7 +947,7 @@ final class Template {
       );
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
-        $query .= "+AND+" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key])";
+        $query .= "+AND+" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key]";
       }
     }
     $query = substr($query, 5);

--- a/Template.php
+++ b/Template.php
@@ -948,7 +948,7 @@ final class Template {
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
         if ($key === "AID") {
-           $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", ($val)) . "\"" . "[$key])";
+           $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", ($val)) . "\"" . "[$key])"; // Do not escape DOIs
         } else {
            $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", urlencode($val)) . "\"" . "[$key])";
         }
@@ -956,9 +956,7 @@ final class Template {
     }
     $query = substr($query, 5);
     $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=$query";
-    print_r($url);
     $xml = @simplexml_load_file($url);
-    print_r($xml);
     if ($xml === FALSE) {
       echo "\n - Unable to do PMID search";
       return array(NULL, 0);

--- a/Template.php
+++ b/Template.php
@@ -947,7 +947,7 @@ final class Template {
       );
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
-        $query .= "+AND+" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key]";
+        $query .= " AND (" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key])";
       }
     }
     $query = substr($query, 5);

--- a/Template.php
+++ b/Template.php
@@ -947,11 +947,11 @@ final class Template {
       );
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
-        $query .= " AND (" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key])";
+        $query .= "+AND+" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key])";
       }
     }
     $query = substr($query, 5);
-    $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=" . $query;
+    $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=$query";
     print_r($url);
     $xml = @simplexml_load_file($url);
     print_r($xml);

--- a/Template.php
+++ b/Template.php
@@ -947,7 +947,7 @@ final class Template {
       );
       $key = $key_index[mb_strtolower($term)];
       if ($key && $term && $val = $this->get($term)) {
-        $query .= " AND (" . str_replace("%E2%80%93", "-", urlencode($val)) . "[$key])";
+        $query .= " AND (" . "\"" . str_replace("%E2%80%93", "-", urlencode($val)) . "\"" . "[$key])";
       }
     }
     $query = substr($query, 5);

--- a/Template.php
+++ b/Template.php
@@ -184,7 +184,7 @@ final class Template {
           $this->handle_et_al();
         }
 
-        $this->expand_by_pubmed($this->blank('pmid') && $this->has('pmc')); //partly to try to find DOI
+        $this->expand_by_pubmed(TRUE); //partly to try to find DOI
 
         if ($this->expand_by_google_books()) {
           echo "\n * Expanded from Google Books API";

--- a/Template.php
+++ b/Template.php
@@ -951,6 +951,7 @@ final class Template {
       }
     }
     $query = substr($query, 5);
+    str_replace("%2F", "/", $query);
     $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=$query";
     print_r($url);
     $xml = @simplexml_load_file($url);

--- a/Template.php
+++ b/Template.php
@@ -953,6 +953,7 @@ final class Template {
     $query = substr($query, 5);
     $url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&tool=DOIbot&email=martins+pubmed@gmail.com&term=$query";
     $xml = @simplexml_load_file($url);
+    print_r($xml);
     if ($xml === FALSE) {
       echo "\n - Unable to do PMID search";
       return array(NULL, 0);

--- a/Template.php
+++ b/Template.php
@@ -184,7 +184,7 @@ final class Template {
           $this->handle_et_al();
         }
 
-        $this->expand_by_pubmed(TRUE); //partly to try to find DOI
+        $this->expand_by_pubmed(); //partly to try to find DOI
 
         if ($this->expand_by_google_books()) {
           echo "\n * Expanded from Google Books API";

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -293,6 +293,12 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $this->assertEquals($text, $expanded_page->parsed_text());
   }
   
+  public function testDoi2PMID() {
+    $text = "{{cite journal|url=doi=10.1073/pnas.171325998}}";
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('11573006',$this->get('pmid'));
+  }
+ 
   public function testSiciExtraction() {
     $text = "{{cite journal|url=http://fake.url/0097-3157(2002)152[0215:HPOVBM]2.0.CO;2}}";
     $expanded = $this->process_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -296,7 +296,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   public function testDoi2PMID() {
     $text = "{{cite journal|url=doi=10.1073/pnas.171325998}}";
     $expanded = $this->process_citation($text);
-    $this->assertEquals('11573006',$this->get('pmid'));
+    $this->assertEquals('11573006',$expanded->get('pmid'));
   }
  
   public function testSiciExtraction() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -294,7 +294,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
   
   public function testDoi2PMID() {
-    $text = "{{cite journal|url=doi=10.1073/pnas.171325998}}";
+    $text = "{{cite journal|doi=10.1073/pnas.171325998}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('11573006',$expanded->get('pmid'));
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -297,6 +297,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = "{{cite journal|doi=10.1073/pnas.171325998}}";
     $expanded = $this->process_citation($text);
     $this->assertEquals('11573006',$expanded->get('pmid'));
+    $this->assertEquals('58796',$expanded->get('pmc'));
   }
  
   public function testSiciExtraction() {


### PR DESCRIPTION
Do not URL encode DOIs.  They must have changed API. (This gives us PMID in test)
Also, after we find a PMID, we then look for a PMC.  (This then gives us PMC in test case)
Also added quotes around search terms.