### PR TITLE
Fix regex out of memory errors

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -302,22 +302,25 @@ class Page {
   public function extract_object($class) {
     $i = 0;
     $text = $this->text;
-    $regexp = $class::REGEXP;
+    $regexp_in = $class::REGEXP;
     $placeholder_text = $class::PLACEHOLDER_TEXT;
     $treat_identical_separately = $class::TREAT_IDENTICAL_SEPARATELY;
     $objects = array();
+    if (!is_array($regexp_in)) $regexp_in = [$regexp_in];
     
-    $preg_ok = TRUE;
-    while ($preg_ok = preg_match($regexp, $text, $match)) {
-      $obj = new $class();
-      $obj->parse_text($match[0]);
-      $exploded = $treat_identical_separately ? explode($match[0], $text, 2) : explode($match[0], $text);
-      $text = implode(sprintf($placeholder_text, $i++), $exploded);
-      $objects[] = $obj;
-    }
-    if ($preg_ok === FALSE) {
-       // PHP 5 segmentation faults in preg_match when it fails.  PHP 7 returns FALSE.
-       trigger_error('Regular expression failure in ' . htmlspecialchars($this->title) . ' when extracting ' . $class . 's', E_USER_ERROR);
+    foreach ($regexp_in as $regexp) {
+      $preg_ok = TRUE;
+      while ($preg_ok = preg_match($regexp, $text, $match)) {
+        $obj = new $class();
+        $obj->parse_text($match[0]);
+        $exploded = $treat_identical_separately ? explode($match[0], $text, 2) : explode($match[0], $text);
+        $text = implode(sprintf($placeholder_text, $i++), $exploded);
+        $objects[] = $obj;
+      }
+      if ($preg_ok === FALSE) {
+        // PHP 5 segmentation faults in preg_match when it fails.  PHP 7 returns FALSE.
+        trigger_error('Regular expression failure in ' . htmlspecialchars($this->title) . ' when extracting ' . $class . 's', E_USER_ERROR);
+      }
     }
     $this->text = $text;
     return $objects;

--- a/Template.php
+++ b/Template.php
@@ -16,7 +16,7 @@ require_once("Parameter.php");
 
 final class Template {
   const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_TEMPLATE %s # # #';
-  const REGEXP = '~\{\{(?>[^\{]|\{[^\{])+?\}\}~su';  // Please see https://stackoverflow.com/questions/1722453/need-to-prevent-php-regex-segfault for discussion of atomic regex
+  const REGEXP = const REGEXP = ['~\{\{[^\{\}\|]+\}\}~su', '~\{\{[^\{\}]+\}\}~su', '~\{\{(?>[^\{]|\{[^\{])+?\}\}~su'];  // Please see https://stackoverflow.com/questions/1722453/need-to-prevent-php-regex-segfault for discussion of atomic regex
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   public $all_templates;  // Points to list of all the Template() on the Page() including this one
   public $date_style = DATES_WHATEVER;  // Will get from the page

--- a/Template.php
+++ b/Template.php
@@ -16,7 +16,7 @@ require_once("Parameter.php");
 
 final class Template {
   const PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_TEMPLATE %s # # #';
-  const REGEXP = const REGEXP = ['~\{\{[^\{\}\|]+\}\}~su', '~\{\{[^\{\}]+\}\}~su', '~\{\{(?>[^\{]|\{[^\{])+?\}\}~su'];  // Please see https://stackoverflow.com/questions/1722453/need-to-prevent-php-regex-segfault for discussion of atomic regex
+  const REGEXP = ['~\{\{[^\{\}\|]+\}\}~su', '~\{\{[^\{\}]+\}\}~su', '~\{\{(?>[^\{]|\{[^\{])+?\}\}~su'];  // Please see https://stackoverflow.com/questions/1722453/need-to-prevent-php-regex-segfault for discussion of atomic regex
   const TREAT_IDENTICAL_SEPARATELY = FALSE;
   public $all_templates;  // Points to list of all the Template() on the Page() including this one
   public $date_style = DATES_WHATEVER;  // Will get from the page


### PR DESCRIPTION
By using a couple Regex to sneak up on the real one, we are able to avoid out of memory errors.  We first look for templates with no set braces or pipes, then ones with no set braces, and finally the full Regex.   The fewer templates to find and the fewer extraneous {  and } floating around the less memory the final Regex needs.

Fixes Deim_Zubeir