### PR TITLE
doi.library.ubc.ca is a DOI resolver too

### DIFF
--- a/DOItools.php
+++ b/DOItools.php
@@ -22,7 +22,7 @@ function junior_test($name) {
 }
 
 function de_wikify($string){
-	return str_replace(Array("[", "]", "'''", "''", "&"), Array("", "", "'", "'", ""), preg_replace(Array("~<[^>]*>~", "~\&[\w\d]{2,7};~", "~\[\[[^\|\]]*\|([^\]]*)\]\]~"), Array("", "", "$1"),  $string));
+	 return str_replace(Array("[", "]", "'''", "''", "&"), Array("", "", "'", "'", ""), preg_replace(Array("~<[^>]*>~", "~\&[\w\d]{2,7};~", "~\[\[[^\|\]]*\|([^\]]*)\]\]~"), Array("", "", "$1"),  $string));
 }
 
 /*

--- a/Template.php
+++ b/Template.php
@@ -1038,7 +1038,7 @@ final class Template {
           }
           return $this->add_if_new("pmc", $match[1]);
         }
-      } elseif (preg_match("~^https?://d?x?\.?doi\.org/([^\?]*)~i", $url, $match)) {
+      } elseif (preg_match("~^https?://(?:d?x?\.?doi\.org|doi\.library\.ubc\.ca)/([^\?]*)~i", $url, $match)) {
         quietly('report_modification', "URL is hard-coded DOI; converting to use DOI parameter.");
         if ($this->wikiname() === 'cite web') $this->change_name_to('Cite journal');
         if (is_null($url_sent)) {
@@ -1778,6 +1778,11 @@ final class Template {
           }
         }
         if (preg_match("~^https?://d?x?\.?doi\.org/*~", $oa_url, $match)) {
+          if ($this->has('doi')) {
+             return TRUE;
+          }
+        }
+        if (preg_match("~^https?://doi\.library\.ubc\.ca/*~", $oa_url, $match)) {
           if ($this->has('doi')) {
              return TRUE;
           }

--- a/constants/bad_data.php
+++ b/constants/bad_data.php
@@ -33,7 +33,9 @@ const CANONICAL_PUBLISHER_URLS = array ('elsevier.com', 'springer.com', 'science
                                 'taylorandfrancis.com', 'wiley.com', 'sagepub.com', 'sagepublications.com',
                                 'scielo.org', 'scielo.br', 'degruyter.com', 'hindawi.com', 'inderscience.com',
                                 'cambridge.org', '.oup.com', 'nature.com', 'macmillan.com', 'ieeexplore.ieee.org',
-                                'worldscientific.com', 'iospress.com', 'iospress.nl', 'pnas.org');
+                                'worldscientific.com', 'iospress.com', 'iospress.nl', 'pnas.org',
+                                //  Below are sites that are simply DOI resolvers, like dx.doi.org
+                                'doi.library.ubc.ca');
 
 const WEB_NEWSPAPERS = array('bbc news', 'bbc', 'news.bbc.co.uk');
 


### PR DESCRIPTION
Normally not a big deal, but people put this in the Open-Access data-base as the URL (Because that is soooooo different from dx.doi.org resolving to the exact same final URL.
