### PR TITLE
Doi hidden in “extra”

### DIFF
--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -142,7 +142,7 @@ function expand_by_zotero(&$template, $url = NULL) {
         if (getenv('TRAVIS')) {
           fwrite(STDERR, "Unexpected data found in zotero extra. " . $result->extra);
         } else {
-          report_info("Unexpected data found in zotero extra for url " $url . "  Citation bot cannot parse. Please report. " . $result->extra);
+          report_info("Unexpected data found in zotero extra for url " . $url . "  Citation bot cannot parse. Please report. " . $result->extra);
         }
     }
   } 

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -140,9 +140,9 @@ function expand_by_zotero(&$template, $url = NULL) {
     }
     if ($result->extra !== '') {
         if (getenv('TRAVIS')) {
-          trigger_error("Unexpected data found in zotero extra. " . $result->extra);
+          fwrite(STDERR, "Unexpected data found in zotero extra. " . $result->extra);
         } else {
-          report_info("Unexpected data found in zotero extra for url ", $url, . "  Citation bot cannot parse. Please report. " . $result->extra);
+          report_info("Unexpected data found in zotero extra for url " $url . "  Citation bot cannot parse. Please report. " . $result->extra);
         }
     }
   } 

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -125,8 +125,8 @@ function expand_by_zotero(&$template, $url = NULL) {
       }
   }
   
