### PR TITLE
Revert "better handling of ends of titles."

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2625,12 +2625,13 @@ final class Template {
                $title = preg_replace(REGEXP_PIPED_WIKILINK, "$2", $title);
              }
           }
-          if (mb_substr($title, mb_strlen($title) - 3) == '...') {
-            $title = mb_substr($title, 0, mb_strlen($title) - 3) 
-                   . html_entity_decode("&hellip;", NULL, 'UTF-8');
-          } elseif (in_array(mb_substr($title, -1), array(',', ';', ':'))) { 
-              // Do not remove periods, which legitimately occur at the end of abreviations
+          if (in_array(mb_substr($title, -1), array('.', ','))) {
+            if (mb_substr($title, mb_strlen($title) - 3) == '...') {
+              $title = mb_substr($title, 0, mb_strlen($title) - 3) 
+                     . html_entity_decode("&hellip;", NULL, 'UTF-8');
+            } else {
               $title = mb_substr($title, 0, -1);
+            }
           }
           $this->set($param, $title);
           if ($title && !strcasecmp($this->get($param), $this->get('work'))) $this->forget('work');


### PR DESCRIPTION
Reverts ms609/citation-bot#703

On reflection, this will delete closing semicolons from HTML entites; e.g. `title=example&#153;`

Perhaps we should just leave any semicolons for now?

(Should probably create this issue in a better way but time is short!)