### PR TITLE
gateway.isiknowledge.com urls are worthless

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1713,6 +1713,7 @@ final class Template {
             return TRUE;
         }
         if (strpos($oa_url, 'bioone.org/doi') !== FALSE) return TRUE;
+        if (strpos($oa_url, 'gateway.isiknowledge.com') !== FALSE) return TRUE;
         // Check if best location is already linked -- avoid double linki
         if (preg_match("~^https?://europepmc\.org/articles/pmc(\d+)~", $oa_url, $match) || preg_match("~^https?://www\.pubmedcentral\.nih\.gov/articlerender.fcgi\?.*\bartid=(\d+)"
                       . "|^https?://www\.ncbi\.nlm\.nih\.gov/pmc/articles/PMC(\d+)~", $oa_url, $match)) {


### PR DESCRIPTION
Even if they did work then they would just point to publisher anyway

Such as    http://gateway.isiknowledge.com/gateway/Gateway.cgi?GWVersion=2&SrcAuth=HighwireFree&SrcApp=PRODUCT_NAME&KeyAID=http://jeb.biologists.org_209_15_2829&DestApp=HighwireFree&SrcAppSID=APP_SID&SrcJTitle=WURS_TITLE
