### PR TITLE
process() - little pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Class files:
 * `Page.php`: Represents an individual page to expand citations on. Key methods are
   `Page::get_text_from()`, `Page::expand_text()`, and `Page::write()`.
 * `Template.php`: most of the actual expansion happens here.
-  `Template::process()` handles some of template expansion and checking;
   `Template::add_if_new()` is generally (but not always) used to add
    parameters to the updated template; `Template::tidy()` cleans up the
    template, but may add parameters as well and have side effects.

--- a/Template.php
+++ b/Template.php
@@ -4,7 +4,6 @@
  * parsing, handling, and expansion.
  *
  * Of particular note:
- *     process() is what handles the different cite/Cite templates differently.
  *     add_if_new() is generally called to add or sometimes overwrite parameters. The central
  *       switch statement handles various parameters differently.
  *     
@@ -2044,7 +2043,6 @@ final class Template {
           $this->param[$param_key]->param = 'url';
           if (stripos($p->val, 'books.google.') !== FALSE) {
             $this->change_name_to('cite book');
-            $this->process();
           }
         } elseif ($p->param == 'doix') {
           report_add("Found unincorporated DOI parameter");

--- a/user_messages.php
+++ b/user_messages.php
@@ -1,11 +1,11 @@
 <?php
   
 function html_echo($text, $alternate_text='') {
-  if (TRUE || !getenv('TRAVIS')) echo HTML_OUTPUT ? $text : $alternate_text;
+  if (!getenv('TRAVIS')) echo HTML_OUTPUT ? $text : $alternate_text;
 }
 
 function user_notice($symbol, $class, $text) {
-  if (TRUE || !getenv('TRAVIS')) {
+  if (!getenv('TRAVIS')) {
     echo "\n " . (HTML_OUTPUT ? "<span class='$class'>" : "")
      . "$symbol $text" . (HTML_OUTPUT ? "</span>" : "");
   }
@@ -20,7 +20,7 @@ function report_warning($text) { user_notice("  !", "warning", $text); }
 function report_modification($text) { user_notice("  ~", "changed", $text); }
 function report_add($text) { user_notice("  +", "added", $text); }
 function report_forget($text) { user_notice("  -", "removed", $text); }
-function report_inline($text) { if (TRUE || !getenv('TRAVIS')) echo " $text"; }
+function report_inline($text) { if (!getenv('TRAVIS')) echo " $text"; }
 
 function quietly($function = report_info, $text) {
   if (defined('VERBOSE') || HTML_OUTPUT ) {

--- a/user_messages.php
+++ b/user_messages.php
@@ -1,11 +1,11 @@
 <?php
   
 function html_echo($text, $alternate_text='') {
-  if (!getenv('TRAVIS')) echo HTML_OUTPUT ? $text : $alternate_text;
+  if (TRUE || !getenv('TRAVIS')) echo HTML_OUTPUT ? $text : $alternate_text;
 }
 
 function user_notice($symbol, $class, $text) {
-  if (!getenv('TRAVIS')) {
+  if (TRUE || !getenv('TRAVIS')) {
     echo "\n " . (HTML_OUTPUT ? "<span class='$class'>" : "")
      . "$symbol $text" . (HTML_OUTPUT ? "</span>" : "");
   }
@@ -20,7 +20,7 @@ function report_warning($text) { user_notice("  !", "warning", $text); }
 function report_modification($text) { user_notice("  ~", "changed", $text); }
 function report_add($text) { user_notice("  +", "added", $text); }
 function report_forget($text) { user_notice("  -", "removed", $text); }
-function report_inline($text) { if (!getenv('TRAVIS')) echo " $text"; }
+function report_inline($text) { if (TRUE || !getenv('TRAVIS')) echo " $text"; }
 
 function quietly($function = report_info, $text) {
   if (defined('VERBOSE') || HTML_OUTPUT ) {


### PR DESCRIPTION
If that little call to process() is still needed, then we need to think about why we do not do it every time we change to cite book.  

Secondly, if for some reason this call is needed, then probably best to just inline the parts that matter instead of calling process(), which calls prepare() and bunch of other stuff.

This is just part of the "process() - big pull" pull, in case you want something smaller