-  if ( isset($result->extra)) { // [extra] => DOI: 10.1038/546031a has been seen in the wild
-    if (!isset($result->DOI) && preg_match('~\sdoi:\s?([^\s]+)\s~', ' ' . $result->extra . ' ', $matches) === 0) {
+  if (isset($result->extra)) { // [extra] => DOI: 10.1038/546031a has been seen in the wild
+    if (!isset($result->DOI) && preg_match('~\sdoi:\s?([^\s]+)\s~', ' ' . $result->extra . ' ', $matches)) {
       $result->DOI = trim($matches[1]);
     }
   } 

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -125,6 +125,12 @@ function expand_by_zotero(&$template, $url = NULL) {
       }
   }
   
+  if ( isset($result->extra)) { // [extra] => DOI: 10.1038/546031a
+    if (!isset($result->DOI) && stripos($result->extra, 'doi:') === 0) {
+      $result->DOI = trim(substr($result->extra, 4));
+    }
+  } 
+  
   if ( isset($result->DOI) && $template->blank('doi')) {
     $template->add_if_new('doi', $result->DOI);
     expand_by_doi($template);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -125,9 +125,9 @@ function expand_by_zotero(&$template, $url = NULL) {
       }
   }
   
-  if ( isset($result->extra)) { // [extra] => DOI: 10.1038/546031a
-    if (!isset($result->DOI) && stripos($result->extra, 'doi:') === 0) {
-      $result->DOI = trim(substr($result->extra, 4));
+  if ( isset($result->extra)) { // [extra] => DOI: 10.1038/546031a has been seen in the wild
+    if (!isset($result->DOI) && preg_match('~\sdoi:\s?([^\s]+)\s~', ' ' . $result->extra . ' ', $matches) === 0) {
+      $result->DOI = trim($matches[1]);
     }
   } 
   

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -125,10 +125,16 @@ function expand_by_zotero(&$template, $url = NULL) {
       }
   }
   
-  if (isset($result->extra)) { // Only [extra] => DOI: 10.1038/546031a has been seen in the wild
+  if (isset($result->extra)) { // [extra] => DOI: 10.1038/546031a has been seen in the wild
     if (preg_match('~\sdoi:\s?([^\s]+)\s~', ' ' . $result->extra . ' ', $matches)) {
-      if (!isset($result->DOI)) $result->DOI = trim($matches[1]);
+      if (!isset($result->DOI) && !isset($matches[2])) $result->DOI = trim($matches[1]); // Only set if only one DOI
       $result->extra = str_ireplace('doi:', '', $result->extra);
+      $result->extra = str_replace(trim($matches[1]), '', $result->extra);
+      $result->extra = trim($result->extra);
+      if (isset($matches[2])) $result->extra = ''; // Obviously not gonna parse this in any way
+    }
+    if (preg_match('~\stype:\s?([^\s]+)\s~', ' ' . $result->extra . ' ', $matches)) { // [extra] => type: dataset has been seen in the wild
+      $result->extra = str_ireplace('type:', '', $result->extra);
       $result->extra = str_replace(trim($matches[1]), '', $result->extra);
       $result->extra = trim($result->extra);
     }
@@ -136,7 +142,7 @@ function expand_by_zotero(&$template, $url = NULL) {
         if (getenv('TRAVIS')) {
           trigger_error("Unexpected data found in zotero extra. " . $result->extra);
         } else {
-          report_info("Unexpected data found in zotero extra.  Citation bot cannot parse. Please report. " . $result->extra);
+          report_info("Unexpected data found in zotero extra for url ", $url, . "  Citation bot cannot parse. Please report. " . $result->extra);
         }
     }
   } 

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -125,9 +125,19 @@ function expand_by_zotero(&$template, $url = NULL) {
       }
   }
   
-  if (isset($result->extra)) { // [extra] => DOI: 10.1038/546031a has been seen in the wild
-    if (!isset($result->DOI) && preg_match('~\sdoi:\s?([^\s]+)\s~', ' ' . $result->extra . ' ', $matches)) {
-      $result->DOI = trim($matches[1]);
+  if (isset($result->extra)) { // Only [extra] => DOI: 10.1038/546031a has been seen in the wild
+    if (preg_match('~\sdoi:\s?([^\s]+)\s~', ' ' . $result->extra . ' ', $matches)) {
+      if (!isset($result->DOI)) $result->DOI = trim($matches[1]);
+      $result->extra = str_ireplace('doi:', '', $result->extra);
+      $result->extra = str_replace(trim($matches[1]), '', $result->extra);
+      $result->extra = trim($result->extra);
+    }
+    if ($result->extra !== '') {
+        if (getenv('TRAVIS')) {
+          trigger_error("Unexpected data found in zotero extra. " . $result->extra);
+        } else {
+          report_info("Unexpected data found in zotero extra.  Citation bot cannot parse. Please report. " . $result->extra);
+        }
     }
   } 
   

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -89,27 +89,14 @@ final class PageTest extends testBaseClass {
   }
  
   public function testBadPage() {  // Use this when debugging pages that crash the bot
-    $bad_page = "Vietnam_War"; //  Replace with something like "Vietnam_War" when debugging
+    $bad_page = ""; //  Replace with something like "Vietnam_War" when debugging
     if ($bad_page !== "") {
       $text = file_get_contents('https://en.wikipedia.org/w/index.php?title=' . $bad_page . '&action=raw');
       $page = new TestPage();
       $page->parse_text($text);
       $page->expand_text();
+      $this->assertTrue(FALSE);
     }
-    $bad_page = "List_of_centenarians_(musicians,_composers_and_music_patrons)"; //  Replace with something like "Vietnam_War" when debugging
-    if ($bad_page !== "") {
-      $text = file_get_contents('https://en.wikipedia.org/w/index.php?title=' . $bad_page . '&action=raw');
-      $page = new TestPage();
-      $page->parse_text($text);
-      $page->expand_text();
-    }
-    $bad_page = "Genetic_studies_on_Turkish_people"; //  Replace with something like "Vietnam_War" when debugging
-    if ($bad_page !== "") {
-      $text = file_get_contents('https://en.wikipedia.org/w/index.php?title=' . $bad_page . '&action=raw');
-      $page = new TestPage();
-      $page->parse_text($text);
-      $page->expand_text();
-    }
-    $this->assertTrue(FALSE);
+    $this->assertTrue(TRUE);
   }
 }

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -95,8 +95,21 @@ final class PageTest extends testBaseClass {
       $page = new TestPage();
       $page->parse_text($text);
       $page->expand_text();
-      $this->assertTrue(FALSE); // prevent us from git committing with a website included
     }
-    $this->assertTrue(TRUE);
+    $bad_page = "List_of_centenarians_(musicians,_composers_and_music_patrons)"; //  Replace with something like "Vietnam_War" when debugging
+    if ($bad_page !== "") {
+      $text = file_get_contents('https://en.wikipedia.org/w/index.php?title=' . $bad_page . '&action=raw');
+      $page = new TestPage();
+      $page->parse_text($text);
+      $page->expand_text();
+    }
+    $bad_page = "Genetic_studies_on_Turkish_people"; //  Replace with something like "Vietnam_War" when debugging
+    if ($bad_page !== "") {
+      $text = file_get_contents('https://en.wikipedia.org/w/index.php?title=' . $bad_page . '&action=raw');
+      $page = new TestPage();
+      $page->parse_text($text);
+      $page->expand_text();
+    }
+    $this->assertTrue(FALSE);
   }
 }

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -89,7 +89,7 @@ final class PageTest extends testBaseClass {
   }
  
   public function testBadPage() {  // Use this when debugging pages that crash the bot
-    $bad_page = ""; //  Replace with something like "Vietnam_War" when debugging
+    $bad_page = "Vietnam_War"; //  Replace with something like "Vietnam_War" when debugging
     if ($bad_page !== "") {
       $text = file_get_contents('https://en.wikipedia.org/w/index.php?title=' . $bad_page . '&action=raw');
       $page = new TestPage();

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -95,7 +95,7 @@ final class PageTest extends testBaseClass {
       $page = new TestPage();
       $page->parse_text($text);
       $page->expand_text();
-      $this->assertTrue(FALSE);
+      $this->assertTrue(FALSE); // prevent us from git committing with a website included
     }
     $this->assertTrue(TRUE);
   }


### PR DESCRIPTION
Some translators just dump stuff in "extra". 
Error checking and data verification done.
@ms609 changes made to guarantee only do this if one DOI.