### PR TITLE
Simplify Jstor tests

### DIFF
--- a/DOItools.php
+++ b/DOItools.php
@@ -22,7 +22,7 @@ function junior_test($name) {
 }
 
 function de_wikify($string){
-	return str_replace(Array("[", "]", "'''", "''", "&"), Array("", "", "'", "'", ""), preg_replace(Array("~<[^>]*>~", "~\&[\w\d]{2,7};~", "~\[\[[^\|\]]*\|([^\]]*)\]\]~"), Array("", "", "$1"),  $string));
+ 	return str_replace(Array("[", "]", "'''", "''", "&"), Array("", "", "'", "'", ""), preg_replace(Array("~<[^>]*>~", "~\&[\w\d]{2,7};~", "~\[\[[^\|\]]*\|([^\]]*)\]\]~"), Array("", "", "$1"),  $string));
 }
 
 /*

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -40,7 +40,7 @@ final class TemplateTest extends testBaseClass {
     $prepared = $this->prepare_citation($text);
     $this->assertEquals('40237667', $prepared->get('jstor'));
     $this->assertNull($prepared->get('doi'));
-    $this->assertEquals(1, substr_count($expanded->parsed_text(), 'jstor'));  // Verify that we do not have both jstor= and jstor=40237667.  Formerly testOverwriteBlanks()
+    $this->assertEquals(1, substr_count($prepared->parsed_text(), 'jstor'));  // Verify that we do not have both jstor= and jstor=40237667.  Formerly testOverwriteBlanks()
 
     $text = "{{Cite web | url = http://www.jstor.org/stable/10.1017/s0022381613000030}}";
     $prepared = $this->prepare_citation($text);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1122,7 +1122,7 @@ ER -  }}';
   public function testOverwriteBlanks() {
     $text = '{{cite journal|url=http://www.jstor.org/stable/1234560|jstor=}}';
     $expanded = $this->process_citation($text);
-    $this->assertEquals('{{cite journal|jstor=1234560}}', $expanded->parsed_text());
+    $this->assertEquals(1, substr_count($expanded->parsed_text(), 'jstor'))
   }
 
   public function testIgnoreJstorPlants() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -36,10 +36,11 @@ final class TemplateTest extends testBaseClass {
     $this->assertEquals('1701972'     , $prepared->get('jstor'));
     $this->assertNull($prepared->get('website'));
 
-    $text = "{{Cite journal | url=http://www.jstor.org/stable/10.2307/40237667}}";
-    $prepared = $this->prepare_citation($text);
+    $text = "{{Cite journal | url=http://www.jstor.org/stable/10.2307/40237667|jstor=}}";
+    $prepared = $this->process_citation($text);
     $this->assertEquals('40237667', $prepared->get('jstor'));
     $this->assertNull($prepared->get('doi'));
+    $this->assertEquals(1, substr_count($expanded->parsed_text(), 'jstor'));  // Verify that we do not have both jstor= and jstor=40237667.  Formerly testOverwriteBlanks()
 
     $text = "{{Cite web | url = http://www.jstor.org/stable/10.1017/s0022381613000030}}";
     $prepared = $this->prepare_citation($text);
@@ -1117,12 +1118,6 @@ ER -  }}';
     $text = '{{Cite journal|url=https://www.jstor.org/sici?sici=0003-0279(196101%2F03)81%3A1%3C43%3AWLIMP%3E2.0.CO%3B2-9}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('594900', $expanded->get('jstor'));
-  }
-  
-  public function testOverwriteBlanks() {
-    $text = '{{cite journal|url=http://www.jstor.org/stable/1234560|jstor=}}';
-    $expanded = $this->process_citation($text);
-    $this->assertEquals(1, substr_count($expanded->parsed_text(), 'jstor'));
   }
 
   public function testIgnoreJstorPlants() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1122,7 +1122,7 @@ ER -  }}';
   public function testOverwriteBlanks() {
     $text = '{{cite journal|url=http://www.jstor.org/stable/1234560|jstor=}}';
     $expanded = $this->process_citation($text);
-    $this->assertEquals(1, substr_count($expanded->parsed_text(), 'jstor'))
+    $this->assertEquals(1, substr_count($expanded->parsed_text(), 'jstor'));
   }
 
   public function testIgnoreJstorPlants() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -37,7 +37,7 @@ final class TemplateTest extends testBaseClass {
     $this->assertNull($prepared->get('website'));
 
     $text = "{{Cite journal | url=http://www.jstor.org/stable/10.2307/40237667|jstor=}}";
-    $prepared = $this->process_citation($text);
+    $prepared = $this->prepare_citation($text);
     $this->assertEquals('40237667', $prepared->get('jstor'));
     $this->assertNull($prepared->get('doi'));
     $this->assertEquals(1, substr_count($expanded->parsed_text(), 'jstor'));  // Verify that we do not have both jstor= and jstor=40237667.  Formerly testOverwriteBlanks()


### PR DESCRIPTION
Only care about loss of url and only having one jstor= block.
Thus, merge into a different test.