### PR TITLE
Don't change to journal if arXiv bibcode

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2439,7 +2439,9 @@ final class Template {
             break;
 
         case 'bibcode':
-          $this->change_name_to('Cite journal', FALSE);
+          if (stripos($this->get($param), 'arxiv') === FALSE) {
+            $this->change_name_to('Cite journal', FALSE);
+          }
           
         case 'chapter': 
           if ($this->has('chapter')) {


### PR DESCRIPTION
Bibcodes typically denote journals... but not if it's in arxiv still?