### PR TITLE
Better handling of wikilinks in titles

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2503,7 +2503,7 @@ final class Template {
                $p->val= preg_replace("~\[\[~", "", $p->val); // Remove any extra [[ or ]] that should not be there
                $p->val= preg_replace("~\]\]~", "", $p->val);
             } else { // Convert a single link to a title-link
-               if (preg_match('~(\[\[)([^|]+?)(\]\])~', $p->val, $matches) { // Convert [[X]] wikilinks into X
+               if (preg_match('~(\[\[)([^|]+?)(\]\])~', $p->val, $matches)) { // Convert [[X]] wikilinks into X
                  $this->add_if_new('title-link', $matches[2]);
                  $p->val= preg_replace("~\[\[~", "", $p->val);
                  $p->val= preg_replace("~\]\]~", "", $p->val);

--- a/Template.php
+++ b/Template.php
@@ -2488,10 +2488,8 @@ final class Template {
             if (mb_substr($p->val, -1) === "," ) {
               $p->val = mb_substr($p->val, 0, -1);  // Remove trailing comma
             }
-            if(mb_substr($p->val, 0, 2) !== "[["   ||   // Completely remove partial links
-               mb_substr($p->val, -2) !== "]]"     ||
-               mb_substr_count($p->val,'[[') !== 1 ||
-               mb_substr_count($p->val,']]') !== 1) {
+            if( mb_substr_count($p->val,'[[') !== 1 ||  // Completely remove multiple wikilinks
+                mb_substr_count($p->val,']]') !== 1) {
                $p->val = preg_replace_callback(  // Convert [[X]] wikilinks into X
                       "~(\[\[)([^|]+?)(\]\])~",
                       function($matches) {return $matches[2];},
@@ -2502,20 +2500,21 @@ final class Template {
                       function($matches) {return $matches[4];},
                       $p->val
                       );
-            } elseif (mb_substr($p->val, 0, 2) === "[["   &&  // Convert full wikilinks to title-link
-               mb_substr($p->val, -2) === "]]"            &&
-               mb_substr_count($p->val,'[[') === 1        &&
-               mb_substr_count($p->val,']]') === 1) {
-               $pipe = mb_strpos($p->val, '|');
-               if ($pipe === FALSE) {
-                  $tval1 = mb_substr($p->val, 2, -2);
-                  $tval2 = $tval1;
-               } else {
-                  $tval1 = mb_substr($p->val, 2, $pipe-2);
-                  $tval2 = mb_substr($p->val, $pipe+1, -2);
+               $p->val= preg_replace("~\[\[~", "", $p->val); // Remove any extra [[ or ]] that should not be there
+               $p->val= preg_replace("~\]\]~", "", $p->val);
+            } else { // Convert a single link to a title-link
+               if (preg_match('~(\[\[)([^|]+?)(\]\])~', $p->val, $matches) { // Convert [[X]] wikilinks into X
+                 $this->add_if_new('title-link', $matches[2]);
+                 $p->val= preg_replace("~\[\[~", "", $p->val);
+                 $p->val= preg_replace("~\]\]~", "", $p->val);
+               } elseif (preg_match('~(\[\[)([^|]+?)(\|)([^|]+?)(\]\])~', $p->val, $matches)) { // Convert [[Y|X]] wikilinks into X
+                 $this->add_if_new('title-link', $matches[2]);
+                 $p->val = preg_replace_callback(
+                      "~(\[\[)([^|]+?)(\|)([^|]+?)(\]\])~",   
+                      function($matches) {return $matches[4];},
+                      $p->val
+                      );
                }
-               $p->val = $tval2;
-               $this->add_if_new('title-link', $tval1);
             }
             break;
           case 'journal': 

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -218,7 +218,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('title'));
     $this->assertEquals('Sith (Star Wars)', $expanded->get('title-link'));
   }
-      
+  
   public function testJournalCapitalization() {
     $expanded = $this->process_citation("{{Cite journal|pmid=9858585}}");
     $this->assertEquals('Molecular and Cellular Biology', $expanded->get('journal'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -214,7 +214,9 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $this->assertEquals('Pure Evil', $expanded->get('title-link'));
     $expanded = $this->process_citation("{{Cite journal|title=[[Dark]] Lord of the [[Sith (Star Wars)|Sith]] [[Pure Evil]]}}");
     $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('title'));
-  
+    $expanded = $this->process_citation("{{Cite journal|title=Dark Lord of the [[Sith (Star Wars)|Sith]] Pure Evil}}");
+    $this->assertEquals('Dark Lord of the Sith Pure Evil', $expanded->get('title'));
+    $this->assertEquals('Sith (Star Wars)', $expanded->get('title-link'));
   }
       
   public function testJournalCapitalization() {


### PR DESCRIPTION
Removes all [[ and ]] from titles: that is not new.
Full title wikilinks become title-link: that is not new.
What's new:
   Single partial wikilinks get converted to title-link
https://en.wikipedia.org/wiki/User_talk:Citation_bot#Do_not_remove_partial_wikilinks_in_titles
  In the case it is GIGO this makes it more likely for a human to fix, so it is still an improvement.

