### PR TITLE
Do not add series that matches title

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -609,6 +609,7 @@ final class Template {
         if ($this->blank($param_name)) {
           $value = wikify_external_text($value);
           if ($this->has('journal') && (strcasecmp($this->get('journal'), $value) === 0)) return FALSE;
+          if ($this->has('title') && (strcasecmp($this->get('title'), $value) === 0)) return FALSE;
           return $this->add($param_name, $value);
         }
         return FALSE;

--- a/Template.php
+++ b/Template.php
@@ -607,8 +607,8 @@ final class Template {
       case 'series':
         if ($this->blank($param_name)) {
           $value = wikify_external_text($value);
-          if ($this->has('journal') && (str_equivalent($this->get('journal'), $value)) return FALSE;
-          if ($this->has('title') && (str_equivalent($this->get('title'), $value)) return FALSE;
+          if ($this->has('journal') && str_equivalent($this->get('journal'), $value)) return FALSE;
+          if ($this->has('title') && str_equivalent($this->get('title'), $value)) return FALSE;
           return $this->add($param_name, $value);
         }
         return FALSE;


### PR DESCRIPTION
Different data sources have different names for same data

Probably should change to str_equivalent() after/before other pull -- depending who goes first