### PR TITLE
Fix parameter choices in tidy

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2688,6 +2688,26 @@ final class Template {
             $this->forget($param);
           }
           return;
+         
+        case 'publicationplace': case 'publication-place':
+          if ($this->blank(['location', 'place'])) {
+            $this->rename($param, 'location'); // This should only be used when 'location'/'place' is being used to describe where is was physically written, i.e. location=Vacationing in France|publication-place=New York
+          }
+          return;
+          
+        case 'publication-date': case 'publicationdate':
+          if ($this->blank(['year', 'date'])) {
+            $this->rename($param, 'date'); // When date & year are blank, this is displayed as date.  So convert
+          }
+          return;
+          
+        case 'orig-year': case 'origyear':
+          if ($this->blank(['year', 'date'])) { // Will not show unless one of these is set, so convert
+            if (preg_match('~^\d\d\d\d$~', $this->get($param)) { // Only if a year, might contain text like "originally was...."
+              $this->rename($param, 'year');
+            }
+          }
+          return; 
       }
     }
   }

--- a/Template.php
+++ b/Template.php
@@ -2703,7 +2703,7 @@ final class Template {
           
         case 'orig-year': case 'origyear':
           if ($this->blank(['year', 'date'])) { // Will not show unless one of these is set, so convert
-            if (preg_match('~^\d\d\d\d$~', $this->get($param)) { // Only if a year, might contain text like "originally was...."
+            if (preg_match('~^\d\d\d\d$~', $this->get($param))) { // Only if a year, might contain text like "originally was...."
               $this->rename($param, 'year');
             }
           }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -671,8 +671,8 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals($text, $prepared->parsed_text());
   }
 
+    
   public function testWorkParamter() {
-
       $text = '{{citation|work=RUBBISH|title=Rubbish|chapter=Dog}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -617,38 +617,41 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   }
     
   public function testChangeParamaters() {
+      // publicationplace
       $text = '{{citation|publicationplace=Home}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();
       $this->assertEquals('{{citation|location=Home}}', $prepared->parsed_text());
-      $text = '{{citation|publicationplace=Home|location=Away}}';
+      
+      $text = '{{citation|publication-place=Home|location=Away}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();
       $this->assertEquals($text, $prepared->parsed_text());
 
+      // publicationdate
       $text = '{{citation|publicationdate=2000}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();
       $this->assertEquals('{{citation|date=2000}}', $prepared->parsed_text());
+      
       $text = '{{citation|publicationdate=2000|date=1999}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();
       $this->assertEquals($text, $prepared->parsed_text());
 
-
+      // origyear
       $text = '{{citation|origyear=2000}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();
       $this->assertEquals('{{citation|year=2000}}', $prepared->parsed_text());
+      
       $text = '{{citation|origyear=2000|date=1999}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();
       $this->assertEquals($text, $prepared->parsed_text()); 
-      
-      return;
  }
     
-  public function testWorkParamter() {
+  public function testWorkParameter() {
       $text = '{{citation|work=RUBBISH|title=Rubbish|chapter=Dog}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -616,6 +616,38 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $this->assertEquals($text, $prepared->parsed_text());
   }
     
+  public function testChangeParamaters() {
+      $text = '{{citation|publicationplace=Home}}';
+      $prepared = $this->prepare_citation($text);
+      $prepared->final_tidy();
+      $this->assertEquals('{{citation|location=Home}}', $prepared->parsed_text());
+      $text = '{{citation|publicationplace=Home|location=Away}}';
+      $prepared = $this->prepare_citation($text);
+      $prepared->final_tidy();
+      $this->assertEquals($text, $prepared->parsed_text());
+
+      $text = '{{citation|publicationdate=2000}}';
+      $prepared = $this->prepare_citation($text);
+      $prepared->final_tidy();
+      $this->assertEquals('{{citation|date=Home}}', $prepared->parsed_text());
+      $text = '{{citation|publicationdate=2000|date=1999}}';
+      $prepared = $this->prepare_citation($text);
+      $prepared->final_tidy();
+      $this->assertEquals($text, $prepared->parsed_text());
+
+
+      $text = '{{citation|origyear=2000}}';
+      $prepared = $this->prepare_citation($text);
+      $prepared->final_tidy();
+      $this->assertEquals('{{citation|year=2000}}', $prepared->parsed_text());
+      $text = '{{citation|origyear=2000|date=1999}}';
+      $prepared = $this->prepare_citation($text);
+      $prepared->final_tidy();
+      $this->assertEquals($text, $prepared->parsed_text()); 
+      
+      return;
+ }
+    
   public function testWorkParamter() {
       $text = '{{citation|work=RUBBISH|title=Rubbish|chapter=Dog}}';
       $prepared = $this->prepare_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -629,7 +629,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
       $text = '{{citation|publicationdate=2000}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();
-      $this->assertEquals('{{citation|date=Home}}', $prepared->parsed_text());
+      $this->assertEquals('{{citation|date=2000}}', $prepared->parsed_text());
       $text = '{{citation|publicationdate=2000|date=1999}}';
       $prepared = $this->prepare_citation($text);
       $prepared->final_tidy();


### PR DESCRIPTION
publication-place: If any one of publication-place, place, or location is defined, the location will show after the title; if publication-place and place or location are defined, then place or location is shown before the title prefixed with "written at" and publication-place is shown after the title.

publication-date: Date of publication when different from the date the work was written. Displays only if year or date are defined and only if different, else publication-date is used and displayed as date.

orig-year: Original publication year; displays after the date or year. For clarity, please supply specifics. For example: |orig-year=First published 1859 or |orig-year=Composed 1904. Alias: origyear