### PR TITLE
Remove <X>  </X> that can have unmatched {{ & }} inside

### DIFF
--- a/Comment.php
+++ b/Comment.php
@@ -34,7 +34,6 @@ final class Nowiki {
   }
 }
 
-
 final class Chemistry {
   const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_CHEMISTRY %s # # #';
   const REGEXP = '~<chem>.*?</chem>~us'; 
@@ -50,10 +49,39 @@ final class Chemistry {
   }
 }
 
-
 final class Mathematics {
-  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_MATHEAMTICS %s # # #';
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_MATHEMATICS %s # # #';
   const REGEXP = '~<math>.*?</math>~us'; 
+  const TREAT_IDENTICAL_SEPARATELY = FALSE;
+  protected $rawtext;
+  
+  public function parse_text($text) {
+    $this->rawtext = $text;
+  }
+  
+  public function parsed_text() {
+    return $this->rawtext;
+  }
+}
+
+final class Musicscores {
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_MUSIC %s # # #';
+  const REGEXP = '~<score>.*?</score>~us'; 
+  const TREAT_IDENTICAL_SEPARATELY = FALSE;
+  protected $rawtext;
+  
+  public function parse_text($text) {
+    $this->rawtext = $text;
+  }
+  
+  public function parsed_text() {
+    return $this->rawtext;
+  }
+}
+
+final class Preformated {
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_PREFORMAT %s # # #';
+  const REGEXP = '~<pre>.*?</pre>~us'; 
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   protected $rawtext;
   

--- a/Comment.php
+++ b/Comment.php
@@ -20,8 +20,40 @@ final class Comment {
 }
 
 final class Nowiki {
-  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_NOWIKI %s # # #';  // Have space in nowiki so that it does not through some crazy bug match itself recursively
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_NOWIKI %s # # #';
   const REGEXP = '~<nowiki>.*?</nowiki>~us'; 
+  const TREAT_IDENTICAL_SEPARATELY = FALSE;
+  protected $rawtext;
+  
+  public function parse_text($text) {
+    $this->rawtext = $text;
+  }
+  
+  public function parsed_text() {
+    return $this->rawtext;
+  }
+}
+
+
+final class Chemistry {
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_CHEMISTRY %s # # #';
+  const REGEXP = '~<chem>.*?</chem>~us'; 
+  const TREAT_IDENTICAL_SEPARATELY = FALSE;
+  protected $rawtext;
+  
+  public function parse_text($text) {
+    $this->rawtext = $text;
+  }
+  
+  public function parsed_text() {
+    return $this->rawtext;
+  }
+}
+
+
+final class Mathematics {
+  const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_MATHEAMTICS %s # # #';
+  const REGEXP = '~<math>.*?</math>~us'; 
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   protected $rawtext;
   

--- a/Page.php
+++ b/Page.php
@@ -123,6 +123,8 @@ class Page {
     $nowiki      = $this->extract_object('Nowiki');
     $chemistry   = $this->extract_object('Chemistry');
     $mathematics = $this->extract_object('Mathematics');
+    $musicality  = $this->extract_object('Musicscores');
+    $preformated = $this->extract_object('Preformated');
     if (!$this->allow_bots()) {
       report_warning("Page marked with {{nobots}} template.  Skipping.");
       return FALSE;
@@ -202,6 +204,8 @@ class Page {
     }
     $this->replace_object($all_templates);
 
+    $this->replace_object($preformated);
+    $this->replace_object($musicality);
     $this->replace_object($mathematics);
     $this->replace_object($chemistry);
     $this->replace_object($comments);

--- a/Page.php
+++ b/Page.php
@@ -118,9 +118,11 @@ class Page {
       return FALSE;
     }
 
-    // COMMENTS AND NOWIKI //
-    $comments = $this->extract_object('Comment');
-    $nowiki   = $this->extract_object('Nowiki');
+    // COMMENTS AND NOWIKI ETC. //
+    $comments    = $this->extract_object('Comment');
+    $nowiki      = $this->extract_object('Nowiki');
+    $chemistry   = $this->extract_object('Chemistry');
+    $mathematics = $this->extract_object('Mathematics');
     if (!$this->allow_bots()) {
       report_warning("Page marked with {{nobots}} template.  Skipping.");
       return FALSE;
@@ -200,6 +202,8 @@ class Page {
     }
     $this->replace_object($all_templates);
 
+    $this->replace_object($mathematics);
+    $this->replace_object($chemistry);
     $this->replace_object($comments);
     $this->replace_object($nowiki);
 

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -401,7 +401,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   */
   
   public function testCommentHandling() {
-    $text = "{{cite book|pages=3333 <!-- yes --> }} {{cite book <!-- no --> | pages=3<nowiki>-</nowiki>6}}";
+    $text = "{{cite book|pages=3333 <!-- yes --> }} {{cite book <!-- no --> | pages=3<nowiki>-</nowiki>6}} {{cite book | pages=3<pre>-</pre>6}} {{cite book | pages=3<math>-</math>6}} {{cite book | pages=3<score>-</score>6}} {{cite book | pages=3<chem>-</chem>6}}";
     $expanded_page = $this->process_page($text);
     $this->assertEquals($text, $expanded_page->parsed_text());
   }


### PR DESCRIPTION
This bug report relates to parsing page Fouling
