### PR TITLE
Expand bibcodes with & symbol correctly

### DIFF
--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -174,11 +174,15 @@ function adsabs_api($ids, $templates, $identifier) {
         unset($ids[$key]);
     } elseif (
         strpos($bibcode, '&') !== false) {
-        $template->expand_by_adsabs();
         unset($ids[$key]);
     }
   }
-
+  foreach ($templates as $template) {
+    if (strpos($template->get('bibcode'), '&') !== false) {
+      $template->expand_by_adsabs();
+    }
+  }
+  
   // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
   $adsabs_url = "https://api.adsabs.harvard.edu/v1/search/bigquery?q=*:*"
               . "&fl=arxiv_class,author,bibcode,doi,doctype,identifier,"

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -182,7 +182,8 @@ function adsabs_api($ids, $templates, $identifier) {
       $template->expand_by_adsabs();
     }
   }
-  
+  if (count($ids) == 0) return TRUE; // None left after removing books and & symbol
+
   // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
   $adsabs_url = "https://api.adsabs.harvard.edu/v1/search/bigquery?q=*:*"
               . "&fl=arxiv_class,author,bibcode,doi,doctype,identifier,"


### PR DESCRIPTION
Old code assumed $template was defined (it was not)
Old code assumed that $ids and $templates were in same order with no duplicates.
Also, fixed case where all $ids had book or & symbol and there were no ids left