### PR TITLE
Normalize researchgate URLS in tidy()

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2412,7 +2412,7 @@ final class Template {
             break;
           case 'url':
             $p->val =  preg_replace_callback(
-               "~(https?://www.researchgate.net/publication/)([0-9]+)(_*)"   // Trim researchgate URLS and force https
+               "~(https?://www.researchgate.net/publication/)([0-9]+)(_*)",   // Trim researchgate URLS and force https
                create_function('$matches', 'return 'https://www.researchgate.net/publication/' . $matches[1];'),
                $p->val
                );

--- a/Template.php
+++ b/Template.php
@@ -2412,8 +2412,8 @@ final class Template {
             break;
           case 'url':
             $p->val =  preg_replace_callback(
-               "~(https?://www.researchgate.net/publication/[0-9]+)(_*)"   // Trim researchgate
-               create_function('$matches', 'return $matches[0];'),
+               "~(https?://www.researchgate.net/publication/)([0-9]+)(_*)"   // Trim researchgate URLS and force https
+               create_function('$matches', 'return 'https://www.researchgate.net/publication/' . $matches[1];'),
                $p->val
                );
             break;

--- a/Template.php
+++ b/Template.php
@@ -2411,8 +2411,8 @@ final class Template {
             $p->val = $this->isbn10Toisbn13($p->val);
             break;
           case 'url':
-            $research_gate = preg_match("~(https?://www.researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches);
-            if ($research_gate === 1) $p->val = 'https://www.researchgate.net/publication/' . $matches[1];
+            $research_gate = preg_match("~^(https?://www.researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches);
+            if ($research_gate === 1) $p->val = 'https://www.researchgate.net/publication/' . $matches[2];
             break;
         }
       }

--- a/Template.php
+++ b/Template.php
@@ -2411,7 +2411,7 @@ final class Template {
             $p->val = $this->isbn10Toisbn13($p->val);
             break;
           case 'url':
-            if (preg_match("~^(https?://www.researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches)) {
+            if (preg_match("~^(https?://[www.|]researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches)) {
                 $p->val = 'https://www.researchgate.net/publication/' . $matches[2];
             }
             break;

--- a/Template.php
+++ b/Template.php
@@ -2411,7 +2411,7 @@ final class Template {
             $p->val = $this->isbn10Toisbn13($p->val);
             break;
           case 'url':
-            if (preg_match("~^(https?://[www.|]researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches)) {
+            if (preg_match("~^(https?://w?w?w?.?researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches)) {
                 $p->val = 'https://www.researchgate.net/publication/' . $matches[2];
             }
             break;

--- a/Template.php
+++ b/Template.php
@@ -2410,6 +2410,13 @@ final class Template {
           case 'isbn':
             $p->val = $this->isbn10Toisbn13($p->val);
             break;
+          case 'url':
+            $p->val =  preg_replace_callback(
+               "~(https?://www.researchgate.net/publication/[0-9]+)(_*)"   // Trim researchgate
+               create_function('$matches', 'return $matches[0];'),
+               $p->val
+               );
+            break;
         }
       }
     }

--- a/Template.php
+++ b/Template.php
@@ -2411,11 +2411,8 @@ final class Template {
             $p->val = $this->isbn10Toisbn13($p->val);
             break;
           case 'url':
-            $p->val =  preg_replace_callback(
-               "~(https?://www.researchgate.net/publication/)([0-9]+)(_*)",   // Trim researchgate URLS and force https
-               create_function('$matches', 'return 'https://www.researchgate.net/publication/' . $matches[1];'),
-               $p->val
-               );
+            $research_gate = preg_match("~(https?://www.researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches);
+            if ($research_gate === 1) $p->val = 'https://www.researchgate.net/publication/' . $matches[1];
             break;
         }
       }

--- a/Template.php
+++ b/Template.php
@@ -2411,8 +2411,9 @@ final class Template {
             $p->val = $this->isbn10Toisbn13($p->val);
             break;
           case 'url':
-            $research_gate = preg_match("~^(https?://www.researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches);
-            if ($research_gate === 1) $p->val = 'https://www.researchgate.net/publication/' . $matches[2];
+            if (preg_match("~^(https?://www.researchgate.net/publication/)([0-9]+)(_*)~", $p->val, $matches)) {
+                $p->val = 'https://www.researchgate.net/publication/' . $matches[2];
+            }
             break;
         }
       }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -870,6 +870,22 @@ ER -  }}';
      $expanded = $this->process_citation($text);
      $this->assertNull($expanded->get('publisher'));  
  }
+    
+ public function testTrimResearchGate() {
+     $want = 'https://www.researchgate.net/publication/320041870';
+     $text = '{{cite journal|url=https://www.researchgate.net/publication/320041870}}';
+     $expanded = $this->process_citation($text);
+     $this->assertEquals($want, $expanded->get('url'));
+     $text = '{{cite journal|url=http://www.researchgate.net/publication/320041870}}';
+     $expanded = $this->process_citation($text);
+     $this->assertEquals($want, $expanded->get('url'));
+     $text = '{{cite journal|url=https://www.researchgate.net/publication/320041870_EXTRA_STUFF_ON_END}}';
+     $expanded = $this->process_citation($text);
+     $this->assertEquals($want, $expanded->get('url'));
+     $text = '{{cite journal|url=http://www.researchgate.net/publication/320041870_EXTRA_STUFF_ON_END}}';
+     $expanded = $this->process_citation($text);
+     $this->assertEquals($want, $expanded->get('url'));
+ }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors
   Test finding a DOI and using it to expand a paper [See testLongAuthorLists - Arxiv example?]

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -885,6 +885,9 @@ ER -  }}';
      $text = '{{cite journal|url=http://www.researchgate.net/publication/320041870_EXTRA_STUFF_ON_END}}';
      $expanded = $this->process_citation($text);
      $this->assertEquals($want, $expanded->get('url'));
+     $text = '{{cite journal|url=http://researchgate.net/publication/320041870_EXTRA_STUFF_ON_END}}';
+     $expanded = $this->process_citation($text);
+     $this->assertEquals($want, $expanded->get('url'));
  }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors


### PR DESCRIPTION
Removes optional end text.
Changes http to https.
Normalizes to including the "www."

There is talk of adding the researchgate ID to the citation templates, so eventually this will probably just set that parameter instead.