### PR TITLE
Fix DOIs code especially for square brackets etc.

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -704,7 +704,7 @@ final class Template {
   public function mark_inactive_doi($doi = NULL) {
     if (is_null($doi)) $doi = $this->get_without_comments_and_placeholders('doi');
     // Only mark as broken if dx.doi.org also fails to resolve
-    $url_test = "https://dx.doi.org/" . $doi;
+    $url_test = "https://dx.doi.org/" . urlencode($doi);
     $headers_test = @get_headers($url_test, 1);
     if ($headers_test !== FALSE && empty($headers_test['Location'])) {
       $this->add_if_new('doi-broken-date', date('Y-m-d'));  
@@ -2812,7 +2812,7 @@ final class Template {
         fwrite(STDERR, "It's not; checking for user input error...");
         // Replace old "doi_inactivedate" and/or other broken/inactive-date parameters,
         // if present, with new "doi-broken-date"
-        $url_test = "https://dx.doi.org/" . $doi;
+        $url_test = "https://dx.doi.org/" . urlencode($doi);
         $headers_test = @get_headers($url_test, 1);
         if ($headers_test === FALSE) {
           fwrite(STDERR, "DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));

--- a/Template.php
+++ b/Template.php
@@ -2809,13 +2809,13 @@ final class Template {
     } else {
       report_info("Checking that DOI " . echoable($doi) . " is operational..." . tag());
       if (doi_active($this->get_without_comments_and_placeholders('doi')) === FALSE) {
-        fwrite(STDERR, "It's not; checking for user input error...");
+        report_inline("It's not; checking for user input error...");
         // Replace old "doi_inactivedate" and/or other broken/inactive-date parameters,
         // if present, with new "doi-broken-date"
         $url_test = "https://dx.doi.org/" . urlencode($doi);
         $headers_test = @get_headers($url_test, 1);
         if ($headers_test === FALSE) {
-          fwrite(STDERR, "DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));
+          report_inline("DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));
           return FALSE;
         }
         $this->forget("doi_inactivedate");
@@ -2823,7 +2823,7 @@ final class Template {
         $this->forget("doi_brokendate");
         if(empty($headers_test['Location'])) {
            $this->set("doi-broken-date", date("Y-m-d"));  // dx.doi.org might work, even if CrossRef fails
-           fwrite(STDERR, "Broken doi: " . echoable($doi));
+           report_inline("Broken doi: " . echoable($doi));
            return FALSE;
         } else {
           return TRUE;

--- a/Template.php
+++ b/Template.php
@@ -2809,13 +2809,13 @@ final class Template {
     } else {
       report_info("Checking that DOI " . echoable($doi) . " is operational..." . tag());
       if (doi_active($this->get_without_comments_and_placeholders('doi')) === FALSE) {
-        printf(STDERR, "It's not; checking for user input error...");
+        fwrite(STDERR, "It's not; checking for user input error...");
         // Replace old "doi_inactivedate" and/or other broken/inactive-date parameters,
         // if present, with new "doi-broken-date"
         $url_test = "https://dx.doi.org/" . $doi;
         $headers_test = @get_headers($url_test, 1);
         if ($headers_test === FALSE) {
-          printf(STDERR, "DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));
+          fwrite(STDERR, "DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));
           return FALSE;
         }
         $this->forget("doi_inactivedate");
@@ -2823,7 +2823,7 @@ final class Template {
         $this->forget("doi_brokendate");
         if(empty($headers_test['Location'])) {
            $this->set("doi-broken-date", date("Y-m-d"));  // dx.doi.org might work, even if CrossRef fails
-           printf(STDERR, "Broken doi: " . echoable($doi));
+           fwrite(STDERR, "Broken doi: " . echoable($doi));
            return FALSE;
         } else {
           return TRUE;

--- a/Template.php
+++ b/Template.php
@@ -2809,22 +2809,25 @@ final class Template {
     } else {
       report_info("Checking that DOI " . echoable($doi) . " is operational..." . tag());
       if (doi_active($this->get_without_comments_and_placeholders('doi')) === FALSE) {
-        report_inline("It's not; checking for user input error...");
+        printf(STDERR, "It's not; checking for user input error...");
         // Replace old "doi_inactivedate" and/or other broken/inactive-date parameters,
         // if present, with new "doi-broken-date"
         $url_test = "https://dx.doi.org/" . $doi;
         $headers_test = @get_headers($url_test, 1);
         if ($headers_test === FALSE) {
-          report_warning("DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));
+          printf(STDERR, "DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));
           return FALSE;
         }
         $this->forget("doi_inactivedate");
         $this->forget("doi-inactive-date");
         $this->forget("doi_brokendate");
-        if(empty($headers_test['Location']))
+        if(empty($headers_test['Location'])) {
            $this->set("doi-broken-date", date("Y-m-d"));  // dx.doi.org might work, even if CrossRef fails
-        report_warning("Broken doi: " . echoable($doi));
-        return FALSE;
+           printf(STDERR, "Broken doi: " . echoable($doi));
+           return FALSE;
+        } else {
+          return TRUE;
+        }
       } else {
         $this->forget('doi_brokendate');
         $this->forget('doi_inactivedate');

--- a/Template.php
+++ b/Template.php
@@ -2815,7 +2815,7 @@ final class Template {
         $url_test = "https://dx.doi.org/" . urlencode($doi);
         $headers_test = @get_headers($url_test, 1);
         if ($headers_test === FALSE) {
-          report_inline("DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));
+          report_warning("DOI status unkown.  dx.doi.org failed to respond at all to: " . echoable($doi));
           return FALSE;
         }
         $this->forget("doi_inactivedate");

--- a/Template.php
+++ b/Template.php
@@ -701,7 +701,7 @@ final class Template {
     }
   }
 
-  protected function mark_inactive_doi($doi = NULL) {
+  public function mark_inactive_doi($doi = NULL) {
     if (is_null($doi)) $doi = $this->get_without_comments_and_placeholders('doi');
     // Only mark as broken if dx.doi.org also fails to resolve
     $url_test = "https://dx.doi.org/" . $doi;

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -380,7 +380,7 @@ function expand_by_doi($template, $force = FALSE) {
         }
       }
     } else {
-      fwrite(STDERR, "No CrossRef record found for doi '" . echoable($doi) ."'; marking as broken");
+      report_warning("No CrossRef record found for doi '" . echoable($doi) ."'; marking as broken");
       $template->mark_inactive_doi($doi);
     }
   }
@@ -402,7 +402,7 @@ function query_crossref($doi) {
       // Keep trying...
     }
   }
-  fwrite(STDERR, "Error loading CrossRef file from DOI " . echoable($doi) . "!");
+  report_warning("Error loading CrossRef file from DOI " . echoable($doi) . "!");
   return FALSE;
 }
 
@@ -418,7 +418,7 @@ function is_doi_active($doi) {
   $response = get_headers("https://api.crossref.org/works/". urlencode($doi))[0];
   if (stripos($response, '200 OK') !== FALSE) return TRUE;
   if (stripos($response, '404 Not Found') !== FALSE) return FALSE;
-  fwrite(STDERR, "CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");
+  report_warning("CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");
   return NULL;
 }
 

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -415,7 +415,7 @@ function doi_active($doi) {
 }
 
 function is_doi_active($doi) {
-  $response = get_headers("https://api.crossref.org/works/$doi")[0];
+  $response = get_headers("https://api.crossref.org/works/". urlencod($doi))[0];
   if (stripos($response, '200 OK') !== FALSE) return TRUE;
   if (stripos($response, '404 Not Found') !== FALSE) return FALSE;
   fwrite(STDERR, "CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -380,7 +380,7 @@ function expand_by_doi($template, $force = FALSE) {
         }
       }
     } else {
-      report_warning("No CrossRef record found for doi '" . echoable($doi) ."'; marking as broken");
+      fwrite(STDERR, "No CrossRef record found for doi '" . echoable($doi) ."'; marking as broken");
       $template->mark_inactive_doi($doi);
     }
   }
@@ -402,7 +402,7 @@ function query_crossref($doi) {
       // Keep trying...
     }
   }
-  report_warning("Error loading CrossRef file from DOI " . echoable($doi) . "!");
+  fwrite(STDERR, "Error loading CrossRef file from DOI " . echoable($doi) . "!");
   return FALSE;
 }
 

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -418,7 +418,7 @@ function is_doi_active($doi) {
   $response = get_headers("https://api.crossref.org/works/$doi")[0];
   if (stripos($response, '200 OK') !== FALSE) return TRUE;
   if (stripos($response, '404 Not Found') !== FALSE) return FALSE;
-  printf(STDERR, "CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");
+  fwrite(STDERR, "CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");
   return NULL;
 }
 

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -415,7 +415,7 @@ function doi_active($doi) {
 }
 
 function is_doi_active($doi) {
-  $response = get_headers("https://api.crossref.org/works/". urlencod($doi))[0];
+  $response = get_headers("https://api.crossref.org/works/". urlencode($doi))[0];
   if (stripos($response, '200 OK') !== FALSE) return TRUE;
   if (stripos($response, '404 Not Found') !== FALSE) return FALSE;
   fwrite(STDERR, "CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -415,7 +415,7 @@ function doi_active($doi) {
 }
 
 function is_doi_active($doi) {
-  $response = get_headers("https://api.crossref.org/works/". urlencode($doi))[0];
+  $response = get_headers("https://api.crossref.org/works/" . urlencode($doi))[0];
   if (stripos($response, '200 OK') !== FALSE) return TRUE;
   if (stripos($response, '404 Not Found') !== FALSE) return FALSE;
   report_warning("CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -418,7 +418,7 @@ function is_doi_active($doi) {
   $response = get_headers("https://api.crossref.org/works/$doi")[0];
   if (stripos($response, '200 OK') !== FALSE) return TRUE;
   if (stripos($response, '404 Not Found') !== FALSE) return FALSE;
-  report_warning("CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");
+  printf(STDERR, "CrossRef server error loading headers for DOI " . echoable($doi) . ": $response");
   return NULL;
 }
 

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -353,6 +353,10 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}', $expanded->parsed_text());
+    
+    $text = '{{cite journal | doi = 10.1002/(SICI)1097-0134(20000515)39:3<216::AID-PROT40>3.0.CO;2-#}}';
+    $expanded = $this->process_citation($text);
+    $this->assertNull($expanded->get('doi-broken-date'));
   }
 
   public function testOpenAccessLookup() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -349,7 +349,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $text = '{{cite journal|doi= {{MC Hammer says to not touch this}} }}';
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('doi-broken-date'));
-    // $this->assertEquals('{{MC Hammer says to not touch this}}', $expanded->get('doi')); This does not work right because we are not doing a "PAGE"
+    $this->assertEquals('{{MC Hammer says to not touch this}}', $expanded->get('doi'));
     $text = '{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('{{Cite journal|url={{This is not real}}|doi={{I am wrong}}|jstor={{yet another bogus one }}}}', $expanded->parsed_text());


### PR DESCRIPTION
mark_inactive_doi needs to be public not protected to call from API file

lots of url encoding for evil square bracket DOIs (and ending with -# is pure evil)

Add missing { } after if that lead to wrong code logic