### PR TITLE
Just forget empty unrecognized parameters

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2296,6 +2296,12 @@ final class Template {
 
     if ((strlen($p->param) > 0) && !in_array(preg_replace('~\d+~', '#', $p->param), $parameter_list) && stripos($p->param, 'CITATION_BOT')===FALSE) {
      
+      if (trim($p->val) === '') {
+        report_forget("Dropping empty unrecognised parameter " . echoable($p->param) . " ");
+        $this->quietly_forget($p->param);
+        continue;
+      }
+      
       report_modification("Unrecognised parameter " . echoable($p->param) . " ");
       $mistake_id = array_search($p->param, $mistake_keys);
       if ($mistake_id) {
@@ -2305,15 +2311,6 @@ final class Template {
         continue;
       }
       
-      /* Not clear why this exception exists.
-       * If it is valid, it should apply only when $p->param relates to authors,
-       * not when it applies to e.g. pages, title.
-      if ($this->initial_author_params) {
-        echo "\n   . initial authors exist, not correcting " . echoable($p->param);
-        continue;
-      }
-      */
-
       $p->param = preg_replace('~author(\d+)-(la|fir)st~', "$2st$1", $p->param);
       $p->param = preg_replace('~surname\-?_?(\d+)~', "last$1", $p->param);
       $p->param = preg_replace('~(?:forename|initials?)\-?_?(\d+)~', "first$1", $p->param);

--- a/constants/regular_expressions.php
+++ b/constants/regular_expressions.php
@@ -15,4 +15,4 @@ const REGEXP_SICI = "~(\d{4}-\d{3}[\dxX])" . // ISSN
 // See https://mathiasbynens.be/demo/url-regex/  This regex is more exact than validator.  We only spend time on this after quick and dirty check is passed
 const REGEXP_IS_URL = '~^(?:(?:https?|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?!10(?:\\.\\d{1,3}){3})(?!127(?:\\.\\d{1,3}){3})(?!169\\.254(?:\\.\\d{1,3}){2})(?!192\\.168(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\x{00a1}-\\x{ffff}0-9]+-?)*[a-z\\x{00a1}-\\x{ffff}0-9]+)(?:\\.(?:[a-z\\x{00a1}-\\x{ffff}0-9]+-?)*[a-z\\x{00a1}-\\x{ffff}0-9]+)*(?:\\.(?:[a-z\\x{00a1}-\\x{ffff}]{2,})))(?::\\d{2,5})?(?:/[^\\s]*)?$~iuS';
 
-const REGEXP_HANDLES = "~^(?:https?://)(?:hdl\.handle\.net/|orbi\.ulg\.ac\.be/handle/|kb\.osu\.edu/dspace/handle/)([^\?]*)~i";
+const REGEXP_HANDLES = "~^(?:https?:/ /)(?:hdl\.handle\.net/|orbi\.ulg\.ac\.be/handle/|kb\.osu\.edu/dspace/handle/)([^\?]*)~i";


### PR DESCRIPTION
Saw bot change authorn= to author2= that’s pretty random since empty

No point changing junk to something that might not make sense in the template context