### PR TITLE
Even if the DOI is broken, drop doi.org URL

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -929,6 +929,11 @@ final class Template {
             }
           }
         } else {
+          // Even if the DOI is broken, still drop URL if URL was dx.doi.org URL
+          if (is_null($url_sent) && strpos(strtolower($url), "doi.org/") !== FALSE) {
+            report_forget("Recognized doi.org URL; dropping URL");
+            $this->forget($url_type);
+          }
           $this->mark_inactive_doi();
         }
         return TRUE; // Added new DOI

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -30,6 +30,7 @@ final class TemplateTest extends testBaseClass {
   }
   
   public function testJstorExpansion() {
+   
     $text = "{{Cite web | www.jstor.org/stable/pdfplus/1701972.pdf?&acceptTC=true|website=i found this online}}";
     $prepared = $this->prepare_citation($text);
     $this->assertEquals('cite journal', $prepared->wikiname());


### PR DESCRIPTION
If the DOI is rubbish, then the URL is rubbish too