### PR TITLE
Need to use report_warning() instead

### DIFF
--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -42,7 +42,7 @@ function zotero_request($url) {
   
   $zotero_response = curl_exec($ch);
   if ($zotero_response === FALSE) {
-    report_info(curl_error($ch) . "   For URL: " . $url);
+    report_warning(curl_error($ch) . "   For URL: " . $url);
   }
   curl_close($ch);
   return $zotero_response;


### PR DESCRIPTION
When zotero is not responding (too busy with other users I assume), the bot can get several of these in a row and the interface freezes.  After waiting two minutes, we can call ob_clean and report it as a warning.