### PR TITLE
cite arXiv does not support some parameters

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2527,6 +2527,7 @@ final class Template {
     && $new_name != $this->wikiname()
     ) {
       if ($new_name === 'cite arxiv') {
+        if (!$this->blank(['website','displayauthors','display-authors','access-date','accessdate'])) return; // Unsupported parameters
         $new_name = 'cite arXiv';  // Without the capital X is the alias
       }
       preg_match("~^(\s*).*\b(\s*)$~", $this->name, $spacing);


### PR DESCRIPTION
Do not change to cite arXiv if it contains parameters that cite arXiv does not support 