### PR TITLE
Disallow top-level domain names in titles

### DIFF
--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -159,7 +159,7 @@ function expand_by_zotero(&$template, $url = NULL) {
   } else {
     if ( isset($result->publicationTitle)) $template->add_if_new('journal', $result->publicationTitle);
   }
-  if ( isset($result->volume))           $template->add_if_new('volume' , $result->volume);
+  if ( isset($result->volume))            $template->add_if_new('volume' , $result->volume);
   if ( isset($result->date))             $template->add_if_new('date'   , tidy_date($result->date));
   if ( isset($result->series))           $template->add_if_new('series' , $result->series);
   $i = 0;

--- a/constants/bad_data.php
+++ b/constants/bad_data.php
@@ -25,7 +25,7 @@ const BAD_ZOTERO_TITLES = ['Browse publications', 'Central Authentication Servic
                                  'domain for sale', 'website for sale', 'domain is for sale', 'website is for sale',
                                  'lease this domain', 'domain available', 'metaTags', 'An Error Occurred', 'User Cookie',
                                  'Cookies Disabled', 'page not found', '411 error', 'url not found',
-                                 'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway', '.com', '.gov', '.org' ];
+                                 'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway', '.com', '.gov', '.org'];
 
 const CANONICAL_PUBLISHER_URLS = array ('elsevier.com', 'springer.com', 'sciencedirect.com', 'tandfonline.com',
                                 'taylorandfrancis.com', 'wiley.com', 'sagepub.com', 'sagepublications.com',

--- a/constants/bad_data.php
+++ b/constants/bad_data.php
@@ -25,7 +25,7 @@ const BAD_ZOTERO_TITLES = ['Browse publications', 'Central Authentication Servic
                                  'domain for sale', 'website for sale', 'domain is for sale', 'website is for sale',
                                  'lease this domain', 'domain available', 'metaTags', 'An Error Occurred', 'User Cookie',
                                  'Cookies Disabled', 'page not found', '411 error', 'url not found',
-                                 'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway', '.com', '.gov', '.org'];
+                                 'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway', '.com', '.gov', '.org' ];
 
 const CANONICAL_PUBLISHER_URLS = array ('elsevier.com', 'springer.com', 'sciencedirect.com', 'tandfonline.com',
                                 'taylorandfrancis.com', 'wiley.com', 'sagepub.com', 'sagepublications.com',

--- a/constants/bad_data.php
+++ b/constants/bad_data.php
@@ -18,14 +18,15 @@ const IN_PRESS_ALIASES = array("in press", "inpress", "pending", "published",
                                "na", "submitted", "tbd", "missing");
 const NON_JOURNAL_BIBCODES = array('arXiv', 'gr.qc', 'hep.ex', 'hep.lat', 'hep.ph', 'hep.th', 
                                    'math.ph', 'math', 'nucl.ex', 'nucl.th', 'physics');
-const NON_PUBLISHERS = ['books.google', 'google books', 'google news', 'google.co', 'amazon.com', 'archive.org']; // Google Inc is a valid publisher, however.
+const NON_PUBLISHERS = ['books.google', 'google books', 'google news', 'google.co', 'amazon.com', 'archive.org' ]; // Google Inc is a valid publisher, however.
 const BAD_ZOTERO_TITLES = ['Browse publications', 'Central Authentication Service', 'http://', 'https://',
                                  'ZbMATH - the first resource for mathematics', 'MR: Matches for:',
                                  ' Log In', 'Log In ', 'Bookmarkable URL intermediate page', 'Shibboleth Authentication Request',
                                  'domain for sale', 'website for sale', 'domain is for sale', 'website is for sale',
                                  'lease this domain', 'domain available', 'metaTags', 'An Error Occurred', 'User Cookie',
                                  'Cookies Disabled', 'page not found', '411 error', 'url not found',
-                                 'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway', 'Captcha', '.com', '.gov', '.org'];
+                                 'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway', 'Captcha',
+                                 '.com', '.gov', '.org'];
 
 const CANONICAL_PUBLISHER_URLS = array ('elsevier.com', 'springer.com', 'sciencedirect.com', 'tandfonline.com',
                                 'taylorandfrancis.com', 'wiley.com', 'sagepub.com', 'sagepublications.com',

--- a/constants/bad_data.php
+++ b/constants/bad_data.php
@@ -25,7 +25,7 @@ const BAD_ZOTERO_TITLES = ['Browse publications', 'Central Authentication Servic
                                  'domain for sale', 'website for sale', 'domain is for sale', 'website is for sale',
                                  'lease this domain', 'domain available', 'metaTags', 'An Error Occurred', 'User Cookie',
                                  'Cookies Disabled', 'page not found', '411 error', 'url not found',
-                                 'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway'];
+                                 'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway', '.com', '.gov', '.org'];
 
 const CANONICAL_PUBLISHER_URLS = array ('elsevier.com', 'springer.com', 'sciencedirect.com', 'tandfonline.com',
                                 'taylorandfrancis.com', 'wiley.com', 'sagepub.com', 'sagepublications.com',


### PR DESCRIPTION
If the bot includes stuff such as `- health.gov` in the title, it is a bad title, since is a lot of junk which should not be in the title.