### PR TITLE
Add jstor book support

### DIFF
--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -438,9 +438,17 @@ function query_jstor_api($ids, $templates) {
 
 function expand_by_jstor($template) {
   if ($template->incomplete() === FALSE) return FALSE;
-  if ($template->blank('jstor')) return FALSE;
-  $jstor = trim($template->get('jstor'));
-  if (preg_match("~[^0-9]~", $jstor) === 1) return FALSE ; // Only numbers in stable jstors.  We do not want i12342 kind
+  if ($template->has('jstor')) {
+     $jstor = trim($template->get('jstor'));
+  } elseif(preg_match('~^https?://(?:www.|)jstor.org/stable/(.*)$~', $template->get('url'), $match)) {
+     $jstor = $match[1];
+  } else {
+     return FALSE;
+  }
+  if (preg_match('~^(.*)(?:\?.*)$~', $jstor, $match)) {
+     $jstor = $match[1]; // remove ?seq= stuff
+  }
+  if (substr($jstor, 0, 1) === 'i') return FALSE ; // We do not want i12342 kind
   $dat = @file_get_contents('https://www.jstor.org/citation/ris/' . $jstor);
   if ($dat === FALSE) {
     report_info("JSTOR API returned nothing for ". jstor_link($jstor));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -256,7 +256,12 @@ final class TemplateTest extends testBaseClass {
     $prepared = $this->prepare_citation($text);
     $this->assertEquals('{{Cite journal|pages=2}}', $prepared->parsed_text());
   }
-
+  public function testExpansionJstorBook() {
+    $text = '{{Cite journal|url=https://www.jstor.org/stable/j.ctt6wp6td.10}}';
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('Verstraete', $expanded->get('last1'));
+  }
+ 
   public function testGarbageRemovalAndSpacing() {
     // Also tests handling of upper-case parameters
     $text = "{{Cite web | title=Ellipsis... | pages=10-11| Edition = 3rd ed. |journal=My Journal| issn=1234-4321 | publisher=Unwarranted |issue=0|accessdate=2013-01-01}}";

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -256,6 +256,7 @@ final class TemplateTest extends testBaseClass {
     $prepared = $this->prepare_citation($text);
     $this->assertEquals('{{Cite journal|pages=2}}', $prepared->parsed_text());
   }
+
   public function testExpansionJstorBook() {
     $text = '{{Cite journal|url=https://www.jstor.org/stable/j.ctt6wp6td.10}}';
     $expanded = $this->process_citation($text);


### PR DESCRIPTION
JSTOR has books.  The jstor= template parameter does not support them so they are urls.  We can expand them 