### PR TITLE
Some PMCs do NOT resolve.  So leave URL

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -978,7 +978,7 @@ final class Template {
           quietly('report_modification', "Converting URL to PMC parameter");
           if (is_null($url_sent)) {
             if (stripos($url, ".pdf") !== FALSE) {
-              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $match[1] . $match[2]);
+              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $match[1] . $match[2];
               $ch = curl_init($test_url);
               curl_setopt($ch,  CURLOPT_RETURNTRANSFER, TRUE);
               @curl_exec($ch);

--- a/Template.php
+++ b/Template.php
@@ -978,7 +978,7 @@ final class Template {
           quietly('report_modification', "Converting URL to PMC parameter");
           if (is_null($url_sent)) {
             if (stripos($url, ".pdf") !== FALSE) {
-              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $match[1] . $match[2];
+              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $match[1] . $match[2] . "/";
               $ch = curl_init($test_url);
               curl_setopt($ch,  CURLOPT_RETURNTRANSFER, TRUE);
               @curl_exec($ch);

--- a/Template.php
+++ b/Template.php
@@ -977,6 +977,17 @@ final class Template {
         if ($this->blank('pmc')) {
           quietly('report_modification', "Converting URL to PMC parameter");
           if (is_null($url_sent)) {
+            if (stripos($url, ".pdf") !== FALSE) {
+              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $match[1] . $match[2]);
+              $ch = curl_init($test_url);
+              curl_setopt($ch,  CURLOPT_RETURNTRANSFER, TRUE);
+              @curl_exec($ch);
+              $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+              curl_close($ch);
+              if($httpCode == 404) { // Some PMCs do NOT resolve.  So leave URL
+                return $this->add_if_new("pmc", $match[1] . $match[2]);
+              }
+            }
             $this->forget($url_type);
           }
           return $this->add_if_new("pmc", $match[1] . $match[2]);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -150,6 +150,12 @@ final class TemplateTest extends testBaseClass {
     $expanded = $this->prepare_citation($text);
     $this->assertEquals('cite journal', $expanded->wikiname());
     $this->assertEquals('154623', $expanded->get('pmc'));
+    $this->assertNull($expanded->get('url'));
+    $text = "{{Cite web | url = https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2491514/pdf/annrcse01476-0076.pdf}}";
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('cite journal', $expanded->wikiname());
+    $this->assertEquals('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2491514/pdf/annrcse01476-0076.pdf', $expanded->get('url'));
+    $this->assertEquals('2491514', $expanded->get('pmc'));
   }
   
   public function testPMC2PMID() {


### PR DESCRIPTION
https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2491514/pdf/annrcse01476-0076.pdf

vs

https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2491514/

The trailing slash is needed in the test, otherwise it re-directs to the slash and you do not get 404