### PR TITLE
Reject � from zotero

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -71,7 +71,7 @@ class Page {
   public function parse_text($text) {
     $this->text = $text;
     $this->start_text = $this->text;
-    $this->modifications = array();
+    $this->modifications = array(); 
   }  
 
   public function parsed_text() {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -84,7 +84,7 @@ function expand_by_zotero(&$template, $url = NULL) {
     report_info("Could not resolve URL ". $url);
     return FALSE;
   }
-  if (mb_strpos($result->title, '�') !== FALSE)) {
+  if (mb_strpos($result->title, '�') !== FALSE) {
     report_info("Could parse unicode characters in ". $url);
     return FALSE;
   }

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -84,7 +84,7 @@ function expand_by_zotero(&$template, $url = NULL) {
     report_info("Could not resolve URL ". $url);
     return FALSE;
   }
-  if (strpos($result->title, '�') !== FALSE)) {
+  if (mb_strpos($result->title, '�') !== FALSE)) {
     report_info("Could parse unicode characters in ". $url);
     return FALSE;
   }

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -84,7 +84,10 @@ function expand_by_zotero(&$template, $url = NULL) {
     report_info("Could not resolve URL ". $url);
     return FALSE;
   }
-  
+  if (strpos($result->title, '�') !== FALSE)) {
+    report_info("Could parse unicode characters in ". $url);
+    return FALSE;
+  }
   report_info("Retrieved info from ". $url);
   // Verify that Zotero translation server did not think that this was a website and not a journal
   if (strtolower(substr(trim($result->title), -9)) === ' on jstor') {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -84,7 +84,9 @@ function expand_by_zotero(&$template, $url = NULL) {
     report_info("Could not resolve URL ". $url);
     return FALSE;
   }
-  if (mb_strpos($result->title, '�') !== FALSE) {
+  $bad_count = mb_substr_count($result->title, '�');  // Reject more than 5 or more than 10%
+  $total_count = mb_strlen($result->title);
+  if (($bad_count > 5) || ($total_count > 1 && (($bad_count/$total_count) > 0.1))) {
     report_info("Could parse unicode characters in ". $url);
     return FALSE;
   }


### PR DESCRIPTION
If we we have that in the title, there is little hope

It seems that sometimes zotero sends us the Unicode replacement character instead.  Citoid on en.wikipedia.org does not have this problem.

Crossref gives us that sometimes instead of umlauts. We just take it from them since it is just one letter.

The bug report is titles that are 90% this character