### PR TITLE
catch bad crossref data

### DIFF
--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -383,6 +383,7 @@ function expand_by_doi($template, $force = FALSE) {
                     || author_is_human($existing_author);
         
         foreach ($crossRef->contributors->contributor as $author) {
+          if (strtoupper($author->surname) === '&NA;') break; // No Author, leave loop now!  Have only seen upper-case in the wild
           if ($author["contributor_role"] == 'editor') {
             ++$ed_i;
             if ($ed_i < 31 && $crossRef->journal_title === NULL) {


### PR DESCRIPTION
<crossref_result xmlns="http://www.crossref.org/qrschema/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://www.crossref.org/qrschema/2.0 https://www.crossref.org/schema/crossref_query_output2.0.xsd">
<query_result>
<head>
<doi_batch_id>none</doi_batch_id>
</head>
<body>
<query status="resolved" fl_count="0">
<doi type="journal_article">10.2165/00126839-200203020-00006</doi>
<issn type="print">1174-5886</issn>
<journal_title>Drugs in R & D</journal_title>
<contributors>
<contributor sequence="first" contributor_role="author">
<surname>&NA;</surname>
</contributor>
</contributors>
<volume>3</volume>
<issue>2</issue>
<first_page>106</first_page>
<last_page>108</last_page>
<year media_type="print">2002</year>
<publication_type>full_text</publication_type>
<article_title>Lerdelimumab</article_title>
</query>
</body>
</query_result>
</crossref_result>