### PR TITLE
10.1093 URLs that look like DOIs, but never work as DOIs

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -731,6 +731,8 @@ final class Template {
         return FALSE;
         
       case 'doi':
+        if (strpos($value, '10.1093/law:epil') === 0) return FALSE; // Those do not work
+        if (strpos($value, '10.1093/oi/authority') === 0) return FALSE; // Those do not work
         if (preg_match(REGEXP_DOI, $value, $match)) {
           if ($this->blank($param_name)) {
             $this->add('doi', $match[0]);          
@@ -930,8 +932,6 @@ final class Template {
         }
         return FALSE;  // URL matched existing DOI, so we did not use it
       }
-      if (strpos($doi, '10.1093/law:epil') === 0) return FALSE; // Those do not work
-      if (strpos($doi, '10.1093/oi/authority') === 0) return FALSE; // Those do not work
       if (preg_match('~(.*)(?:#[^#]+)$~', $doi, $match_pound)) {
         if(!doi_active($doi) && doi_active($match_pound[1])) $doi = $match_pound[1]; // lose #pages and such
       }

--- a/Template.php
+++ b/Template.php
@@ -930,6 +930,7 @@ final class Template {
         }
         return FALSE;  // URL matched existing DOI, so we did not use it
       }
+      if (strpos($doi, '10.1093/law:epil') === 0) return FALSE; // Those do not work
       if (preg_match('~(.*)(?:#[^#]+)$~', $doi, $match_pound)) {
         if(!doi_active($doi) && doi_active($match_pound[1])) $doi = $match_pound[1]; // lose #pages and such
       }

--- a/Template.php
+++ b/Template.php
@@ -931,6 +931,7 @@ final class Template {
         return FALSE;  // URL matched existing DOI, so we did not use it
       }
       if (strpos($doi, '10.1093/law:epil') === 0) return FALSE; // Those do not work
+      if (strpos($doi, '10.1093/oi/authority') === 0) return FALSE; // Those do not work
       if (preg_match('~(.*)(?:#[^#]+)$~', $doi, $match_pound)) {
         if(!doi_active($doi) && doi_active($match_pound[1])) $doi = $match_pound[1]; // lose #pages and such
       }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -80,6 +80,11 @@ final class TemplateTest extends testBaseClass {
     $expanded = $this->process_citation($text);
     $this->assertNotNull($expanded->get('doi-broken-date'));
     $this->assertNotNull($expanded->get('url'));
+   // Newer code does not even add it
+    $text = '{{cite journal|url=http://opil.ouplaw.com/view/10.1093/law:epil/9780199231690/law-9780199231690-e1301}}';
+    $expanded = $this->process_citation($text);
+    $this->assertNull($expanded->get('doi'));
+    $this->assertNotNull($expanded->get('url'));
   }
   
   public function testBrokenDoiUrlChanges() {


### PR DESCRIPTION
These dois never resolve
http://opil.ouplaw.com/view/10.1093/law:epil/9780199231690/law-9780199231690-e1301 and such

http://oxfordindex.oup.com/view/10.1093/oi/authority.20110803095840253?rskey=mH20Zr&result=0&q=gagan
also lead to DOIs the never work

I think I just manually removed all these from wikipedia

These are also 10.1093 DOIs like the other pull, but these do not truncate to anything that resolves.