### PR TITLE
Fix crashes on huge pages -- use atomic regex

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -17,7 +17,7 @@ require_once("Parameter.php");
 
 final class Template {
   const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_TEMPLATE %s # # #';
-  const REGEXP = '~\{\{(?:[^\{]|\{[^\{])+?\}\}~su';
+  const REGEXP = '~\{\{(?>[^\{]|\{[^\{])+?\}\}~su';  // Please see https://stackoverflow.com/questions/1722453/need-to-prevent-php-regex-segfault for discussion of atomic regex
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   public $all_templates;  // Points to list of all the Template() on the Page() including this one
   protected $rawtext;


### PR DESCRIPTION
https://stackoverflow.com/questions/1722453/need-to-prevent-php-regex-segfault

Please think about this, since this changes the RegEx, but I think that in our case the capture is exactly the same.

Please see https://github.com/ms609/citation-bot/pull/735 where this is tested.  Do not accept that pull for it includes the Vietnam War page that takes a minute to process with PHP 5.6.

Interestingly enough, in PHP 7 the page still gives up with FALSE, but with PHP 5.6 it actually parses.