### PR TITLE
Only remove double angle quotes if some of both

### DIFF
--- a/DOItools.php
+++ b/DOItools.php
@@ -245,6 +245,7 @@ function straighten_quotes($str) {
   if((mb_strpos($str, '&raquo;')  !== FALSE && mb_strpos($str, '&laquo;')  !== FALSE) ||
      (mb_strpos($str, '\x{00AB}') !== FALSE && mb_strpos($str, '\x{00AB}') !== FALSE)) { // Only replace angle quotes if some of both
      $str = preg_replace('~&[lr]aquo;|[\x{00AB}\x{00BB}]~u', '"', $str);                 // Websites tiles: Jobs » Iowa » Cows » Ames
-     return $str;
+  }
+  return $str;
 }
 

--- a/DOItools.php
+++ b/DOItools.php
@@ -241,7 +241,10 @@ function format_multiple_authors($authors, $returnAsArray = FALSE){
 
 function straighten_quotes($str) {
   $str = preg_replace('~&#821[679];|&#x201[89];|[\x{2039}\x{203A}\x{FF07}\x{2018}-\x{201B}`]|&[rl]s?[ab]?quo;~u', "'", $str);
-  $str = preg_replace('~&#822[013];|[\x{00AB}\x{00BB}\x{201C}-\x{201F}]|&[rlb][ad]?quo;~u', '"', $str);
+  $str = preg_replace('~&#822[013];|[\x{00AB}\x{00BB}\x{201C}-\x{201F}]|&[rlb][d]?quo;~u', '"', $str);
+  if(mb_strpos($str, '&raquo;') !== FALSE && b_strpos($str, '&laquo;') !== FALSE) { // Only replace angle quotes if some of both
+     $str = preg_replace('~&[lr]aquo;~u', '"', $str);                               // Websites tiles: Jobs » Iowa » Cows » Ames
+  }
   return $str;
 }
 

--- a/DOItools.php
+++ b/DOItools.php
@@ -243,7 +243,7 @@ function straighten_quotes($str) {
   $str = preg_replace('~&#821[679];|&#x201[89];|[\x{2039}\x{203A}\x{FF07}\x{2018}-\x{201B}`]|&[rl]s?[ab]?quo;~u', "'", $str);
   $str = preg_replace('~&#822[013];|[\x{201C}-\x{201F}]|&[rlb][d]?quo;~u', '"', $str);
   if((mb_strpos($str, '&raquo;')  !== FALSE && mb_strpos($str, '&laquo;')  !== FALSE) ||
-      mb_strpos($str, '\x{00AB}') !== FALSE && mb_strpos($str, '\x{00AB}') !== FALSE)) { // Only replace angle quotes if some of both
+     (mb_strpos($str, '\x{00AB}') !== FALSE && mb_strpos($str, '\x{00AB}') !== FALSE)) { // Only replace angle quotes if some of both
      $str = preg_replace('~&[lr]aquo;|[\x{00AB}\x{00BB}]~u', '"', $str);                 // Websites tiles: Jobs » Iowa » Cows » Ames
      return $str;
 }

--- a/DOItools.php
+++ b/DOItools.php
@@ -241,10 +241,10 @@ function format_multiple_authors($authors, $returnAsArray = FALSE){
 
 function straighten_quotes($str) {
   $str = preg_replace('~&#821[679];|&#x201[89];|[\x{2039}\x{203A}\x{FF07}\x{2018}-\x{201B}`]|&[rl]s?[ab]?quo;~u', "'", $str);
-  $str = preg_replace('~&#822[013];|[\x{00AB}\x{00BB}\x{201C}-\x{201F}]|&[rlb][d]?quo;~u', '"', $str);
-  if(mb_strpos($str, '&raquo;') !== FALSE && b_strpos($str, '&laquo;') !== FALSE) { // Only replace angle quotes if some of both
-     $str = preg_replace('~&[lr]aquo;~u', '"', $str);                               // Websites tiles: Jobs » Iowa » Cows » Ames
-  }
-  return $str;
+  $str = preg_replace('~&#822[013];|[\x{201C}-\x{201F}]|&[rlb][d]?quo;~u', '"', $str);
+  if((mb_strpos($str, '&raquo;')  !== FALSE && mb_strpos($str, '&laquo;')  !== FALSE) ||
+      mb_strpos($str, '\x{00AB}') !== FALSE && mb_strpos($str, '\x{00AB}') !== FALSE)) { // Only replace angle quotes if some of both
+     $str = preg_replace('~&[lr]aquo;|[\x{00AB}\x{00BB}]~u', '"', $str);                 // Websites tiles: Jobs » Iowa » Cows » Ames
+     return $str;
 }
 

--- a/DOItools.php
+++ b/DOItools.php
@@ -243,8 +243,9 @@ function straighten_quotes($str) {
   $str = preg_replace('~&#821[679];|&#x201[89];|[\x{2039}\x{203A}\x{FF07}\x{2018}-\x{201B}`]|&[rl]s?[ab]?quo;~u', "'", $str);
   $str = preg_replace('~&#822[013];|[\x{201C}-\x{201F}]|&[rlb][d]?quo;~u', '"', $str);
   if((mb_strpos($str, '&raquo;')  !== FALSE && mb_strpos($str, '&laquo;')  !== FALSE) ||
-     (mb_strpos($str, '\x{00AB}') !== FALSE && mb_strpos($str, '\x{00AB}') !== FALSE)) { // Only replace angle quotes if some of both
-     $str = preg_replace('~&[lr]aquo;|[\x{00AB}\x{00BB}]~u', '"', $str);                 // Websites tiles: Jobs » Iowa » Cows » Ames
+     (mb_strpos($str, '\x{00AB}') !== FALSE && mb_strpos($str, '\x{00AB}') !== FALSE) ||
+     (mb_strpos($str, '«')        !== FALSE && mb_strpos($str, '»')        !== FALSE)) { // Only replace angle quotes if some of both
+     $str = preg_replace('~&[lr]aquo;|[\x{00AB}\x{00BB}]|[«»]~u', '"', $str);                 // Websites tiles: Jobs » Iowa » Cows » Ames
   }
   return $str;
 }

--- a/tests/phpunit/DOIToolsTest.php
+++ b/tests/phpunit/DOIToolsTest.php
@@ -139,6 +139,13 @@ final class doiToolsTest extends PHPUnit\Framework\TestCase {
     $page->expand_text();
     $this->assertNotNull($page->edit_summary());
   }
+ 
+  public function testArrowAreQuotes() {
+    $text = "This » That";
+    $this->assertEquals($text,straighten_quotes($text));
+    $text = "X«Y»Z";
+    $this->assertEquals('X"Y"Z',straighten_quotes($text));
+  }
   
   public function testMathInTitle() {
     // This MML code comes from a real CrossRef search of DOI 10.1016/j.newast.2009.05.001

--- a/tests/phpunit/DOIToolsTest.php
+++ b/tests/phpunit/DOIToolsTest.php
@@ -139,7 +139,7 @@ final class doiToolsTest extends PHPUnit\Framework\TestCase {
     $page->expand_text();
     $this->assertNotNull($page->edit_summary());
   }
- 
+
   public function testArrowAreQuotes() {
     $text = "This » That";
     $this->assertEquals($text,straighten_quotes($text));


### PR DESCRIPTION
Fixes websites the do sections using these instead of arrow:
Science » Chemistry » Physical Chemistry » Computational Chemistry » Super Heroes