### PR TITLE
Switch Zotero to HTTPS and reduce timeout

### DIFF
--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -37,7 +37,7 @@ function zotero_request($url) {
   curl_setopt($ch, CURLOPT_POSTFIELDS, $url);  
   curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: text/plain']);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);   
-  if (getenv('TRAVIS') { // try harder in TRAVIS to make tests more successful and make it his zotero less often
+  if (getenv('TRAVIS')) { // try harder in TRAVIS to make tests more successful and make it his zotero less often
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
     curl_setopt($ch, CURLOPT_TIMEOUT, 45);
   } else {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -30,15 +30,15 @@ function query_url_api($ids, $templates) {
 function zotero_request($url) {
   
   #$ch = curl_init('http://' . TOOLFORGE_IP . '/translation-server/web');
-  $ch = curl_init('http://tools.wmflabs.org/translation-server/web');
+  $ch = curl_init('https://tools.wmflabs.org/translation-server/web');
   
   curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
   curl_setopt($ch, CURLOPT_USERAGENT, "Citation_bot");  
   curl_setopt($ch, CURLOPT_POSTFIELDS, $url);  
   curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: text/plain']);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);      
-  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10); 
-  curl_setopt($ch, CURLOPT_TIMEOUT, 45);
+  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1); 
+  curl_setopt($ch, CURLOPT_TIMEOUT, 5);
   
   $zotero_response = curl_exec($ch);
   if ($zotero_response === FALSE) {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -42,7 +42,7 @@ function zotero_request($url) {
     curl_setopt($ch, CURLOPT_TIMEOUT, 45);
   } else {
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 5); 
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10); 
   }
   
   $zotero_response = curl_exec($ch);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -37,9 +37,9 @@ function zotero_request($url) {
   curl_setopt($ch, CURLOPT_POSTFIELDS, $url);  
   curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: text/plain']);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);   
-  if (getenv('TRAVIS') {
+  if (getenv('TRAVIS') { // try harder in TRAVIS to make tests more successful and make it his zotero less often
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 25);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 45);
   } else {
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
     curl_setopt($ch, CURLOPT_TIMEOUT, 5); 

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -36,9 +36,14 @@ function zotero_request($url) {
   curl_setopt($ch, CURLOPT_USERAGENT, "Citation_bot");  
   curl_setopt($ch, CURLOPT_POSTFIELDS, $url);  
   curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: text/plain']);
-  curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);      
-  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1); 
-  curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);   
+  if (getenv('TRAVIS') {
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 25);
+  } else {
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 5); 
+  }
   
   $zotero_response = curl_exec($ch);
   if ($zotero_response === FALSE) {


### PR DESCRIPTION
With a hundred references and one minute per Zotero request, the job
can easily take hours. Just skip when the Zotero server is too slow.
* 1 second should be plenty to connect to a local server.
* 5 seconds is enough when the server is actually working.

https://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT.html