### PR TITLE
Add zotero to test name

### DIFF
--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -170,7 +170,7 @@ final class PageTest extends testBaseClass {
       $this->assertEquals('<ref>{{cite web}}</ref><ref>{{cite web}}</ref><ref>{{Cite journal | doi=10.1145/358589.358596|title = Improving computer program readability to aid modification| journal=Communications of the ACM| volume=25| issue=8| pages=512–521|year = 1982|last1 = Elshoff|first1 = James L.| last2=Marcotty| first2=Michael}}</ref>', $page->parsed_text());
   }
  
-  public function testRespectDates() {
+  public function testRespectDatesZotero() {
       $text = '{{Use mdy dates}}{{cite web|url=https://www.nasa.gov/content/profile-of-john-glenn}}';
       $page = $this->process_page($text);
       $this->assertTrue((boolean) strpos($page->parsed_text(), '12-05-2016'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -358,7 +358,7 @@ final class TemplateTest extends testBaseClass {
     $this->assertEquals('Verstraete', $expanded->get('last1'));
   }
  
-  public function testAP() {
+  public function testAP_zotero() {
     $text = '{{cite web|author=Associated Press |url=https://www.theguardian.com/science/2018/feb/03/scientists-discover-ancient-mayan-city-hidden-under-guatemalan-jungle}}';
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('author'));


### PR DESCRIPTION
This way when you have tests that fail, you easily remember that ‘stupid zotero’ instead of ‘what did I do to the dates code??’   I am getting too old to remember these things.