### PR TITLE
Set curl time limits

### DIFF
--- a/WikipediaBot.php
+++ b/WikipediaBot.php
@@ -59,7 +59,8 @@ class WikipediaBot {
         CURLOPT_HTTPGET => TRUE, // Reset to default GET
         CURLOPT_RETURNTRANSFER => TRUE,
         
-        CURLOPT_CONNECTTIMEOUT_MS => 1200,
+        CURLOPT_CONNECTTIMEOUT => 2,
+        CURLOPT_TIMEOUT => 20,
         
         CURLOPT_COOKIESESSION => TRUE,
         CURLOPT_COOKIEFILE => 'cookie.txt',


### PR DESCRIPTION
2 seconds to connect and 20 seconds to time-out on download
Honestly the 20 might be less than defaults but it is effectively infinite for us