### PR TITLE
Remove uneeded test

### DIFF
--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -98,9 +98,4 @@ class PageTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals($text, $page->parsed_text());
   }
   
-  public function testWeirdTemplateInteraction() {  // For some reason this template crashed a version of the bot
-      $text = ' {{Cite web|url=https://www.nobelprize.org/nobel_prizes/chemistry/laureates/1966/mulliken-lecture.pdf|year=1966|last=Mulliken |first=Robert S.|title=Spectroscopy, molecular orbitals, and chemical bonding|website=nobelprize.org}}{{cite journal|doi=10.1103/RevModPhys.23.69|title=New Developments in Molecular Orbital Theory|journal=Reviews of Modern Physics|volume=23|issue=2|pages=69–89|year=1951|last1=Roothaan|first1=C. C. J.|bibcode = 1951RvMP...23...69R }} ';
-      $page = $this->process_page($text);
-      $this->assertEquals($text, $page->parsed_text());
-  }
 }


### PR DESCRIPTION
The API finds the journal copy of the Noble Prize speech which changed the output, and it is no longer needed.