### PR TITLE
fix: fix open-access url when oadoi returns no url_for_landing_page

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1699,6 +1699,7 @@ final class Template {
           return TRUE;
         }
         // sometimes url_for_landing_page = null, eg http://api.oadoi.org/v2/10.1145/3238147.3240474?email=m@f
+        $oa_url = NULL;
         if ($best_location->url_for_landing_page != null) {
           $oa_url = $best_location->url_for_landing_page;
         } elseif ($best_location->url_for_pdf != null) {
@@ -1706,6 +1707,7 @@ final class Template {
         } elseif ($best_location->url != null) {
           $oa_url = $best_location->url;
         }
+        if ($oa_url == NULL) return FALSE;
         if ($this->get('url')) {
             $this->get_identifiers_from_url($oa_url);  // Maybe we can get a new link type
             return TRUE;

--- a/Template.php
+++ b/Template.php
@@ -1699,15 +1699,15 @@ final class Template {
           return TRUE;
         }
         // sometimes url_for_landing_page = null, eg http://api.oadoi.org/v2/10.1145/3238147.3240474?email=m@f
-        $oa_url = NULL;
         if ($best_location->url_for_landing_page != null) {
           $oa_url = $best_location->url_for_landing_page;
         } elseif ($best_location->url_for_pdf != null) {
           $oa_url = $best_location->url_for_pdf;
         } elseif ($best_location->url != null) {
           $oa_url = $best_location->url;
+        } else {
+          return FALSE;
         }
-        if ($oa_url == NULL) return FALSE;
         if ($this->get('url')) {
             $this->get_identifiers_from_url($oa_url);  // Maybe we can get a new link type
             return TRUE;

--- a/Template.php
+++ b/Template.php
@@ -1701,10 +1701,10 @@ final class Template {
         // sometimes url_for_landing_page = null, eg http://api.oadoi.org/v2/10.1145/3238147.3240474?email=m@f
         if ($best_location->url_for_landing_page != null) {
           $oa_url = $best_location->url_for_landing_page;
-        }
-        // if we have the actual PDF, we directly point to it
-        if ($best_location->url_for_pdf != null) {
+        } elseif ($best_location->url_for_pdf != null) {
           $oa_url = $best_location->url_for_pdf;
+        } elseif ($best_location->url != null) {
+          $oa_url = $best_location->url;
         }
         if ($this->get('url')) {
             $this->get_identifiers_from_url($oa_url);  // Maybe we can get a new link type

--- a/Template.php
+++ b/Template.php
@@ -1698,7 +1698,14 @@ final class Template {
           // The best location is already linked to by the doi link
           return TRUE;
         }
-        $oa_url = $best_location->url_for_landing_page;
+        // sometimes url_for_landing_page = null, eg http://api.oadoi.org/v2/10.1145/3238147.3240474?email=m@f
+        if ($best_location->url_for_landing_page != null) {
+          $oa_url = $best_location->url_for_landing_page;
+        }
+        // if we have the actual PDF, we directly point to it
+        if ($best_location->url_for_pdf != null) {
+          $oa_url = $best_location->url_for_pdf;
+        }
         if ($this->get('url')) {
             $this->get_identifiers_from_url($oa_url);  // Maybe we can get a new link type
             return TRUE;


### PR DESCRIPTION
fix open-access url when oadoi returns no url_for_landing_page

Changes implemented in this pull request:
- check for null value in JSON field url_for_landing_page
- prefer PDF url is one exists
