### PR TITLE
Better DOI validation

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -572,7 +572,7 @@ final class Template {
         return FALSE;
         
       case 'doi':
-        if ($this->blank($param_name) &&  preg_match('~(10\..+)$~', $value, $match)) {
+        if ($this->blank($param_name) &&  preg_match('~(10\..+/.+)$~', $value, $match)) {
           $this->add('doi', $match[0]);
           $this->verify_doi();
           $this->expand_by_doi();

--- a/Template.php
+++ b/Template.php
@@ -572,7 +572,7 @@ final class Template {
         return FALSE;
         
       case 'doi':
-        if ($this->blank($param_name) && preg_match('~(10\..+/.+)$~', $value, $match)) {
+        if ($this->blank($param_name) && preg_match(DOI_REGEXP, $value, $match)) {
           $this->add('doi', $match[0]);
           $this->verify_doi();
           $this->expand_by_doi();

--- a/Template.php
+++ b/Template.php
@@ -268,7 +268,7 @@ final class Template {
     return (!(
              ($this->has('journal') || $this->has('periodical'))
           &&  $this->has("volume")
-          &&  ($this->has("issue") || $this->has('number'))
+          && ($this->has("issue") || $this->has('number'))
           &&  $this->has("title")
           && ($this->has("date") || $this->has("year"))
           && ($this->has("author2") || $this->has("last2") || $this->has('surname2'))
@@ -572,7 +572,7 @@ final class Template {
         return FALSE;
         
       case 'doi':
-        if ($this->blank($param_name) &&  preg_match('~(10\..+/.+)$~', $value, $match)) {
+        if ($this->blank($param_name) && preg_match('~(10\..+/.+)$~', $value, $match)) {
           $this->add('doi', $match[0]);
           $this->verify_doi();
           $this->expand_by_doi();


### PR DESCRIPTION
Avoid GIGO.  Pubmed needs to do a better job verifying their data.  Although technically 10.4244/ was a valid DOI, since the standard allows a zero length suffix.

Old code only needed 10.X, where X is at least single character.
New code requires 10.X/Y where X and Y are at least one character each.
