### PR TITLE
Don’t Remove publisher/location too early 

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -3208,7 +3208,7 @@ final class Template {
       $this->forget('doi'); // Forget DOI that is really jstor, if it is broken
       foreach (DOI_BROKEN_ALIASES as $alias) $this->forget($alias);
     }
-    if ($this->has('journal') {  // Do this at the very end of work in case we change type/etc during expansion
+    if ($this->has('journal')) {  // Do this at the very end of work in case we change type/etc during expansion
           if ($this->blank(['chapter', 'isbn', 'lccn', 'olcn'])) {
             // Avoid renaming between cite journal and cite book
             $this->change_name_to('cite journal');

--- a/Template.php
+++ b/Template.php
@@ -2853,7 +2853,8 @@ final class Template {
           
         case 'journal':
           if ($this->lacks($param)) return;
-          if ($this->blank(['chapter', 'isbn', 'lccn', 'olcn'])) { // Avoid cyclic renaming between journal and book	
+          if ($this->blank(['chapter', 'isbn'])) {
+             // Avoid renaming between cite journal and cite book
              $this->change_name_to('cite journal');
           }
           if (str_equivalent($this->get($param), $this->get('work'))) $this->forget('work');

--- a/Template.php
+++ b/Template.php
@@ -2850,15 +2850,6 @@ final class Template {
           
         case 'journal':
           if ($this->lacks($param)) return;
-          if ($this->blank(['chapter', 'isbn'])) {
-            // Avoid renaming between cite journal and cite book
-            $this->change_name_to('cite journal');
-            $this->forget('publisher');
-            $this->forget('location');
-          } else {
-            report_warning('Citation should probably not have journal = ' . $this->get('journal')
-            . ' as well as chapter / ISBN ' . $this->get('chapter') . $this->get('isbn'));
-          }
           if (str_equivalent($this->get($param), $this->get('work'))) $this->forget('work');
           // No break here: Continue on from journal into periodical
         case 'periodical':
@@ -3216,6 +3207,18 @@ final class Template {
     if (!$this->blank(DOI_BROKEN_ALIASES) && $this->has('jstor') && strpos($this->get('doi'), '10.2307') === 0) {
       $this->forget('doi'); // Forget DOI that is really jstor, if it is broken
       foreach (DOI_BROKEN_ALIASES as $alias) $this->forget($alias);
+    }
+    if ($this->has('journal') {  // Do this at the very end of work in case we change type/etc during expansion
+          if ($this->blank(['chapter', 'isbn', 'lccn', 'olcn'])) {
+            // Avoid renaming between cite journal and cite book
+            $this->change_name_to('cite journal');
+            $this->forget('publisher');
+            $this->forget('location');
+          } else {
+            report_warning('Citation should probably not have journal = ' . $this->get('journal')
+            . ' as well as chapter / ISBN / LCCN / OLCN ' . $this->get('chapter') . ' ' .  $this->get('isbn') . ' '
+            .  $this->get('lccn') . ' ' .  $this->get('olcn'));
+          }
     }
     foreach (ALL_ALIASES as $alias_list) {
       if (!$this->blank($alias_list)) { // At least one is set

--- a/Template.php
+++ b/Template.php
@@ -2854,8 +2854,8 @@ final class Template {
         case 'journal':
           if ($this->lacks($param)) return;
           if ($this->blank(['chapter', 'isbn'])) {
-             // Avoid renaming between cite journal and cite book
-             $this->change_name_to('cite journal');
+            // Avoid renaming between cite journal and cite book
+            $this->change_name_to('cite journal');
           }
           if (str_equivalent($this->get($param), $this->get('work'))) $this->forget('work');
           // No break here: Continue on from journal into periodical

--- a/Template.php
+++ b/Template.php
@@ -2850,6 +2850,9 @@ final class Template {
           
         case 'journal':
           if ($this->lacks($param)) return;
+          if ($this->blank(['chapter', 'isbn', 'lccn', 'olcn'])) { // Avoid cyclic renaming between journal and book	
+             $this->change_name_to('cite journal');
+           }
           if (str_equivalent($this->get($param), $this->get('work'))) $this->forget('work');
           // No break here: Continue on from journal into periodical
         case 'periodical':

--- a/Template.php
+++ b/Template.php
@@ -1270,7 +1270,7 @@ final class Template {
 
   public function get_doi_from_crossref() {
     if ($this->has('doi')) {
-      return $this->get_without_comments_and_placeholders('doi');
+      return $th is->get_without_comments_and_placeholders('doi');
     }
     report_action("Checking CrossRef database for doi. ");
     $data = [

--- a/Template.php
+++ b/Template.php
@@ -2852,7 +2852,7 @@ final class Template {
           if ($this->lacks($param)) return;
           if ($this->blank(['chapter', 'isbn', 'lccn', 'olcn'])) { // Avoid cyclic renaming between journal and book	
              $this->change_name_to('cite journal');
-           }
+          }
           if (str_equivalent($this->get($param), $this->get('work'))) $this->forget('work');
           // No break here: Continue on from journal into periodical
         case 'periodical':

--- a/Template.php
+++ b/Template.php
@@ -3216,15 +3216,14 @@ final class Template {
       foreach (DOI_BROKEN_ALIASES as $alias) $this->forget($alias);
     }
     if ($this->has('journal')) {  // Do this at the very end of work in case we change type/etc during expansion
-          if ($this->blank(['chapter', 'isbn', 'lccn', 'olcn'])) {
+          if ($this->blank(['chapter', 'isbn'])) {
             // Avoid renaming between cite journal and cite book
             $this->change_name_to('cite journal');
             $this->forget('publisher');
             $this->forget('location');
           } else {
             report_warning('Citation should probably not have journal = ' . $this->get('journal')
-            . ' as well as chapter / ISBN / LCCN / OLCN ' . $this->get('chapter') . ' ' .  $this->get('isbn') . ' '
-            .  $this->get('lccn') . ' ' .  $this->get('olcn'));
+            . ' as well as chapter / ISBN ' . $this->get('chapter') . ' ' .  $this->get('isbn'));
           }
     }
     foreach (ALL_ALIASES as $alias_list) {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1709,7 +1709,7 @@ ER -  }}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('10.1002/(ISSN)1099-0739', $expanded->get('doi'));
     $this->assertEquals('http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1099-0739/homepage/EditorialBoard.html', $expanded->get('url'));
-  }
+   }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors
   Test finding a DOI and using it to expand a paper [See testLongAuthorLists - Arxiv example?]

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -369,7 +369,7 @@ final class TemplateTest extends testBaseClass {
   public function testGarbageRemovalAndSpacing() {
     // Also tests handling of upper-case parameters
     $text = "{{Cite web | title=Ellipsis... | pages=10-11| Edition = 3rd ed. |journal=My Journal| issn=1234-4321 | publisher=Unwarranted |issue=0|accessdate=2013-01-01}}";
-    $prepared = $this->prepare_citation($text);
+    $prepared = $this->process_citation($text);
     // ISSN should be retained when journal is originally present
     $this->assertEquals('{{Cite journal | title=Ellipsis... | pages=10–11| edition = 3rd |journal=My Journal| issn=1234-4321 }}', $prepared->parsed_text());
     

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -375,6 +375,8 @@ final class TemplateTest extends testBaseClass {
     
     $text = "{{Cite web | Journal=My Journal| issn=1357-4321 | publisher=Unwarranted }}";
     $prepared = $this->prepare_citation($text);
+    $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 | publisher=Unwarranted }}', $prepared->parsed_text());
+    $expanded = $this->process_citation($text);
     $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 }}', $prepared->parsed_text());
   }
     
@@ -1613,7 +1615,7 @@ ER -  }}';
   
   public function testRemovePublisherWithWork() {
     $text = '{{cite journal|jstor=1148172|title=Strategic Acupuncture|work=Foreign Policy|issue=Winter 1980|pages=44–61|publisher=Washingtonpost.Newsweek Interactive, LLC|year=1980}}';
-    $expanded = $this->prepare_citation($text);
+    $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('publisher'));  
   }
     

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -377,7 +377,7 @@ final class TemplateTest extends testBaseClass {
     $prepared = $this->prepare_citation($text); // Do not drop publisher at start
     $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 | publisher=Unwarranted }}', $prepared->parsed_text());
     $expanded = $this->process_citation($text);  // Drop it at end
-    $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 }}', $prepared->parsed_text());
+    $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 }}', $expanded->parsed_text());
   }
     
   public function testPublisherRemoval() {

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -374,9 +374,9 @@ final class TemplateTest extends testBaseClass {
     $this->assertEquals('{{Cite journal | title=Ellipsis... | pages=10–11| edition = 3rd |journal=My Journal| issn=1234-4321 }}', $prepared->parsed_text());
     
     $text = "{{Cite web | Journal=My Journal| issn=1357-4321 | publisher=Unwarranted }}";
-    $prepared = $this->prepare_citation($text);
-    $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 | publisher=Unwarranted }}', $prepared->parsed_text());
-    $expanded = $this->process_citation($text);
+    $prepared = $this->prepare_citation($text); // Do not drop publisher at start
+    $this->assertEquals($text, $prepared->parsed_text());
+    $expanded = $this->process_citation($text);  // Drop it at end
     $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 }}', $prepared->parsed_text());
   }
     

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -375,7 +375,7 @@ final class TemplateTest extends testBaseClass {
     
     $text = "{{Cite web | Journal=My Journal| issn=1357-4321 | publisher=Unwarranted }}";
     $prepared = $this->prepare_citation($text); // Do not drop publisher at start
-    $this->assertEquals($text, $prepared->parsed_text());
+    $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 | publisher=Unwarranted }}', $prepared->parsed_text());
     $expanded = $this->process_citation($text);  // Drop it at end
     $this->assertEquals('{{Cite journal | journal=My Journal| issn=1357-4321 }}', $prepared->parsed_text());
   }


### PR DESCRIPTION
Current code drop location/publisher very early in the expansion process from Journals.

This code moves that to the very end (in final_tidy). 

The reason being that during the expansion, we sometimes detect that it is really a book/etc.  This way we do not drop publisher/location and then regret it when we figure out that we had a book.