### PR TITLE
Better renaming and forgetting of parameters

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2670,6 +2670,7 @@ final class Template {
 
   // Amend parameters
   protected function rename($old_param, $new_param, $new_value = FALSE) {
+    if($this->blank($new_param)) $this->forget($new_param); // Forget empty old copies, if they exist
     foreach ($this->param as $p) {
       if ($p->param == $old_param) {
         $p->param = $new_param;
@@ -2780,7 +2781,7 @@ final class Template {
     }
     $pos = $this->get_param_key($par);
     if ($pos !== NULL) {
-      echo "\n   - Dropping parameter " . echoable($par) . tag();
+      if ($this->has($par)) echo "\n   - Dropping parameter " . echoable($par) . tag(); // Do not mention forgetting empty parameters
       unset($this->param[$pos]);
     }
   }

--- a/Template.php
+++ b/Template.php
@@ -2781,7 +2781,7 @@ final class Template {
     }
     $pos = $this->get_param_key($par);
     if ($pos !== NULL) {
-      if ($this->has($par)) echo "\n   - Dropping parameter " . echoable($par) . tag(); // Do not mention forgetting empty parameters
+      if ($this->has($par) && strpos($par,'CITATION_BOT_PLACEHOLDER') === FALSE) echo "\n   - Dropping parameter " . echoable($par) . tag(); // Do not mention forgetting empty parameters
       unset($this->param[$pos]);
     }
   }


### PR DESCRIPTION
1.  Do not echo when forgetting parameters that are set to nothing {{cite journal| forget_me=}}
2.  Do not echo when forgetting CITATION_BOT_PLACEHOLDER_year and such.
3.  Remove **empty** copies of parameters that are going to be overwritten.
{{cite journal | item1=|item2=X}}
rename('item2','item1') old code leads to:
{{cite journal | item1=|item1=X}}
but with new code leads to 
{{cite journal | item1=X}}