### PR TITLE
Remove nbsp from id

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2976,6 +2976,7 @@ final class Template {
     $ret = $this->get($name);
     $ret = preg_replace('~<!--.*?-->~su', '', $ret); // Comments
     $ret = preg_replace('~# # # CITATION_BOT_PLACEHOLDER.*?# # #~sui', '', $ret); // Other place holders already escaped.  Case insensitive
+    $ret = str_replace("\xc2\xa0", ' ', $ret); // Replace non-breaking with breaking spaces, which are trimmable
     $ret = trim($ret);
     return ($ret ? $ret : FALSE);
   }

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -20,7 +20,7 @@ function entrez_api($ids, $templates, $db) {
   if (isset($xml->DocSum->Item) && count($xml->DocSum->Item) > 0) foreach($xml->DocSum as $document) {
     report_info("Found match for $db identifier " . $document->Id);
     $template_key = array_search($document->Id, $ids);
-    if (!$template_key) {
+    if ($template_key === FALSE) {
       report_warning("Pubmed returned an identifier, [" . $document->Id . "] that we didn't search for.");
       continue;
     }


### PR DESCRIPTION
ID parameters should not contain non-breaking spaces, or they won't be `trim`med properly
Fixes #680 .