### PR TITLE
Remove outdated template clutter

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2747,7 +2747,7 @@ final class Template {
             $this->forget('format');
           }
           // Citation templates do this automatically -- also remove if there is no url, which is template error
-          if (in_array(strtolower($this->get($param)), ['pdf', 'portable document format', '[[portable document format|pdf]]']) {
+          if (in_array(strtolower($this->get($param)), ['pdf', 'portable document format', '[[portable document format|pdf]]', '[[portable document format]]']) {
             if ($this->blank('url') || substr($this->get('url'), -4) === '.pdf' || substr($this->get('url'), -4) === '.PDF') {
                $this->forget('format');
             }

--- a/Template.php
+++ b/Template.php
@@ -2744,13 +2744,36 @@ final class Template {
           if ($this->get($param) === 'Accepted manuscript' ||
               $this->get($param) === 'Submitted manuscript' ||
               $this->get($param) === 'Full text') {
-            $this->forget('format');
+            $this->forget($param);
           }
           // Citation templates do this automatically -- also remove if there is no url, which is template error
           if (in_array(strtolower($this->get($param)), ['pdf', 'portable document format', '[[portable document format|pdf]]', '[[portable document format]]'])) {
             if ($this->blank('url') || substr($this->get('url'), -4) === '.pdf' || substr($this->get('url'), -4) === '.PDF') {
-               $this->forget('format');
+               $this->forget($param);
             }
+          }
+          return;
+          
+        case 'chapter-format':
+        // clean up bot's old (pre-2018-09-18) edits
+          if ($this->get($param) === 'Accepted manuscript' ||
+              $this->get($param) === 'Submitted manuscript' ||
+              $this->get($param) === 'Full text') {
+            $this->forget($param);
+          }
+          // Citation templates do this automatically -- also remove if there is no url, which is template error
+          if (in_array(strtolower($this->get($param)), ['pdf', 'portable document format', '[[portable document format|pdf]]', '[[portable document format]]'])) {
+             if ($this->has('chapter-url')) {
+               if (substr($this->get('chapter-url'), -4) === '.pdf' || substr($this->get('chapter-url'), -4) === '.PDF') {
+                 $this->forget($param);
+               }
+             } elseif ($this->has('chapterurl')) {
+               if (substr($this->get('chapterurl'), -4) === '.pdf' || substr($this->get('chapterurl'), -4) === '.PDF') {
+                 $this->forget($param);
+               }
+             } else {
+               $this->forget($param); // Has no chapter URL at all
+             }
           }
           return;
           

--- a/Template.php
+++ b/Template.php
@@ -2747,7 +2747,7 @@ final class Template {
             $this->forget('format');
           }
           // Citation templates do this automatically -- also remove if there is no url, which is template error
-          if (in_array(strtolower($this->get($param)), ['pdf', 'portable document format', '[[portable document format|pdf]]', '[[portable document format]]']) {
+          if (in_array(strtolower($this->get($param)), ['pdf', 'portable document format', '[[portable document format|pdf]]', '[[portable document format]]'])) {
             if ($this->blank('url') || substr($this->get('url'), -4) === '.pdf' || substr($this->get('url'), -4) === '.PDF') {
                $this->forget('format');
             }

--- a/Template.php
+++ b/Template.php
@@ -2746,6 +2746,12 @@ final class Template {
               $this->get($param) === 'Full text') {
             $this->forget('format');
           }
+          // Citation templates do this automatically -- also remove if there is no url, which is template error
+          if (in_array(strtolower($this->get($param)), ['pdf', 'portable document format', '[[portable document format|pdf]]']) {
+            if ($this->blank('url') || substr($this->get('url'), -4) === '.pdf' || substr($this->get('url'), -4) === '.PDF') {
+               $this->forget('format');
+            }
+          }
           return;
           
         case 'isbn':

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -271,14 +271,14 @@ final class TemplateTest extends testBaseClass {
   }
   
   public function testTemplateRenamingURLConvert() {
-    $text='{{cite journal |url=http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf |title=Terrestrialization (Precambrian–Devonian) |last=Selden |first=Paul A. |year=2005 |encyclopedia=[[Encyclopedia of Life Sciences]] |publisher=[[John Wiley & Sons, Ltd.]] |doi=10.1038/npg.els.0004145 |format=PDF}}';
+    $text='{{cite journal |url=http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf |title=Terrestrialization (Precambrian–Devonian) |last=Selden |first=Paul A. |year=2005 |encyclopedia=[[Encyclopedia of Life Sciences]] |publisher=[[John Wiley & Sons, Ltd.]] |doi=10.1038/npg.els.0004145 |format=DUDE}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0470016176', $expanded->get('isbn'));
     $this->assertEquals('cite book', $expanded->wikiname());
     $this->assertEquals('http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf', $expanded->get('chapter-url'));
     $this->assertNull($expanded->get('url'));
     $this->assertNull($expanded->get('format'));
-    $this->assertEquals('PDF', $expanded->get('chapter-format'));
+    $this->assertEquals('DUDE', $expanded->get('chapter-format'));
     $text='{{Cite book|url=http://www.sciencedirect.com/science/article/pii/B9780123864543000129|title=Encyclopedia of Toxicology (Third Edition)|last=Roberts|first=L.|date=2014|publisher=Academic Press|isbn=978-0-12-386455-0|editor-last=Wexler|editor-first=Philip|location=Oxford|pages=993–995|doi=10.1016/b978-0-12-386454-3.00012-9}}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('http://www.sciencedirect.com/science/article/pii/B9780123864543000129', $expanded->get('chapter-url'));


### PR DESCRIPTION
CS1 and CS2 templates detect .PDF and .pdf and automatically set the format.

The linking to PDF wikipage is silly too

Also, the format= item only applies to URLs, not chapter-urls, etc.

And yes there was a discussion about this on wikipedia

Had to change  |format=PDF to  |format=DUDE in a test to keep it from being deleted!