### PR TITLE
Avoid returning "0" as page number/range

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -184,7 +184,7 @@ final class Template {
   }
   
   public function process() { // This code used to be the core of the Citation Bot, now it is only used by generate_template.php
-    if ($this->should_be_processed()) {  // This code is "tested" in testEmptyCitations()
+    if ($this->should_be_processed()) {  // This code is "tested" in testE mptyCitations()
       $this->prepare(); // This routine does much of the work, since incoming templates are always {{cite web}}
 
       switch ($this->wikiname()) {

--- a/Template.php
+++ b/Template.php
@@ -697,7 +697,7 @@ final class Template {
       return FALSE;
       
       case "page": case "pages":
-        if(in_array((string) $value, ['0', '0-0', '0–0'], TRUE) return FALSE;  // Reject bogus zero page number
+        if(in_array((string) $value, ['0', '0-0', '0–0'], TRUE)) return FALSE;  // Reject bogus zero page number
         if ($this->has('at')) return FALSE;  // Leave at= alone.  People often use that for at=See figure 17 on page......
         $pages_value = $this->get('pages');
         $all_page_values = $pages_value . $this->get("page") . $this->get("pp") . $this->get("p") . $this->get('at');

--- a/Template.php
+++ b/Template.php
@@ -3434,6 +3434,7 @@ final class Template {
   public function name() {return trim($this->name);}
 
   protected function page_range() {
+    if ($this->page() === "0-0") return NULL;
     preg_match("~(\w?\w?\d+\w?\w?)(?:\D+(\w?\w?\d+\w?\w?))?~", $this->page(), $pagenos);
     return $pagenos;
   }

--- a/Template.php
+++ b/Template.php
@@ -697,6 +697,7 @@ final class Template {
       return FALSE;
       
       case "page": case "pages":
+        if(in_array((string) $value, ['0', '0-0', '0–0'], TRUE) return FALSE;  // Reject bogus zero page number
         if ($this->has('at')) return FALSE;  // Leave at= alone.  People often use that for at=See figure 17 on page......
         $pages_value = $this->get('pages');
         $all_page_values = $pages_value . $this->get("page") . $this->get("pp") . $this->get("p") . $this->get('at');
@@ -3434,7 +3435,6 @@ final class Template {
   public function name() {return trim($this->name);}
 
   protected function page_range() {
-    if ($this->page() === "0-0") return NULL;
     preg_match("~(\w?\w?\d+\w?\w?)(?:\D+(\w?\w?\d+\w?\w?))?~", $this->page(), $pagenos);
     return $pagenos;
   }

--- a/Template.php
+++ b/Template.php
@@ -697,7 +697,7 @@ final class Template {
       return FALSE;
       
       case "page": case "pages":
-        if(in_array((string) $value, ['0', '0-0', '0–0'], TRUE)) return FALSE;  // Reject bogus zero page number
+        if (in_array((string) $value, ['0', '0-0', '0–0'], TRUE)) return FALSE;  // Reject bogus zero page number
         if ($this->has('at')) return FALSE;  // Leave at= alone.  People often use that for at=See figure 17 on page......
         $pages_value = $this->get('pages');
         $all_page_values = $pages_value . $this->get("page") . $this->get("pp") . $this->get("p") . $this->get('at');

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1571,14 +1571,6 @@ ER -  }}';
     $this->assertEquals('222', $prepared->get('number'));
     $this->assertEquals('12(44-33)', $prepared->get('volume'));
   }
-    
-  public function testBibcodeBook() {
-    $this->requires_secrets(function() {
-      $text = '{{cite book|bibcode=2003hoe..book.....K}}';
-      $expanded = $this->process_citation($text);
-      $this->assertEquals('{{cite book|bibcode=2003hoe..book.....K|year=2003|title=Hands-On Electronics|last1=Kaplan|first1=Daniel M.|last2=White|first2=Christopher G.}}', $expanded->parsed_text());
-    });
-  }
  
   public function testSpaces() {
       // None of the "spaces" in $text are normal spaces.  They are U+2000 to U+200A

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -592,12 +592,14 @@ final class TemplateTest extends testBaseClass {
   }
   
   public function testBibcodesBooks() {
-    $text = "{{Cite book|bibcode=1982mcts.book.....H}}";
-    $expanded = $this->process_citation($text);
-    $this->assertEquals('1982', $expanded->get('year'));
-    $this->assertEquals('Houk', $expanded->get('last1'));
-    $this->assertEquals('N.', $expanded->get('first1'));
-    $this->assertNotNull($expanded->get('title'));
+    $this->requires_secrets(function() {
+      $text = "{{Cite book|bibcode=1982mcts.book.....H}}";
+      $expanded = $this->process_citation($text);
+      $this->assertEquals('1982', $expanded->get('year'));
+      $this->assertEquals('Houk', $expanded->get('last1'));
+      $this->assertEquals('N.', $expanded->get('first1'));
+      $this->assertNotNull($expanded->get('title'));
+    });
   }
  
   public function testParameterAlias() {
@@ -1571,9 +1573,11 @@ ER -  }}';
   }
     
   public function testBibcodeBook() {
+    $this->requires_secrets(function() {
       $text = '{{cite book|bibcode=2003hoe..book.....K}}';
       $expanded = $this->process_citation($text);
       $this->assertEquals('{{cite book|bibcode=2003hoe..book.....K|year=2003|title=Hands-On Electronics|last1=Kaplan|first1=Daniel M.|last2=White|first2=Christopher G.}}', $expanded->parsed_text());
+    });
   }
  
   public function testSpaces() {


### PR DESCRIPTION
Example:
https://en.wikipedia.org/?diff=878079480

Coming from `"page":"0-0"` in:
https://api.crossref.org/works/10.1111/j.1755-3768.2010.4142.x