### PR TITLE
Respect access-dates

### DIFF
--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -47,6 +47,10 @@ function zotero_request($url) {
 }
   
 function expand_by_zotero(&$template, $url = NULL) {
+  $access_date = strtotime("1 January 2222");
+  if (is_null($url)) {
+     $access_date = strtotime(tidy_date($template->get('accessdate') . ' ' . $template->get('access-date'))); 
+  }
   if (!$template->profoundly_incomplete()) return FALSE; // Only risk unvetted data if there's little good data to sully
   if (is_null($url)) $url = $template->get('url');
   if (!$url) {
@@ -90,6 +94,8 @@ function expand_by_zotero(&$template, $url = NULL) {
     report_info("Could parse unicode characters in ". $url);
     return FALSE;
   }
+  if (is
+  
   report_info("Retrieved info from ". $url);
   // Verify that Zotero translation server did not think that this was a website and not a journal
   if (strtolower(substr(trim($result->title), -9)) === ' on jstor') {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -94,15 +94,6 @@ function expand_by_zotero(&$template, $url = NULL) {
     report_info("Could parse unicode characters in ". $url);
     return FALSE;
   }
-  if ($access_date && isset($result->date)) {
-    $new_date = strtotime(tidy_date($result->date));
-    if($new_date) { // can compare
-      if($new_date > $access_date) {
-        report_info("URL appears to have changed since access-date ". $url);
-        return FALSE;
-      }
-    }
-  }
   
   report_info("Retrieved info from ". $url);
   // Verify that Zotero translation server did not think that this was a website and not a journal
@@ -139,6 +130,17 @@ function expand_by_zotero(&$template, $url = NULL) {
     return TRUE; // We can just use this.  If this is wrong, then we should not trust anything else anyway
   }
 
+  if ( isset($result->ISBN))             $template->add_if_new('isbn'   , $result->ISBN);
+  if ($access_date && isset($result->date)) {
+    $new_date = strtotime(tidy_date($result->date));
+    if($new_date) { // can compare
+      if($new_date > $access_date) {
+        report_info("URL appears to have changed since access-date ". $url);
+        return FALSE;
+      }
+    }
+  }
+  
   if (isset($result->bookTitle)) {
     $template->add_if_new('title', $result->bookTitle);
     if (isset($result->title))      $template->add_if_new('chapter',   $result->title);
@@ -149,8 +151,7 @@ function expand_by_zotero(&$template, $url = NULL) {
        if (isset($result->publisher))  $template->add_if_new('publisher', $result->publisher); 
     }
   }
-    
-  if ( isset($result->ISBN))             $template->add_if_new('isbn'   , $result->ISBN);
+
   if ( isset($result->issue))            $template->add_if_new('issue'  , $result->issue);
   if ( isset($result->pages))            $template->add_if_new('pages'  , $result->pages);
   if (isset($result->itemType) && $result->itemType == 'newspaperArticle') {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -95,7 +95,7 @@ function expand_by_zotero(&$template, $url = NULL) {
     return FALSE;
   }
   if ($access_date && isset($result->date)) {
-    $new_date = strtodate(tidy_date($result->date));
+    $new_date = strtotime(tidy_date($result->date));
     if($new_date) { // can compare
       if($new_date > $access_date) {
         report_info("URL appears to have changed since access-date ". $url);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -94,7 +94,6 @@ function expand_by_zotero(&$template, $url = NULL) {
     report_info("Could parse unicode characters in ". $url);
     return FALSE;
   }
-  
   report_info("Retrieved info from ". $url);
   // Verify that Zotero translation server did not think that this was a website and not a journal
   if (strtolower(substr(trim($result->title), -9)) === ' on jstor') {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -47,7 +47,7 @@ function zotero_request($url) {
 }
   
 function expand_by_zotero(&$template, $url = NULL) {
-  $access_date = strtotime("1 January 2222");
+  $access_date = FALSE;
   if (is_null($url)) {
      $access_date = strtotime(tidy_date($template->get('accessdate') . ' ' . $template->get('access-date'))); 
   }
@@ -94,7 +94,15 @@ function expand_by_zotero(&$template, $url = NULL) {
     report_info("Could parse unicode characters in ". $url);
     return FALSE;
   }
-  if (is
+  if ($access_date && isset($result->date)) {
+    $new_date = strtodate(tidy_date($result->date)));
+    if($new_date) { // can compare
+      if($new_date > $access_date) {
+        report_info("URL appears to have changed since access-date ". $url);
+        return FALSE;
+      }
+    }
+  }
   
   report_info("Retrieved info from ". $url);
   // Verify that Zotero translation server did not think that this was a website and not a journal

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -95,7 +95,7 @@ function expand_by_zotero(&$template, $url = NULL) {
     return FALSE;
   }
   if ($access_date && isset($result->date)) {
-    $new_date = strtodate(tidy_date($result->date)));
+    $new_date = strtodate(tidy_date($result->date));
     if($new_date) { // can compare
       if($new_date > $access_date) {
         report_info("URL appears to have changed since access-date ". $url);

--- a/tests/phpunit/zoteroTest.php
+++ b/tests/phpunit/zoteroTest.php
@@ -23,7 +23,7 @@ class ZoteroTest extends testBaseClass {
   }
 
   public function testZoteroExpansionNBK() {
-    $text = '{{Cite journal|url=https://www.ncbi.nlm.nih.gov/books/NBK24662/}}';
+    $text = '{{Cite journal|url=https://www.ncbi.nlm.nih.gov/books/NBK24662/|access-date=2099-12-12}}';  // Date is before access-date so will expand
     $expanded = $this->expand_via_zotero($text);
     $this->assertEquals('Continuing Efforts to More Efficiently Use Laboratory Animals', $expanded->get('title'));
     $this->assertEquals('2004', $expanded->get('year'));
@@ -31,7 +31,7 @@ class ZoteroTest extends testBaseClass {
   }
  
   public function testZoteroExpansionAccessDates() {
-    $text = '{{Cite journal|url=https://www.ncbi.nlm.nih.gov/books/NBK24663/|access-date=2099-12-12}}';
+    $text = '{{Cite journal|url=https://www.ncbi.nlm.nih.gov/books/NBK24663/|access-date=1978-12-12}}';  // Access date is too far in past, will not expand
     $expanded = $this->expand_via_zotero($text);
     $this->assertEquals($text, $expanded->parsed_text());
   }

--- a/tests/phpunit/zoteroTest.php
+++ b/tests/phpunit/zoteroTest.php
@@ -29,6 +29,12 @@ class ZoteroTest extends testBaseClass {
     $this->assertEquals('2004', $expanded->get('year'));
     $this->assertEquals('National Academies Press (US)', $expanded->get('publisher'));
   }
+ 
+  public function testZoteroExpansionAccessDates() {
+    $text = '{{Cite journal|url=https://www.ncbi.nlm.nih.gov/books/NBK24663/|access-date=2099-12-12}}';
+    $expanded = $this->expand_via_zotero($text);
+    $this->assertEquals($text, $expanded->parsed_text());
+  }
 
   public function testZoteroExpansionNYT() {
     $text = '{{Cite journal|url =https://www.nytimes.com/2018/06/11/technology/net-neutrality-repeal.html}}';


### PR DESCRIPTION
Do after doi and isbn since they are probably not changing.  Also allows us to often drop the url once we get a DOI.  

Test added too (without being nagged)