### PR TITLE
do not add urls from dx.doi.org or JSTOR

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1630,7 +1630,7 @@ final class Template {
     }
   }
   
-  public function expand_by_RIS(&$dat) { // Pass by pointer to wipe this data when called from use_unnamed_params()
+  public function expand_by_RIS(&$dat, $add_url) { // Pass by pointer to wipe this data when called from use_unnamed_params()
     $ris_review    = FALSE;
     $ris_issn      = FALSE;
     $ris_publisher = FALSE;
@@ -1711,7 +1711,7 @@ final class Template {
       }
       unset($ris_part[0]);
       if ($ris_parameter
-              && $this->add_if_new($ris_parameter, trim(implode($ris_part)))
+              && (($ris_parameter=='url' && !$add_url) || $this->add_if_new($ris_parameter, trim(implode($ris_part))))
           ) {
         $dat = trim(str_replace("\n$ris_line", "", "\n$dat"));
       }
@@ -2151,7 +2151,7 @@ final class Template {
       }
 
       if (preg_match("~^TY\s+-\s+[A-Z]+~", $dat)) { // RIS formatted data:
-        $this->expand_by_RIS($dat);
+        $this->expand_by_RIS($dat, TRUE);
       }
       
       $doi = extract_doi($dat);

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -457,7 +457,7 @@ function expand_doi_with_dx($template, $doi) {
        return FALSE;
      }
      report_action("Querying dx.doi.org: doi:" . doi_link($doi));
-     $template->expand_by_RIS($ris);
+     $template->expand_by_RIS($ris, FALSE);
      return TRUE;
 }
 
@@ -510,7 +510,7 @@ function expand_by_jstor($template) {
     return FALSE;
   }
   $has_a_url = $template->has('url');
-  $template->expand_by_RIS($dat);
+  $template->expand_by_RIS($dat, FALSE);
   if ($template->has('url') && !$has_a_url) { // we added http://www.jstor.org/stable/12345, so remove quietly
       $template->quietly_forget('url');
   }


### PR DESCRIPTION
Exising calls to dx.doi.org can result in a URL, that exactly matches the one that the doi directs to of course.