### PR TITLE
Use TRAVIS_PULL_REQUEST correctly 

### DIFF
--- a/tests/testBaseClass.php
+++ b/tests/testBaseClass.php
@@ -35,7 +35,7 @@ abstract class testBaseClass extends PHPUnit\Framework\TestCase {
   }
 
   protected function requires_secrets($function) {
-    if (getenv('TRAVIS_PULL_REQUEST')) {
+    if (getenv('TRAVIS_PULL_REQUEST') && ((string)getenv('TRAVIS_PULL_REQUEST') !== 'false')) {
       echo 'S'; // Skipping test: Risks exposing secret keys
       $this->assertNull(NULL); // Make Travis think we tested something
     } else {


### PR DESCRIPTION
this way the actual system builds do all the tests

I know that it’s a little bit closing the barn door after the horse leaves, but better than not closing at all

I guess you can think about if this is correct?

Probably bot will fail in page write test from travis.