### PR TITLE
Do not modify complex at= parameters

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -562,7 +562,7 @@ final class Template {
         if (mb_stripos($all_page_parameters, 'CITATION_BOT_PLACEHOLDER') !== FALSE) return FALSE;  // A comment or template will block the bot
         if (    $all_page_parameters == ""     // Nothing
                 || (strpos(strtolower($all_page_parameters), 'no') !== FALSE && $this->blank('at')) // "None" or "no" contained within something other than "at"
-                || (strcasecmp($all_page_parameters,'no') || strcasecmp($all_page_parameters,'none')) // Is exactly "no" or "none"
+                || (strcasecmp($all_page_parameters,'no')===0 || strcasecmp($all_page_parameters,'none')===0) // Is exactly "no" or "none"
                 || (strpos($value, chr(2013)) || (strpos($value, '-'))    // New pages have dash, old did not
                   && !strpos($all_page_parameters, chr(2013))
                   && !strpos($all_page_parameters, chr(150)) // Also en-dash

--- a/Template.php
+++ b/Template.php
@@ -556,22 +556,25 @@ final class Template {
       return FALSE;
       
       case "page": case "pages":
-        if (( $this->blank("pages") && $this->blank("page") && $this->blank("pp")  && $this->blank("p") && $this->blank('at'))
-                || strpos(strtolower($this->get('pages') . $this->get('page')), 'no') !== FALSE
-                || (strpos($value, chr(2013)) || (strpos($value, '-'))
-                  && !strpos($this->get('pages'), chr(2013))
-                  && !strpos($this->get('pages'), chr(150)) // Also en-dash
-                  && !strpos($this->get('pages'), chr(226)) // Also en-dash
-                  && !strpos($this->get('pages'), '-')
-                  && !strpos($this->get('pages'), '&ndash;'))
+        $all_page_parameters = $this->get("pages") . $this->get("page") . $this->get("pp") . $this->get("p") . $this->get("at");
+        if (mb_stripos($all_page_parameters, 'see ') !== FALSE) return FALSE;  // Someone is pointing to a specific part
+        if (mb_stripos($all_page_parameters, 'table') !== FALSE) return FALSE; // Someone is pointing to a specific table
+        if (mb_stripos($all_page_parameters, 'CITATION_BOT_PLACEHOLDER') !== FALSE) return FALSE;  // A comment or template will block the bot
+        if (    $all_page_parameters == ""     // Nothing
+                || (strpos(strtolower($all_page_parameters), 'no') !== FALSE && $this->blank('at')) // "None" or "no" contained within something other than "at"
+                || (strcasecmp($all_page_parameters,'no') || strcasecmp($all_page_parameters,'none')) // Is exactly "no" or "none"
+                || (strpos($value, chr(2013)) || (strpos($value, '-'))    // New pages have dash, old did not
+                  && !strpos($all_page_parameters, chr(2013))
+                  && !strpos($all_page_parameters, chr(150)) // Also en-dash
+                  && !strpos($all_page_parameters, chr(226)) // Also en-dash
+                  && !strpos($all_page_parameters, '-')
+                  && !strpos($all_page_parameters, '&ndash;'))
         ) {
-            $all_page_parameters = $this->get("pages") . $this->get("page") . $this->get("pp") . $this->get("p");
-            if (mb_stripos($all_page_parameters, 'CITATION_BOT_PLACEHOLDER') !== FALSE) return FALSE;  // A comment or template will block the bot
             if ($param_name !== "pages") $this->forget("pages"); // Forget others -- sometimes we upgrade page=123 to pages=123-456
-            if ($param_name !== "page")$this->forget("page");
-            if ($param_name !== "pp")$this->forget("pp");
-            if ($param_name !== "p")$this->forget("p");
-            if ($param_name !== "at")$this->forget("at");
+            if ($param_name !== "page") $this->forget("page");
+            if ($param_name !== "pp") $this->forget("pp");
+            if ($param_name !== "p") $this->forget("p");
+            if ($param_name !== "at") $this->forget("at");
             $param_key = $this->get_param_key($param_name);
             if (!is_null($param_key)) {
               $this->param[$param_key]->val = sanitize_string($value); // Minimize template changes (i.e. location) when upgrading from page=123 to pages=123-456

--- a/Template.php
+++ b/Template.php
@@ -563,7 +563,7 @@ final class Template {
         if (    $all_page_parameters == ""     // Nothing
                 || (strpos(strtolower($all_page_parameters), 'no') !== FALSE && $this->blank('at')) // "None" or "no" contained within something other than "at"
                 || (strcasecmp($all_page_parameters,'no')===0 || strcasecmp($all_page_parameters,'none')===0) // Is exactly "no" or "none"
-                || (strpos($value, chr(2013)) || (strpos($value, '-'))    // New pages have dash, old did not
+                || (strpos($value, chr(2013)) || (strpos($value, '-'))
                   && !strpos($all_page_parameters, chr(2013))
                   && !strpos($all_page_parameters, chr(150)) // Also en-dash
                   && !strpos($all_page_parameters, chr(226)) // Also en-dash

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1019,6 +1019,9 @@ ER -  }}';
     $text = '{{cite journal|pages=[http://bogus.bogus/1–2/ 1–2]|title=do not change }}';
     $prepared = $this->prepare_citation($text);
     $this->assertEquals('[http://bogus.bogus/1–2/ 1–2]', $prepared->get('pages'));
+    $text = '{{Cite journal|doi=10.1007/s11746-998-0245-y|at=pp.425–439, see Table&nbsp;2 p.&nbsp;426 for tempering temperatures}}';
+    $prepared = $this->prepare_citation($text);
+    $this->assertEquals('pp.425–439, see Table&nbsp;2 p.&nbsp;426 for tempering temperatures', $prepared->get('at')); // Leave complex at=
   }
     
   public function testCollapseRanges() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1020,8 +1020,8 @@ ER -  }}';
     $prepared = $this->prepare_citation($text);
     $this->assertEquals('[http://bogus.bogus/1–2/ 1–2]', $prepared->get('pages'));
     $text = '{{Cite journal|doi=10.1007/s11746-998-0245-y|at=pp.425–439, see Table&nbsp;2 p.&nbsp;426 for tempering temperatures}}';
-    $prepared = $this->prepare_citation($text);
-    $this->assertEquals('pp.425–439, see Table&nbsp;2 p.&nbsp;426 for tempering temperatures', $prepared->get('at')); // Leave complex at=
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('pp.425–439, see Table&nbsp;2 p.&nbsp;426 for tempering temperatures', $expanded->get('at')); // Leave complex at=
   }
     
   public function testCollapseRanges() {


### PR DESCRIPTION
Make code recognize all pages template elements when checking for existing dashes

Add special code to save pages that include "see " and "table"
