### PR TITLE
Wayback Machine

### DIFF
--- a/constants/bad_data.php
+++ b/constants/bad_data.php
@@ -27,7 +27,7 @@ const BAD_ZOTERO_TITLES = ['Browse publications', 'Central Authentication Servic
                                  'lease this domain', 'domain available', 'metaTags', 'An Error Occurred', 'User Cookie',
                                  'Cookies Disabled', 'page not found', '411 error', 'url not found',
                                  'limit exceeded', 'Error Page', '}}', '{{', 'EU Login', 'bad gateway', 'Captcha',
-                                 '.com', '.gov', '.org', 'View PDF'];
+                                 '.com', '.gov', '.org', 'View PDF', 'Wayback Machine'];
 
 const CANONICAL_PUBLISHER_URLS = array ('elsevier.com', 'springer.com', 'sciencedirect.com', 'tandfonline.com',
                                 'taylorandfrancis.com', 'wiley.com', 'sagepub.com', 'sagepublications.com',


### PR DESCRIPTION
`<ref>https://web.archive.org/web/20051231112918/http://www.linguasphere.org/auswanderungs_deutsch.pdf</ref>`

`<ref>{{cite web | url=https://web.archive.org/web/20051231112918/http://www.linguasphere.org/auswanderungs_deutsch.pdf | title=Wayback Machine}}</ref>`