### PR TITLE
Ignore rubbish dates

### DIFF
--- a/expandFns.php
+++ b/expandFns.php
@@ -329,6 +329,7 @@ function tidy_date($string) {
     }
   }
   if (preg_match('~^(.*\d{4}\-\d?\d(?:\-?\d\d?))\S*~', $string, $matches)) return $matches[1];
+  if (preg_match('~^\d+$~', $string)) return "" ; // just a string of number????
   return $string;
 }
 


### PR DESCRIPTION
Just a string of numbers with no spaces or punctuation is not a date.
Earlier we grab four numbers in a row