### PR TITLE
Better support for non-english dates

### DIFF
--- a/expandFns.php
+++ b/expandFns.php
@@ -334,9 +334,7 @@ function tidy_date($string) {
     $string = $cleaned;
   }
   $string = preg_replace("~[^\x01-\x7F]~","-", $string); // Convert any non-ASCII Characters to dashes
-  $string = preg_replace('~\-[\s\-]+~', '-',$string); // Combine dash followed by white or dashes
-  $string = preg_replace('~[\s\-]+\-~', '-',$string); // Combine dash preceeded by white or dashes
-  $string = preg_replace('~\-+~', '-',$string); // Combine multiple dashes
+  $string = preg_replace('~[\s\-]*\-[\s\-]*~', '-',$string); // Combine dash with any following or preceeding white space and other dash
   $string = preg_replace('~\-$~', '',$string);  // Remove trailing dash
   $string = preg_replace('~^\-~', '',$string);  // Remove leading dash
   $string = trim($string);

--- a/expandFns.php
+++ b/expandFns.php
@@ -321,7 +321,7 @@ function tidy_date($string) {
   if (stripos($string, 'Invalid') !== FALSE) return '';
   if (!preg_match('~\d{2}~', $string)) return ''; // If there are not two numbers next to each other, reject
   
-  if (strlen($string) != mb_strlen($string) {  // Conver multi-byte to dashes
+  if (strlen($string) != mb_strlen($string) {  // Convert all multi-byte characters to dashes
     $cleaned = '';
     for ($i = 0; $i < mb_strlen($string); $i++) {
        $char = mb_substr($string,$i,1);
@@ -333,7 +333,7 @@ function tidy_date($string) {
     }
     $string = $cleaned;
   }
-  $string = preg_replace("~[^\x01-\x7F]~","-", $string); // Convert any non-ASCII Characters
+  $string = preg_replace("~[^\x01-\x7F]~","-", $string); // Convert any non-ASCII Characters to dashes
   $string = preg_replace('~\-+~u', '-',$string); // Combine multiple dashes
   $string = preg_replace('~\- ~u', ' ',$string); // Remove dash followed by space
   $string = preg_replace('~ \-~u', ' ',$string); // Remove dash proceeded by space

--- a/expandFns.php
+++ b/expandFns.php
@@ -320,13 +320,24 @@ function tidy_date($string) {
   $string=trim($string);
   if (stripos($string, 'Invalid') !== FALSE) return '';
   if (!preg_match('~\d{2}~', $string)) return ''; // If there are not two numbers next to each other, reject
-  if (strlen($string) != mb_strlen($string) {
-    remove them
-    $string = preg_replace('~\-+~u', '-',$string); // Combine multiple dashes
-    $string = preg_replace('~\- ~u', ' ',$string); // Remove dash followed by space
-    $string = preg_replace('~ \-~u', ' ',$string); // Remove dash proceeded by space
-    $string = trim($string);
+  
+  if (strlen($string) != mb_strlen($string) {  // Conver multi-byte to dashes
+    $cleaned = '';
+    for ($i = 0; $i < mb_strlen($string); $i++) {
+    $char = mb_substr($string,$i,1);
+    if (mb_strlen($char) == strlen($char)) {
+        $cleaned .= $char;
+    } else {
+        $cleaned .= '-';
+    }
+    $string = $cleaned;
   }
+  $string = preg_replace("~[^\x01-\x7F]~","-", $string); // Convert any non-ASCII Characters
+  $string = preg_replace('~\-+~u', '-',$string); // Combine multiple dashes
+  $string = preg_replace('~\- ~u', ' ',$string); // Remove dash followed by space
+  $string = preg_replace('~ \-~u', ' ',$string); // Remove dash proceeded by space
+  $string = trim($string);
+
   if (is_numeric($string) && is_int(1*$string)) {
     $string = intval($string);
     if ($string < -2000 || $string > date("Y") + 10) return ''; // A number that is not a year; probably garbage 

--- a/expandFns.php
+++ b/expandFns.php
@@ -321,7 +321,7 @@ function tidy_date($string) {
   if (stripos($string, 'Invalid') !== FALSE) return '';
   if (!preg_match('~\d{2}~', $string)) return ''; // If there are not two numbers next to each other, reject
   // Huge amout of character cleaning
-  if (strlen($string) != mb_strlen($string) {  // Convert all multi-byte characters to dashes
+  if (strlen($string) != mb_strlen($string)) {  // Convert all multi-byte characters to dashes
     $cleaned = '';
     for ($i = 0; $i < mb_strlen($string); $i++) {
        $char = mb_substr($string,$i,1);

--- a/expandFns.php
+++ b/expandFns.php
@@ -340,7 +340,7 @@ function tidy_date($string) {
   // End of character clean-up
   $string = preg_replace('~[^0-9]+\d{2}:\d{2}:\d{2}$~', '', $string); //trailing time
   $string = preg_replace('~^Date published \(~', '', $string);
-  if (is_numeric($string) && is_int(1)) {
+  if (is_numeric($string) && is_int(1*$string)) {
     $string = intval($string);
     if ($string < -2000 || $string > date("Y") + 10) return ''; // A number that is not a year; probably garbage 
     if ($string > -2 && $string < 2) return ''; // reject -1,0,1

--- a/expandFns.php
+++ b/expandFns.php
@@ -320,11 +320,13 @@ function tidy_date($string) {
   $string=trim($string);
   if (stripos($string, 'Invalid') !== FALSE) return '';
   if (!preg_match('~\d{2}~', $string)) return ''; // If there are not two numbers next to each other, reject
-  $string = preg_replace('~[年月日星期五]~u', '-', $string); // convert non-englist date characters to dashes
-  $string = preg_replace('~\-+~u', '-',$string); // Combine multiple dashes
-  $string = preg_replace('~\- ~u', ' ',$string); // Remove dash followed by space
-  $string = preg_replace('~ \-~u', ' ',$string); // Remove dash proceeded by space
-  $string = trim($string);
+  if (strlen($string) != mb_strlen($string) {
+    remove them
+    $string = preg_replace('~\-+~u', '-',$string); // Combine multiple dashes
+    $string = preg_replace('~\- ~u', ' ',$string); // Remove dash followed by space
+    $string = preg_replace('~ \-~u', ' ',$string); // Remove dash proceeded by space
+    $string = trim($string);
+  }
   if (is_numeric($string) && is_int(1*$string)) {
     $string = intval($string);
     if ($string < -2000 || $string > date("Y") + 10) return ''; // A number that is not a year; probably garbage 

--- a/expandFns.php
+++ b/expandFns.php
@@ -320,7 +320,7 @@ function tidy_date($string) {
   $string=trim($string);
   if (stripos($string, 'Invalid') !== FALSE) return '';
   if (!preg_match('~\d{2}~', $string)) return ''; // If there are not two numbers next to each other, reject
-  
+  // Huge amout of character cleaning
   if (strlen($string) != mb_strlen($string) {  // Convert all multi-byte characters to dashes
     $cleaned = '';
     for ($i = 0; $i < mb_strlen($string); $i++) {
@@ -334,11 +334,13 @@ function tidy_date($string) {
     $string = $cleaned;
   }
   $string = preg_replace("~[^\x01-\x7F]~","-", $string); // Convert any non-ASCII Characters to dashes
-  $string = preg_replace('~\-+~u', '-',$string); // Combine multiple dashes
-  $string = preg_replace('~\- ~u', ' ',$string); // Remove dash followed by space
-  $string = preg_replace('~ \-~u', ' ',$string); // Remove dash proceeded by space
+  $string = preg_replace('~\-[\s\-]+~', '-',$string); // Combine dash followed by white or dashes
+  $string = preg_replace('~[\s\-]+\-~', '-',$string); // Combine dash preceeded by white or dashes
+  $string = preg_replace('~\-+~', '-',$string); // Combine multiple dashes
+  $string = preg_replace('~\-$~', '',$string);  // Remove trailing dash
+  $string = preg_replace('~^\-~', '',$string);  // Remove leading dash
   $string = trim($string);
-
+  // End of character clean-up
   if (is_numeric($string) && is_int(1*$string)) {
     $string = intval($string);
     if ($string < -2000 || $string > date("Y") + 10) return ''; // A number that is not a year; probably garbage 

--- a/expandFns.php
+++ b/expandFns.php
@@ -339,7 +339,8 @@ function tidy_date($string) {
   $string = trim($string);
   // End of character clean-up
   $string = preg_replace('~[^0-9]+\d{2}:\d{2}:\d{2}$~', '', $string); //trailing time
-  $string = preg_replace('~^Date published \(~', '', $string);
+  $string = preg_replace('~^Date published \(~', '', $string); // seen this
+  if (strcasecmp('19xx', $string) === 0) return ''; //archive.org gives this if unknown
   if (is_numeric($string) && is_int(1*$string)) {
     $string = intval($string);
     if ($string < -2000 || $string > date("Y") + 10) return ''; // A number that is not a year; probably garbage 

--- a/expandFns.php
+++ b/expandFns.php
@@ -335,7 +335,7 @@ function tidy_date($string) {
   }
   $string = preg_replace("~[^\x01-\x7F]~","-", $string); // Convert any non-ASCII Characters to dashes
   $string = preg_replace('~[\s\-]*\-[\s\-]*~', '-',$string); // Combine dash with any following or preceeding white space and other dash
-  $string = preg_replace('~\-$~', '',$string);  // Remove trailing dash
+  $string = preg_replace('~^\-*(.+?)\-*$~', '\1', $string);  // Remove trailing dash
   $string = preg_replace('~^\-~', '',$string);  // Remove leading dash
   $string = trim($string);
   // End of character clean-up

--- a/expandFns.php
+++ b/expandFns.php
@@ -338,7 +338,9 @@ function tidy_date($string) {
   $string = preg_replace('~^\-*(.+?)\-*$~', '\1', $string);  // Remove trailing/leading dashes
   $string = trim($string);
   // End of character clean-up
-  if (is_numeric($string) && is_int(1*$string)) {
+  $string = preg_replace('~[^0-9]+\d{2}:\d{2}:\d{2}$~', '', $string); //trailing time
+  $string = preg_replace('~^Date published \(~', '', $string);
+  if (is_numeric($string) && is_int(1)) {
     $string = intval($string);
     if ($string < -2000 || $string > date("Y") + 10) return ''; // A number that is not a year; probably garbage 
     if ($string > -2 && $string < 2) return ''; // reject -1,0,1

--- a/expandFns.php
+++ b/expandFns.php
@@ -320,6 +320,11 @@ function tidy_date($string) {
   $string=trim($string);
   if (stripos($string, 'Invalid') !== FALSE) return '';
   if (!preg_match('~\d{2}~', $string)) return ''; // If there are not two numbers next to each other, reject
+  $string = preg_replace('~[年月日星期五]~u', '-', $string); // convert non-englist date characters to dashes
+  $string = preg_replace('~\-+~u', '-',$string); // Combine multiple dashes
+  $string = preg_replace('~\- ~u', ' ',$string); // Remove dash followed by space
+  $string = preg_replace('~ \-~u', ' ',$string); // Remove dash proceeded by space
+  $string = trim($string);
   if (is_numeric($string) && is_int(1*$string)) {
     $string = intval($string);
     if ($string < -2000 || $string > date("Y") + 10) return ''; // A number that is not a year; probably garbage 

--- a/expandFns.php
+++ b/expandFns.php
@@ -335,8 +335,7 @@ function tidy_date($string) {
   }
   $string = preg_replace("~[^\x01-\x7F]~","-", $string); // Convert any non-ASCII Characters to dashes
   $string = preg_replace('~[\s\-]*\-[\s\-]*~', '-',$string); // Combine dash with any following or preceeding white space and other dash
-  $string = preg_replace('~^\-*(.+?)\-*$~', '\1', $string);  // Remove trailing dash
-  $string = preg_replace('~^\-~', '',$string);  // Remove leading dash
+  $string = preg_replace('~^\-*(.+?)\-*$~', '\1', $string);  // Remove trailing/leading dashes
   $string = trim($string);
   // End of character clean-up
   if (is_numeric($string) && is_int(1*$string)) {

--- a/expandFns.php
+++ b/expandFns.php
@@ -324,11 +324,12 @@ function tidy_date($string) {
   if (strlen($string) != mb_strlen($string) {  // Conver multi-byte to dashes
     $cleaned = '';
     for ($i = 0; $i < mb_strlen($string); $i++) {
-    $char = mb_substr($string,$i,1);
-    if (mb_strlen($char) == strlen($char)) {
-        $cleaned .= $char;
-    } else {
-        $cleaned .= '-';
+       $char = mb_substr($string,$i,1);
+       if (mb_strlen($char) == strlen($char)) {
+          $cleaned .= $char;
+       } else {
+          $cleaned .= '-';
+       }
     }
     $string = $cleaned;
   }

--- a/tests/phpunit/expandFnsTest.php
+++ b/tests/phpunit/expandFnsTest.php
@@ -47,7 +47,7 @@ final class expandFnsTest extends testBaseClass {
   
   public function testTidyDate() {
     $this->assertEquals('2014', tidy_date('maanantai 14. heinäkuuta 2014'));
-    $this->assertEquals('2012-03-20', tidy_date('2012年4月20日 星期五'));
+    $this->assertEquals('2012-04-20', tidy_date('2012年4月20日 星期五'));
     $this->assertEquals('2011-05-10', tidy_date('2011-05-10T06:34:00-0400'));
     $this->assertEquals('2014-07-01', tidy_date('2014-07-01T23:50:00Z, 2014-07-01'));
     $this->assertEquals('', tidy_date('۱۳۸۶/۱۰/۰۴ - ۱۱:۳۰'));

--- a/tests/phpunit/expandFnsTest.php
+++ b/tests/phpunit/expandFnsTest.php
@@ -47,5 +47,9 @@ final class expandFnsTest extends testBaseClass {
   
   public function testTidyDate() {
     $this->assertEquals('2014', tidy_date('maanantai 14. heinäkuuta 2014'));
+    $this->assertEquals('2012-03-20', tidy_date('2012年4月20日 星期五'));
+    $this->assertEquals('2011-05-10', tidy_date('2011-05-10T06:34:00-0400'));
+    $this->assertEquals('2014-07-01', tidy_date('2014-07-01T23:50:00Z, 2014-07-01'));
+    $this->assertEquals('', tidy_date('۱۳۸۶/۱۰/۰۴ - ۱۱:۳۰'));
   }
 }

--- a/tests/phpunit/expandFnsTest.php
+++ b/tests/phpunit/expandFnsTest.php
@@ -51,7 +51,7 @@ final class expandFnsTest extends testBaseClass {
     $this->assertEquals('2011-05-10', tidy_date('2011-05-10T06:34:00-0400'));
     $this->assertEquals('2014-07-01', tidy_date('2014-07-01T23:50:00Z, 2014-07-01'));
     $this->assertEquals('', tidy_date('۱۳۸۶/۱۰/۰۴ - ۱۱:۳۰'));
-    $this->assertEquals('2014-01-24', tidy_date('24/01/2014 16:01:06'));
+    $this->assertEquals('24/01/2014', tidy_date('24/01/2014 16:01:06'));
     $this->assertEquals('2018-10-21', tidy_date('Date published (2018-10-21'));
   }
 }

--- a/tests/phpunit/expandFnsTest.php
+++ b/tests/phpunit/expandFnsTest.php
@@ -51,5 +51,7 @@ final class expandFnsTest extends testBaseClass {
     $this->assertEquals('2011-05-10', tidy_date('2011-05-10T06:34:00-0400'));
     $this->assertEquals('2014-07-01', tidy_date('2014-07-01T23:50:00Z, 2014-07-01'));
     $this->assertEquals('', tidy_date('۱۳۸۶/۱۰/۰۴ - ۱۱:۳۰'));
+    $this->assertEquals('2014-01-24', tidy_date('24/01/2014 16:01:06'));
+    $this->assertEquals('2018-10-21', tidy_date('Date published (2018-10-21'));
   }
 }


### PR DESCRIPTION
By “support” mean fire napalm at

This is a heavy hammer  for the non-English Whack a mole.

Tests added too (without being asked)

Use "-", not "/", since strtodate assumes Non-american for "-" and american for "/"

Also a few more random things