### PR TITLE
zotero should be done last, not before PMID etc.

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -216,13 +216,13 @@ class Page {
     
     // BATCH API CALLS
     report_phase('Consult APIs to expand templates');
-    $this->expand_templates_from_identifier('url',     $our_templates);
     $this->expand_templates_from_identifier('pmid',    $our_templates);
     $this->expand_templates_from_identifier('pmc',     $our_templates);
     $this->expand_templates_from_identifier('bibcode', $our_templates);
     $this->expand_templates_from_identifier('jstor',   $our_templates);
     $this->expand_templates_from_identifier('doi',     $our_templates);
     expand_arxiv_templates($our_templates);
+    $this->expand_templates_from_identifier('url',     $our_templates);
     
     report_phase('Expand individual templates by API calls');
     for ($i = 0; $i < count($our_templates); $i++) {


### PR DESCRIPTION
Just seem the crappiest data should be used last.
Secondly, a whole lot of the calls to zotero will be avoided with the "profoundly_incomplete()".  That might save us from most of our hangs.

Not random, this is yet another change noticed during the ISSN only DOI problems fixing