### PR TITLE
[[file:img|12px|alt=words]] and such

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -75,23 +75,14 @@ final class Template {
   // Parts of each param: | [pre] [param] [eq] [value] [post]
   protected function split_params($text) {
     // Replace | characters that are inside template parameter/value pairs
-    $START = "~(\[\[[^\[\]\|]+)";
-    $STOP  =      "([^\[\]\|]+\]\])~";
-    $MID   =      "([^\[\]\|]+)";
-    $PIPE  = "\|";
-    $text = preg_replace($START . $PIPE . $STOP, "$1" . PIPE_PLACEHOLDER . "$2", $text);
-    $text = preg_replace($START . $PIPE . $MID . $PIPE . $STOP,
-                         "$1" . PIPE_PLACEHOLDER . "$2" .
-                         PIPE_PLACEHOLDER . "$3", $text);
-    $text = preg_replace($START . $PIPE . $MID . $PIPE . $MID . $PIPE . $STOP,
-                         "$1" . PIPE_PLACEHOLDER . "$2" .
-                         PIPE_PLACEHOLDER . "$3" .
-                         PIPE_PLACEHOLDER . "$4", $text);
-    $text = preg_replace($START . $PIPE . $MID . $PIPE . $MID . $PIPE . $MID . $PIPE . $STOP,
-                         "$1" . PIPE_PLACEHOLDER . "$2" .
-                         PIPE_PLACEHOLDER . "$3" .
-                         PIPE_PLACEHOLDER . "$4" .
-                         PIPE_PLACEHOLDER . "$5", $text);
+    $PIPE_REGEX = "~(\[\[[^\[\]]*)(?:\|)([^\[\]]*\]\])~u";
+    while (preg_match($PIPE_REGEX, $text)) {
+      $text = preg_replace_callback($PIPE_REGEX,
+          function($matches) {
+             return($matches[1] . PIPE_PLACEHOLDER . $matches[2]);     
+          },
+          $text);
+    }
     $params = explode('|', $text);
     // TODO: this naming is confusing, distinguish between $text above and
     //       $text in the loop (derived from $text above via $params)

--- a/Template.php
+++ b/Template.php
@@ -77,7 +77,7 @@ final class Template {
     // Replace | characters that are inside template parameter/value pairs
     $text = preg_replace('~(\[\[[^\[\]]+)\|([^\[\]]+\]\])~', "$1" . PIPE_PLACEHOLDER . "$2", $text);
     $params = explode('|', $text);
-
+fwrite(STDERR,print_r($params));
     // TODO: this naming is confusing, distinguish between $text above and
     //       $text in the loop (derived from $text above via $params)
     foreach ($params as $i => $text) {

--- a/Template.php
+++ b/Template.php
@@ -75,19 +75,19 @@ final class Template {
   // Parts of each param: | [pre] [param] [eq] [value] [post]
   protected function split_params($text) {
     // Replace | characters that are inside template parameter/value pairs
-    const START = "~(\[\[[^\[\]\|]+)";
-    const STOP  =      "([^\[\]\|]+\]\])~";
-    const MID   =      "([^\[\]\|]+)";
-    const PIPE  = "\|";
-    $text = preg_replace(START . PIPE . STOP, "$1" . PIPE_PLACEHOLDER . "$2", $text);
-    $text = preg_replace(START . PIPE . MID . PIPE . STOP,
+    $START = "~(\[\[[^\[\]\|]+)";
+    $STOP  =      "([^\[\]\|]+\]\])~";
+    $MID   =      "([^\[\]\|]+)";
+    $PIPE  = "\|";
+    $text = preg_replace($START . $PIPE . $STOP, "$1" . PIPE_PLACEHOLDER . "$2", $text);
+    $text = preg_replace($START . $PIPE . $MID . $PIPE . $STOP,
                          "$1" . PIPE_PLACEHOLDER . "$2" .
                          PIPE_PLACEHOLDER . "$3", $text);
-    $text = preg_replace(START . PIPE . MID . PIPE . MID . PIPE . STOP,
+    $text = preg_replace($START . $PIPE . $MID . $PIPE . $MID . $PIPE . $STOP,
                          "$1" . PIPE_PLACEHOLDER . "$2" .
                          PIPE_PLACEHOLDER . "$3" .
                          PIPE_PLACEHOLDER . "$4", $text);
-    $text = preg_replace(START . PIPE . MID . PIPE . MID . PIPE . MID . PIPE . STOP,
+    $text = preg_replace($START . $PIPE . $MID . $PIPE . $MID . $PIPE . $MID . $PIPE . $STOP,
                          "$1" . PIPE_PLACEHOLDER . "$2" .
                          PIPE_PLACEHOLDER . "$3" .
                          PIPE_PLACEHOLDER . "$4" .

--- a/Template.php
+++ b/Template.php
@@ -75,9 +75,9 @@ final class Template {
   // Parts of each param: | [pre] [param] [eq] [value] [post]
   protected function split_params($text) {
     // Replace | characters that are inside template parameter/value pairs
-    $text = preg_replace('~(\[\[[^\[\]]+)\|([^\[\]]+\]\])~', "$1" . PIPE_PLACEHOLDER . "$2", $text);
+    $text = preg_replace('~(\[\[[^\[\]\|]+)\|([^\[\]\|]+\]\])~', "$1" . PIPE_PLACEHOLDER . "$2", $text);
+    $text = preg_replace('~(\[\[[^\[\]\|]+)\|([^\[\]\|]*)\|([^\[\]\|]+\]\])~', "$1" . PIPE_PLACEHOLDER . "$2" . PIPE_PLACEHOLDER . "$3", $text);
     $params = explode('|', $text);
-fwrite(STDERR,print_r($params));
     // TODO: this naming is confusing, distinguish between $text above and
     //       $text in the loop (derived from $text above via $params)
     foreach ($params as $i => $text) {

--- a/Template.php
+++ b/Template.php
@@ -83,8 +83,8 @@ final class Template {
           },
           $text);
     }
-
     $params = explode('|', $text);
+
     // TODO: this naming is confusing, distinguish between $text above and
     //       $text in the loop (derived from $text above via $params)
     foreach ($params as $i => $text) {

--- a/Template.php
+++ b/Template.php
@@ -75,8 +75,23 @@ final class Template {
   // Parts of each param: | [pre] [param] [eq] [value] [post]
   protected function split_params($text) {
     // Replace | characters that are inside template parameter/value pairs
-    $text = preg_replace('~(\[\[[^\[\]\|]+)\|([^\[\]\|]+\]\])~', "$1" . PIPE_PLACEHOLDER . "$2", $text);
-    $text = preg_replace('~(\[\[[^\[\]\|]+)\|([^\[\]\|]*)\|([^\[\]\|]+\]\])~', "$1" . PIPE_PLACEHOLDER . "$2" . PIPE_PLACEHOLDER . "$3", $text);
+    const START = "~(\[\[[^\[\]\|]+)";
+    const STOP  =      "([^\[\]\|]+\]\])~";
+    const MID   =      "([^\[\]\|]+)";
+    const PIPE  = "\|";
+    $text = preg_replace(START . PIPE . STOP, "$1" . PIPE_PLACEHOLDER . "$2", $text);
+    $text = preg_replace(START . PIPE . MID . PIPE . STOP,
+                         "$1" . PIPE_PLACEHOLDER . "$2" .
+                         PIPE_PLACEHOLDER . "$3", $text);
+    $text = preg_replace(START . PIPE . MID . PIPE . MID . PIPE . STOP,
+                         "$1" . PIPE_PLACEHOLDER . "$2" .
+                         PIPE_PLACEHOLDER . "$3" .
+                         PIPE_PLACEHOLDER . "$4", $text);
+    $text = preg_replace(START . PIPE . MID . PIPE . MID . PIPE . MID . PIPE . STOP,
+                         "$1" . PIPE_PLACEHOLDER . "$2" .
+                         PIPE_PLACEHOLDER . "$3" .
+                         PIPE_PLACEHOLDER . "$4" .
+                         PIPE_PLACEHOLDER . "$5", $text);
     $params = explode('|', $text);
     // TODO: this naming is confusing, distinguish between $text above and
     //       $text in the loop (derived from $text above via $params)

--- a/Template.php
+++ b/Template.php
@@ -83,6 +83,7 @@ final class Template {
           },
           $text);
     }
+
     $params = explode('|', $text);
     // TODO: this naming is confusing, distinguish between $text above and
     //       $text in the loop (derived from $text above via $params)

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -142,8 +142,8 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
      $this->assertEquals('M. M.', $expanded->get('first3'));
   }
     
-  public function testJusrBrackets() {
-     $text = '{{cite book|title=[[a|b]][[c]]}}';
+  public function testJustBrackets() {
+     $text = '{{cite book|title=[[W|x|v=W]]}}';
      $expanded = $this->process_citation($text);
      $this->assertEquals($text, $expanded->parsed_text());
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -143,7 +143,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
     
   public function testJustBrackets() {
-     $text = '{{cite book|title=[[W|x|v=W]]}}';
+     $text = '{{cite book|title=[[W|12px|alt=W]]}}';
      $expanded = $this->process_citation($text);
      $this->assertEquals($text, $expanded->parsed_text());
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -143,7 +143,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
     
   public function testJusrBrackets() {
-     $text = '{{cite book|title=[[|]][[]]}}';
+     $text = '{{cite book|title=[[a|b]][[c]]}}';
      $expanded = $this->process_citation($text);
      $this->assertEquals($text, $expanded->parsed_text());
   }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -145,7 +145,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   public function testJusrBrackets() {
      $text = '{{cite book|title=[[|]][[]]}}';
      $expanded = $this->process_citation($text);
-     $this->assertEquals($text, $expanded->get_parsed());
+     $this->assertEquals($text, $expanded->parsed_text());
   }
 
   public function testPmidIsZero() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -146,6 +146,9 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
      $text = '{{cite book|title=[[W|12px|alt=W]]}}';
      $expanded = $this->process_citation($text);
      $this->assertEquals($text, $expanded->parsed_text());
+     $text = '{{cite book|title=[[File:Example.png|thumb|upright|alt=Example alt text|Example caption]]}}';
+     $expanded = $this->process_citation($text);
+     $this->assertEquals($text, $expanded->parsed_text());
   }
 
   public function testPmidIsZero() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -141,7 +141,13 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
      $expanded = $this->process_citation($text);
      $this->assertEquals('M. M.', $expanded->get('first3'));
   }
- 
+    
+  public function testJusrBrackets() {
+     $text = '{{cite book|title=[[|]][[]]}}';
+     $expanded = $this->process_citation($text);
+     $this->assertEquals($text, $expanded->get_parsed());
+  }
+
   public function testPmidIsZero() {
       $text = '{{cite journal|pmc=2676591}}';
       $expanded = $this->process_citation($text);


### PR DESCRIPTION
Current code does [[]] and [[|]].  
Added up to this size:
[[File:Example.png|thumb|upright|alt=Example alt text|Example caption]]