### PR TITLE
add support for proxy jstor urls

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -924,8 +924,8 @@ final class Template {
       }
     }
    
-    if (preg_match('~^(https?://(?:www\.|)jstor\.org/)(?:stable|discover)/10.2307/(.+)$~i', $url, $matches)) {
-       $url = $matches[1] . 'stable/' . $matches[2] ; // that is default.  This also means we get jstor not doi
+    if (preg_match('~^(https?://(?:www\.|)jstor\.org)(?:\S*proxy\S*/|/)(?:stable|discover)/10.2307/(.+)$~i', $url, $matches)) {
+       $url = $matches[1] . '/stable/' . $matches[2] ; // that is default.  This also means we get jstor not doi
        if (!is_null($url_sent)) {
          $this->set($url_type, $url); // Update URL with cleaner one.  Will probably call forget on it below
        }

--- a/tests/phpunit/apiFunctionsTest.php
+++ b/tests/phpunit/apiFunctionsTest.php
@@ -44,7 +44,7 @@ final class apiFunctionsTest extends testBaseClass {
   public function testExpansion_doi_not_from_crossref() {
      $text = '{{Cite journal| doi= 10.13140/RG.2.1.1002.9609}}';
      $expanded = $this->process_citation($text);
-     $this->assertEquals('Lesson Study as a form of in-School Professional Development', $expanded->get('title'));
+     $this->asser tEquals('Lesson Study as a form of in-School Professional Development', $expanded->get('title'));
      $this->assertEquals('2015', $expanded->get('year'));
    }
 }


### PR DESCRIPTION
For some reason, jstor urls are very prone to having a proxy in them