### PR TITLE
do not assume case

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -3196,7 +3196,7 @@ final class Template {
     }
     $pos = $this->get_param_key($par);
     if ($pos !== NULL) {
-      if ($echo_forgetting && $this->has($par) && strpos($par, 'CITATION_BOT_PLACEHOLDER') === FALSE) {
+      if ($echo_forgetting && $this->has($par) && stripos($par, 'CITATION_BOT_PLACEHOLDER') === FALSE) {
         // Do not mention forgetting empty parameters
         report_forget("Dropping parameter \"" . echoable($par) . '"' . tag());
       }

--- a/Template.php
+++ b/Template.php
@@ -3197,7 +3197,7 @@ final class Template {
     $pos = $this->get_param_key($par);
     if ($pos !== NULL) {
       if ($echo_forgetting && $this->has($par) && stripos($par, 'CITATION_BOT_PLACEHOLDER') === FALSE) {
-        // Do not mention forgetting empty parameters
+        // Do not mention forgetting empty parameters or internal temporary parameters
         report_forget("Dropping parameter \"" . echoable($par) . '"' . tag());
       }
       unset($this->param[$pos]);


### PR DESCRIPTION
We assumed that our placeholders do not get lower-cased.  Which can happen.