### PR TITLE
Prefer values over empty strings

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2058,6 +2058,11 @@ final class Template {
       if ($par->param && isset($param_occurrences[$par->param])) {
         $duplicate_pos = $param_occurrences[$par->param];
         array_unshift($duplicated_parameters, $duplicate_pos);
+        if ($par->val === '') {  // If one of them is blank, then get rid of it instead of flagging as DUPLICATE_ - we do this by tricking the later code into thinking they are the same
+          $par->val = $this->param[$duplicate_pos]->val;
+        } elseif ($this->param[$duplicate_pos]->val === '') {
+          $this->param[$duplicate_pos]->val = $par->val;
+        }
         array_unshift($duplicate_identical, ($par->val == $this->param[$duplicate_pos]->val));
       }
       $param_occurrences[$par->param] = $pointer;

--- a/Template.php
+++ b/Template.php
@@ -2056,13 +2056,13 @@ final class Template {
     
     foreach ($this->param as $pointer => $par) {
       if ($par->param && isset($param_occurrences[$par->param])) {
-        if ($this->val === '') {
-          unset($par);  // If second one is blank, then just forget it
+        $duplicate_pos = $param_occurrences[$par->param];
+        if ($par->val === '') {
+          unset($par);  // If new one is blank, then just forget it
         } elseif ($this->param[$duplicate_pos]->val === '') {
           $this->param[$duplicate_pos]->val = $par->val; // If first one is blank, then copy value to it
           unset($par); // And then forget second one
         } else {
-          $duplicate_pos = $param_occurrences[$par->param];
           array_unshift($duplicated_parameters, $duplicate_pos);
           array_unshift($duplicate_identical, ($par->val == $this->param[$duplicate_pos]->val));
         }

--- a/Template.php
+++ b/Template.php
@@ -2058,16 +2058,14 @@ final class Template {
       if ($par->param && isset($param_occurrences[$par->param])) {
         $duplicate_pos = $param_occurrences[$par->param];
         if ($par->val === '') {
-          unset($pointer);  // If new one is blank, then just forget it
+          $par->val = $this->param[$duplicate_pos]->val;
         } elseif ($this->param[$duplicate_pos]->val === '') {
-          $this->param[$duplicate_pos]->val = $par->val; // If first one is blank, then copy value to it
-          unset($pointer); // And then forget second one
-        } else {
-          array_unshift($duplicated_parameters, $duplicate_pos);
-          array_unshift($duplicate_identical, ($par->val == $this->param[$duplicate_pos]->val));
+          $this->param[$duplicate_pos]->val = $par->val;
         }
+        array_unshift($duplicated_parameters, $duplicate_pos);
+        array_unshift($duplicate_identical, ($par->val == $this->param[$duplicate_pos]->val));
       }
-      if (isset($pointer)) $param_occurrences[$par->param] = $pointer;
+      $param_occurrences[$par->param] = $pointer;
     }
     
     $n_dup_params = count($duplicated_parameters);

--- a/Template.php
+++ b/Template.php
@@ -2058,16 +2058,16 @@ final class Template {
       if ($par->param && isset($param_occurrences[$par->param])) {
         $duplicate_pos = $param_occurrences[$par->param];
         if ($par->val === '') {
-          unset($par);  // If new one is blank, then just forget it
+          unset($pointer);  // If new one is blank, then just forget it
         } elseif ($this->param[$duplicate_pos]->val === '') {
           $this->param[$duplicate_pos]->val = $par->val; // If first one is blank, then copy value to it
-          unset($par); // And then forget second one
+          unset($pointer); // And then forget second one
         } else {
           array_unshift($duplicated_parameters, $duplicate_pos);
           array_unshift($duplicate_identical, ($par->val == $this->param[$duplicate_pos]->val));
         }
       }
-      if (isset($par)) $param_occurrences[$par->param] = $pointer;
+      if (isset($pointer)) $param_occurrences[$par->param] = $pointer;
     }
     
     $n_dup_params = count($duplicated_parameters);

--- a/Template.php
+++ b/Template.php
@@ -2067,7 +2067,7 @@ final class Template {
           array_unshift($duplicate_identical, ($par->val == $this->param[$duplicate_pos]->val));
         }
       }
-      $param_occurrences[$par->param] = $pointer;
+      if (isset($par)) $param_occurrences[$par->param] = $pointer;
     }
     
     $n_dup_params = count($duplicated_parameters);

--- a/Template.php
+++ b/Template.php
@@ -2056,14 +2056,16 @@ final class Template {
     
     foreach ($this->param as $pointer => $par) {
       if ($par->param && isset($param_occurrences[$par->param])) {
-        $duplicate_pos = $param_occurrences[$par->param];
-        array_unshift($duplicated_parameters, $duplicate_pos);
-        if ($par->val === '') {  // If one of them is blank, then get rid of it instead of flagging as DUPLICATE_ - we do this by tricking the later code into thinking they are the same
-          $par->val = $this->param[$duplicate_pos]->val;
+        if ($this->val === '') {
+          unset($par);  // If second one is blank, then just forget it
         } elseif ($this->param[$duplicate_pos]->val === '') {
-          $this->param[$duplicate_pos]->val = $par->val;
+          $this->param[$duplicate_pos]->val = $par->val; // If first one is blank, then copy value to it
+          unset($par); // And then forget second one
+        } else {
+          $duplicate_pos = $param_occurrences[$par->param];
+          array_unshift($duplicated_parameters, $duplicate_pos);
+          array_unshift($duplicate_identical, ($par->val == $this->param[$duplicate_pos]->val));
         }
-        array_unshift($duplicate_identical, ($par->val == $this->param[$duplicate_pos]->val));
       }
       $param_occurrences[$par->param] = $pointer;
     }

--- a/Template.php
+++ b/Template.php
@@ -2078,7 +2078,7 @@ final class Template {
       } else {
         $this->param[$duplicated_parameters[$i]]->param = str_replace('DUPLICATE_DUPLICATE_', 'DUPLICATE_', 'DUPLICATE_' . $this->param[$duplicated_parameters[$i]]->param);
         report_modification("Marking duplicate parameter: " .
-          echoable($duplicated_parameters[$i]->param));
+          echoable($this->param[$duplicated_parameters[$i]]->param));
       }
     }
     

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1565,6 +1565,28 @@ ER -  }}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('2006', $expanded->get('year'));
   }
+ 
+  public function testDuplicateParametersFlagging() {
+    $text = '{{cite web|year=2010|year=2011}}';
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('2011', $expanded->get('year'));
+    $this->assertEquals('2010', $expanded->get('DUPLICATE_year'));
+    $text = '{{cite web|year=|year=2011}}';
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('2011', $expanded->get('year'));
+    $this->assertNull($expanded->get('DUPLICATE_year'));
+    $text = '{{cite web|year=2011|year=}}';
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('2011', $expanded->get('year'));
+    $this->assertNull($expanded->get('DUPLICATE_year'));
+    $text = '{{cite web|year=|year=|year=2011|year=|year=}}';
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('2011', $expanded->get('year'));
+    $this->assertNull($expanded->get('DUPLICATE_year'));
+    $text = '{{cite web|year=|year=|year=|year=|year=}}';
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('{{cite web|year=}}', $expanded->parsed_text());
+  }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors
   Test finding a DOI and using it to expand a paper [See testLongAuthorLists - Arxiv example?]


### PR DESCRIPTION
Current code always uses last value seen as valid value -- so viewed citation is unchanged.
