### PR TITLE
Fix deploy target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ language: php
 matrix:
   include:
     - stage: test
+      php: 7.2
       before_script:  
         - travis_retry composer self-update
         - composer require mediawiki/oauthclient
-      php: 7.2
       script: phpunit --coverage-clover coverage.xml --bootstrap expandFns.php tests/phpunit
       after_success: bash <(curl -s https://codecov.io/bash)
     - php: 5.6
@@ -21,10 +21,8 @@ matrix:
       script: phpunit --bootstrap expandFns.php tests/phpunit
     - stage: deploy
       name: "Update WMFlabs servers"
-      if: (branch == master) AND (NOT env(TRAVIS_PULL_REQUEST))
-      script: bash <(echo wget -O- https://tools.wmflabs.org/citations/gitpull.php)
-      if: (branch == development) AND (NOT env(TRAVIS_PULL_REQUEST))
-      script: bash <(echo wget -O- https://tools.wmflabs.org/citations-dev/gitpull.php)
+      - if [ "$TRAVIS_BRANCH" = "master"      -a "$TRAVIS_PULL_REQUEST" = "false" ]; then wget -O- https://tools.wmflabs.org/citations/gitpull.php ; fi
+      - if [ "$TRAVIS_BRANCH" = "development" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then wget -O- https://tools.wmflabs.org/citations-dev/gitpull.php ; fi
 
 git:
   depth: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
       script: phpunit --bootstrap expandFns.php tests/phpunit
     - stage: deploy
       name: "Update WMFlabs servers"
+      php: 5.6 # Avoid downloading and installing 5.5
       script:
         - if [ "$TRAVIS_BRANCH" = "master"      -a "$TRAVIS_PULL_REQUEST" = "false" ]; then wget -O- https://tools.wmflabs.org/citations/gitpull.php ; fi
         - if [ "$TRAVIS_BRANCH" = "development" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then wget -O- https://tools.wmflabs.org/citations-dev/gitpull.php ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ matrix:
       script: phpunit --bootstrap expandFns.php tests/phpunit
     - stage: deploy
       name: "Update WMFlabs servers"
-      - if [ "$TRAVIS_BRANCH" = "master"      -a "$TRAVIS_PULL_REQUEST" = "false" ]; then wget -O- https://tools.wmflabs.org/citations/gitpull.php ; fi
-      - if [ "$TRAVIS_BRANCH" = "development" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then wget -O- https://tools.wmflabs.org/citations-dev/gitpull.php ; fi
+      script:
+        - if [ "$TRAVIS_BRANCH" = "master"      -a "$TRAVIS_PULL_REQUEST" = "false" ]; then wget -O- https://tools.wmflabs.org/citations/gitpull.php ; fi
+        - if [ "$TRAVIS_BRANCH" = "development" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then wget -O- https://tools.wmflabs.org/citations-dev/gitpull.php ; fi
 
 git:
   depth: 3


### PR DESCRIPTION
I finally ran across this:

https://stackoverflow.com/questions/27896816/how-to-check-if-master-branch-pushed-with-a-tag-under-travis

PHP 5.6 is specified explicitly since otherwise Travis assumes you want 5.5 which has to be downloaded and installed (and then never used by us)

I invite you to check out Travis CI output.