### PR TITLE
Add test for Horrible bibcode bug

### DIFF
--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -96,12 +96,12 @@ class PageTest extends PHPUnit\Framework\TestCase {
   }
   
   public function testWeirdTemplateInteraction() {
-      $text = '{{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }}';
+      $text = ' {{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }} ';
       $page = $this->process_page($text);
       $this->assertEquals($text, $page->parsed_text());
       $page = new Page(); // Try with non testPage page
       $page->parse_text($text);
       $page->expand_text();
-      $this->assertEquals($text, $page->parsed_text())
+      $this->assertEquals($text, $page->parsed_text());
   }
 }

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -94,5 +94,10 @@ class PageTest extends PHPUnit\Framework\TestCase {
       $page = $this->process_page($text);
       $this->assertEquals($text, $page->parsed_text());
   }
-
+  
+  public funtion testWeirdTemplateInteraction() {
+      $text = '{{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }}';
+      $page = $this->process_page($text);
+      $this->assertEquals($text, $page->parsed_text());
+  }
 }

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -95,7 +95,7 @@ class PageTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals($text, $page->parsed_text());
   }
   
-  public function testWeirdTemplateInteraction() {  // For some reason this template crashed a version of the cot
+  public function testWeirdTemplateInteraction() {  // For some reason this template crashed a version of the bot
       $text = ' {{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }} ';
       $page = $this->process_page($text);
       $this->assertEquals($text, $page->parsed_text());

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -95,7 +95,7 @@ class PageTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals($text, $page->parsed_text());
   }
   
-  public funtion testWeirdTemplateInteraction() {
+  public function testWeirdTemplateInteraction() {
       $text = '{{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }}';
       $page = $this->process_page($text);
       $this->assertEquals($text, $page->parsed_text());

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -99,5 +99,9 @@ class PageTest extends PHPUnit\Framework\TestCase {
       $text = '{{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }}';
       $page = $this->process_page($text);
       $this->assertEquals($text, $page->parsed_text());
+      $page = new Page(); // Try with non testPage page
+      $page->parse_text($text);
+      $page->expand_text();
+      $this->assertEquals($text, $page->parsed_text())
   }
 }

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -95,7 +95,7 @@ class PageTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals($text, $page->parsed_text());
   }
   
-  public function testWeirdTemplateInteraction() {
+  public function testWeirdTemplateInteraction() {  // For some reason this template crashed a version of the cot
       $text = ' {{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }} ';
       $page = $this->process_page($text);
       $this->assertEquals($text, $page->parsed_text());

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -99,9 +99,5 @@ class PageTest extends PHPUnit\Framework\TestCase {
       $text = ' {{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }} ';
       $page = $this->process_page($text);
       $this->assertEquals($text, $page->parsed_text());
-      $page = new Page(); // Try with non testPage page
-      $page->parse_text($text);
-      $page->expand_text();
-      $this->assertEquals($text, $page->parsed_text());
   }
 }


### PR DESCRIPTION
When the first template is done alone it works on wikipedia.  When done with another template on Wikipedia (that has a bibcode) it goes nuts.  

I assume that if the code on wikipedia was updated this bug would not appear there.