### PR TITLE
Actually search Crossref for DOIs

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1286,6 +1286,7 @@ final class Template {
     ];
     
     $novel_data = FALSE;
+    foreach ($data as $key => $value) if ($value) {		
       if ($this->api_has_not_used('crossref', equivalent_parameters($key))) $novel_data = TRUE;
       $this->record_api_usage('crossref', $key);    
     }

--- a/Template.php
+++ b/Template.php
@@ -1286,7 +1286,7 @@ final class Template {
     ];
     
     $novel_data = FALSE;
-    foreach ($data as $key => $value) if ($value) {		
+    foreach ($data as $key => $value) if ($value) {
       if ($this->api_has_not_used('crossref', equivalent_parameters($key))) $novel_data = TRUE;
       $this->record_api_usage('crossref', $key);    
     }

--- a/Template.php
+++ b/Template.php
@@ -1312,7 +1312,7 @@ final class Template {
       elseif ($result['status'] == 'malformed') {
         report_warning("Cannot search CrossRef: " . echoable($result->msg));
       }
-      elseif ($result['status'] == 'resolved') {
+      elseif ($result["status"] == "resolved") {
         if (!isset($result->doi) || is_array($result->doi)) return FALSE; // Never seen array, but pays to be paranoid
         report_info(" Successful!");
         return $this->add_if_new('doi', $result->doi);

--- a/Template.php
+++ b/Template.php
@@ -1312,9 +1312,9 @@ final class Template {
         report_warning("Cannot search CrossRef: " . echoable($result->msg));
       }
       elseif ($result['status'] == 'resolved') {
-        if (!isset($result['doi']) || is_array($result['doi'])) return FALSE; // Never seen array, but pays to be paranoid
+        if (!isset($result->doi) || is_array($result->doi)) return FALSE; // Never seen array, but pays to be paranoid
         report_info(" Successful!");
-        return $this->add_if_new('doi', $result['doi']);
+        return $this->add_if_new('doi', $result->doi);
       }
     }
     
@@ -1336,9 +1336,9 @@ final class Template {
     elseif ($result['status'] == 'malformed') {
       report_warning("Cannot search CrossRef: " . echoable($result->msg));
     } elseif ($result["status"]=="resolved") {
-      if (!isset($result['doi']) || is_array($result['doi'])) return FALSE; // Never seen array, but pays to be paranoid
+      if (!isset($result->doi) || is_array($result->doi)) return FALSE; // Never seen array, but pays to be paranoid
       report_info(" Successful!");
-      return $this->add_if_new('doi', $result['doi']);
+      return $this->add_if_new('doi', $result->doi);
     }
     return FALSE;
   }

--- a/Template.php
+++ b/Template.php
@@ -1272,13 +1272,13 @@ final class Template {
       return TRUE;
     }
     report_action("Checking CrossRef database for doi. ");
+    $page_range = $this->page_range();
     $data = [
       'title'      => $this->get('title'),
       'journal'    => $this->get('journal'),
       'author'     => $this->first_surname(),
       'year'       => $this->get('year'),
       'volume'     => $this->get('volume'),
-      'page_range' => $this->page_range(),
       'start_page' => isset($page_range[1]) ? $page_range[1] : NULL,
       'end_page'   => isset($page_range[2]) ? $page_range[2] : NULL,
       'issn'       => $this->get('issn'),

--- a/Template.php
+++ b/Template.php
@@ -1286,7 +1286,6 @@ final class Template {
     ];
     
     $novel_data = FALSE;
-    foreach ($data as $key => $value) if ($value) {
       if ($this->api_has_not_used('crossref', equivalent_parameters($key))) $novel_data = TRUE;
       $this->record_api_usage('crossref', $key);    
     }
@@ -1314,7 +1313,7 @@ final class Template {
       }
       elseif ($result['@attributes']['status'] == 'resolved') {
         if (!isset($result['doi']) || is_array($result['doi'])) return FALSE; // Never seen array, but pays to be paranoid
-        echo " Successful!";
+        report_info(" Successful!");
         return $this->add_if_new('doi', $result['doi']);
       }
     }
@@ -1338,7 +1337,7 @@ final class Template {
       report_warning("Cannot search CrossRef: " . echoable($result->msg));
     } elseif ($result["status"]=="resolved") {
       if (!isset($result['doi']) || is_array($result['doi'])) return FALSE; // Never seen array, but pays to be paranoid
-      echo " Successful!";
+      report_info(" Successful!");
       return $this->add_if_new('doi', $result['doi']);
     }
     return FALSE;

--- a/Template.php
+++ b/Template.php
@@ -1308,10 +1308,10 @@ final class Template {
       if (!($result = @simplexml_load_file($url)->query_result->body->query)){
         report_warning("Error loading simpleXML file from CrossRef.");
       }
-      elseif ($result['@attributes']['status'] == 'malformed') {
+      elseif ($result['status'] == 'malformed') {
         report_warning("Cannot search CrossRef: " . echoable($result->msg));
       }
-      elseif ($result['@attributes']['status'] == 'resolved') {
+      elseif ($result['status'] == 'resolved') {
         if (!isset($result['doi']) || is_array($result['doi'])) return FALSE; // Never seen array, but pays to be paranoid
         report_info(" Successful!");
         return $this->add_if_new('doi', $result['doi']);

--- a/Template.php
+++ b/Template.php
@@ -1309,10 +1309,10 @@ final class Template {
       if (!($result = @simplexml_load_file($url)->query_result->body->query)){
         report_warning("Error loading simpleXML file from CrossRef.");
       }
-      elseif ($result['status'] == 'malformed') {
+      elseif ($result['@attributes']['status'] == 'malformed') {
         report_warning("Cannot search CrossRef: " . echoable($result->msg));
       }
-      elseif ($result["status"] == "resolved") {
+      elseif ($result['@attributes']['status'] == 'resolved') {
         if (!isset($result['doi']) || is_array($result['doi'])) return FALSE; // Never seen array, but pays to be paranoid
         echo " Successful!";
         return $this->add_if_new('doi', $result['doi']);

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1716,7 +1716,7 @@ ER -  }}';
     $expanded = $this->process_citation($text);
     $this->assertEquals('10.1002/(ISSN)1099-0739', $expanded->get('doi'));
     $this->assertEquals('http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1099-0739/homepage/EditorialBoard.html', $expanded->get('url'));
-  }
+   }
   /* TODO 
   Test adding a paper with > 4 editors; this should trigger displayeditors
   Test finding a DOI and using it to expand a paper [See testLongAuthorLists - Arxiv example?]

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -28,6 +28,14 @@ final class TemplateTest extends testBaseClass {
     $this->assertEquals('22'          ,      $prepared->get('volume'));
     $this->assertEquals('5–6'         ,      $prepared->get('pages'));
   }
+ 
+  public function testGetDoi() {
+     $expanded = $this->process_citation('{{Cite journal | last1 = Glaesemann | first1 = K. R. | last2 = Fried | first2 = L. E. | doi = | title = Improved wood–kirkwood detonation chemical kinetics | journal = Theoretical Chemistry Accounts | volume = 120 | pages = 37–43 | year = 2007 |issue=1–3}}');
+     $this->assertEquals('10.1007/s00214-007-0303-9', $expanded->get('doi'));
+     $this->assertNull($expanded->get('pmid'));
+     $this->assertNull($expanded->get('bibcode'));
+     $this->assertNull($expanded->get('pmvc'));
+  }
   
   public function testJstorExpansion() {
     $text = "{{Cite web | www.jstor.org/stable/pdfplus/1701972.pdf?&acceptTC=true|website=i found this online}}";

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -29,12 +29,13 @@ final class TemplateTest extends testBaseClass {
     $this->assertEquals('5–6'         ,      $prepared->get('pages'));
   }
  
-  public function testGetDoi() {
-     $expanded = $this->process_citation('{{Cite journal | last1 = Glaesemann | first1 = K. R. | last2 = Fried | first2 = L. E. | doi = | title = Improved wood–kirkwood detonation chemical kinetics | journal = Theoretical Chemistry Accounts | volume = 120 | pages = 37–43 | year = 2007 |issue=1–3}}');
+  public function testGetDoiFromCrossref() {
+     $text = '{{Cite journal | last1 = Glaesemann | first1 = K. R. | last2 = Fried | first2 = L. E. | doi = | title = Improved wood–kirkwood detonation chemical kinetics | journal = Theoretical Chemistry Accounts | volume = 120 | pages = 37–43 | year = 2007 |issue=1–3}}';
+     $expanded = $this->process_citation($text);
      $this->assertEquals('10.1007/s00214-007-0303-9', $expanded->get('doi'));
-     $this->assertNull($expanded->get('pmid'));
+     $this->assertNull($expanded->get('pmid'));  // do not want reference where pmid leads to doi
      $this->assertNull($expanded->get('bibcode'));
-     $this->assertNull($expanded->get('pmvc'));
+     $this->assertNull($expanded->get('pmc'));
   }
   
   public function testJstorExpansion() {


### PR DESCRIPTION
Page range code was wrong, so even after the other fix, we were still not always finding them.

Also, we confused Object with Array, so even if we found stuff, we still did not add it.

@ms609 added a test too, since we kinda sucked on this.