### PR TITLE
improve URL=DOI code

### DIFF
--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -10,7 +10,7 @@ function query_url_api($ids, $templates) {
   foreach ($templates as $template) {
        if ($template->has('biorxiv')) {
          if ($template->blank('doi')) {
-           $template->add_if_new('doi', '10.1101/' . $template->get('biorxiv'));
+           $template->add_if_new('doi', '10.1101/' . $template->get('biorxiv')); 
          } elseif (strstr($template->get('doi') , '10.1101') === FALSE) {
            expand_by_zotero($template, 'https://dx.doi.org/10.1101/' . $template->get('biorxiv'));  // Rare case there is a different DOI
          }

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -46,6 +46,7 @@ function query_url_api($ids, $templates) {
         $url &&
         !$template->incomplete() &&
         !preg_match(REGEXP_DOI_ISSN_ONLY, $doi) &&
+        (stripos('10.1093/', $doi) === FALSE) &&
         $template->blank(DOI_BROKEN_ALIASES))
     {
           curl_setopt($ch, CURLOPT_URL, "https://dx.doi.org/" . urlencode($doi));

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -59,7 +59,7 @@ function query_url_api($ids, $templates) {
           curl_setopt($ch, CURLOPT_URL, "https://dx.doi.org/" . urlencode($doi));
           if (@curl_exec($ch)) {
             $redirectedUrl_doi = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);  // Final URL
-            $redirectedUrl_doi = str_replace('action/captchaChallenge?redirectUri=', '', $redirectedUrl_doi);
+            $redirectedUrl_doi = str_replace('/action/captchaChallenge?redirectUri=', '', $redirectedUrl_doi);
             $redirectedUrl_doi = urldecode($redirectedUrl_doi);
             $redirectedUrl_doi = strtok($redirectedUrl_doi, '?#');  // Remove session stuff
             $url_short         = strtok(urldecode($url), '?#');
@@ -78,7 +78,7 @@ function query_url_api($ids, $templates) {
                curl_setopt($ch, CURLOPT_URL, $url);
                if (@curl_exec($ch)) {
                   $redirectedUrl_url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-                  $redirectedUrl_url = str_replace('action/captchaChallenge?redirectUri=', '', $redirectedUrl_url);
+                  $redirectedUrl_url = str_replace('/action/captchaChallenge?redirectUri=', '', $redirectedUrl_url);
                   $redirectedUrl_url = urldecode($redirectedUrl_url);
                   $url_short = strtok($redirectedUrl_url, '?#');
                   $url_short = str_ireplace('https', 'http', $url_short);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -55,8 +55,8 @@ function query_url_api($ids, $templates) {
             $url_short         = strtok($url,               '?#');
             if (stripos($redirectedUrl_doi, 'cookie') !== FALSE) break;
             if (stripos($redirectedUrl_doi, 'denied') !== FALSE) break;
-            if ( preg_match('~^https?://.+/(pii/|PII)(S\d{4}[0-9]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {
-                 $redirectedUrl_doi = $matches[2] ;  // Grab PII numbers
+            if ( preg_match('~^https?://.+/pii/(S\d{4}[0-9]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {
+                 $redirectedUrl_doi = $matches[1] ;  // Grab PII numbers
             }
             $url_short = str_ireplace('https', 'http', $url_short);
             $redirectedUrl_doi = str_ireplace('https', 'http', $redirectedUrl_doi);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -59,6 +59,8 @@ function query_url_api($ids, $templates) {
           curl_setopt($ch, CURLOPT_URL, "https://dx.doi.org/" . urlencode($doi));
           if (@curl_exec($ch)) {
             $redirectedUrl_doi = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);  // Final URL
+            $redirectedUrl_doi = str_replace('action/captchaChallenge?redirectUri=', '', $redirectedUrl_doi);
+            $redirectedUrl_doi = urldecode($redirectedUrl_doi);
             $redirectedUrl_doi = strtok($redirectedUrl_doi, '?#');  // Remove session stuff
             $url_short         = strtok($url,               '?#');
             if (stripos($redirectedUrl_doi, 'cookie') !== FALSE) break;
@@ -76,6 +78,8 @@ function query_url_api($ids, $templates) {
                curl_setopt($ch, CURLOPT_URL, $url);
                if (@curl_exec($ch)) {
                   $redirectedUrl_url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+                  $redirectedUrl_url = str_replace('action/captchaChallenge?redirectUri=', '', $redirectedUrl_url);
+                  $redirectedUrl_url = urldecode($redirectedUrl_url);
                   $url_short = strtok($redirectedUrl_url, '?#');
                   $url_short = str_ireplace('https', 'http', $url_short);
                   if (stripos($url_short, $redirectedUrl_doi) !== FALSE ||

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -229,6 +229,13 @@ function expand_by_zotero(&$template, $url = NULL) {
       $result->extra = str_replace(trim($matches[1]), '', $result->extra);
       $result->extra = trim($result->extra);
     }
+    if (preg_match('~PMID: (\d+), (\d+)~i', ' ' . $result->extra . ' ', $matches)) {
+      $result->extra = str_replace(trim($matches[1]), '', $result->extra);
+      $result->extra = trim($result->extra);
+      if ($matches[1] === $matches[2]) {
+        $template->add_if_new('pmid', $matches[1]);
+      }
+    }
     if ($result->extra !== '') {
         if (getenv('TRAVIS')) {
           trigger_error("Unhandled extra data: " . $result->extra);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -46,8 +46,6 @@ function query_url_api($ids, $templates) {
         $url &&
         !$template->incomplete() &&
         !preg_match(REGEXP_DOI_ISSN_ONLY, $doi) &&
-        str_ireplace(CANONICAL_PUBLISHER_URLS, '', $url) != $url &&
-        str_ireplace(['pdf', 'image', 'plate', 'figure', 'picture'], '', $url) == $url &&
         $template->blank(DOI_BROKEN_ALIASES))
     {
           curl_setopt($ch, CURLOPT_URL, "https://dx.doi.org/" . urlencode($doi));
@@ -57,7 +55,7 @@ function query_url_api($ids, $templates) {
             $url_short         = strtok($url,               '?#');
             if (stripos($redirectedUrl_doi, 'cookie') !== FALSE) break;
             if (stripos($redirectedUrl_doi, 'denied') !== FALSE) break;
-            if ( preg_match('~^https?://*+/pii/(S\d{4}[0-9]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {
+            if ( preg_match('~^https?://[^/]+/pii/(S\d{4}[0-9]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {
                  $redirectedUrl_doi = $matches[1] ;  // Grab PII numbers
             }
             $url_short = str_ireplace('https', 'http', $url_short);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -231,6 +231,7 @@ function expand_by_zotero(&$template, $url = NULL) {
       $result->extra = trim($result->extra);
       if ($matches[1] === $matches[2]) {
         $template->add_if_new('pmid', $matches[1]);
+        entrez_api(array($matches[1]), array($template), 'pubmed');
       }
     }
     if ($result->extra !== '') {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -62,7 +62,7 @@ function query_url_api($ids, $templates) {
             $url_short         = strtok($url,               '?#');
             if (stripos($redirectedUrl_doi, 'cookie') !== FALSE) break;
             if (stripos($redirectedUrl_doi, 'denied') !== FALSE) break;
-            if ( preg_match('~^https?://.+/pii/(S\d{4}[0-9]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {
+            if ( preg_match('~^https?://.+/pii/?(S\d{4}[^/]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {
                  $redirectedUrl_doi = $matches[1] ;  // Grab PII numbers
             }
             $url_short = str_ireplace('https', 'http', $url_short);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -51,7 +51,7 @@ function query_url_api($ids, $templates) {
     $url = $template->get('url');
     if ($doi &&
         $url &&
-        !$template->incomplete() &&
+        !$template->profoundly_incomplete() &&
         !preg_match(REGEXP_DOI_ISSN_ONLY, $doi) &&
         (strpos('10.1093/', $doi) === FALSE) &&
         $template->blank(DOI_BROKEN_ALIASES))

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -218,19 +218,16 @@ function expand_by_zotero(&$template, $url = NULL) {
   
   if (isset($result->extra)) { // [extra] => DOI: 10.1038/546031a has been seen in the wild
     if (preg_match('~\sdoi:\s?([^\s]+)\s~i', ' ' . $result->extra . ' ', $matches)) {
-      if (!isset($result->DOI) && !isset($matches[2])) $result->DOI = trim($matches[1]); // Only set if only one DOI
-      $result->extra = str_ireplace('doi:', '', $result->extra);
-      $result->extra = str_replace(trim($matches[1]), '', $result->extra);
+      if (!isset($result->DOI)) $result->DOI = trim($matches[1]);
+      $result->extra = str_replace(trim($matches[0]), '', $result->extra);
       $result->extra = trim($result->extra);
-      if (isset($matches[2])) $result->extra = ''; // Obviously not gonna parse this in any way
     }
     if (preg_match('~\stype:\s?([^\s]+)\s~i', ' ' . $result->extra . ' ', $matches)) { // [extra] => type: dataset has been seen in the wild
-      $result->extra = str_ireplace('type:', '', $result->extra);
-      $result->extra = str_replace(trim($matches[1]), '', $result->extra);
+      $result->extra = str_replace(trim($matches[0]), '', $result->extra);
       $result->extra = trim($result->extra);
     }
-    if (preg_match('~PMID: (\d+), (\d+)~i', ' ' . $result->extra . ' ', $matches)) {
-      $result->extra = str_replace(trim($matches[1]), '', $result->extra);
+    if (preg_match('~\sPMID: (\d+), (\d+)\s~i', ' ' . $result->extra . ' ', $matches)) {
+      $result->extra = str_replace(trim($matches[0]), '', $result->extra);
       $result->extra = trim($result->extra);
       if ($matches[1] === $matches[2]) {
         $template->add_if_new('pmid', $matches[1]);

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -44,7 +44,8 @@ function query_url_api($ids, $templates) {
   curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 4); 
   curl_setopt($ch, CURLOPT_TIMEOUT, 15);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-  curl_setopt($ch, CURLOPT_COOKIESESSION, TRUE);
+  curl_setopt($ch, CURLOPT_COOKIEFILE, "");
+  curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
   foreach ($templates as $template) {
     $doi = $template->get_without_comments_and_placeholders('doi');
     $url = $template->get('url');

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -62,7 +62,7 @@ function query_url_api($ids, $templates) {
             $redirectedUrl_doi = str_replace('action/captchaChallenge?redirectUri=', '', $redirectedUrl_doi);
             $redirectedUrl_doi = urldecode($redirectedUrl_doi);
             $redirectedUrl_doi = strtok($redirectedUrl_doi, '?#');  // Remove session stuff
-            $url_short         = strtok($url,               '?#');
+            $url_short         = strtok(urldecode($url), '?#');
             if (stripos($redirectedUrl_doi, 'cookie') !== FALSE) break;
             if (stripos($redirectedUrl_doi, 'denied') !== FALSE) break;
             if ( preg_match('~^https?://.+/pii/?(S\d{4}[^/]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -52,7 +52,7 @@ function query_url_api($ids, $templates) {
         $url &&
         !$template->incomplete() &&
         !preg_match(REGEXP_DOI_ISSN_ONLY, $doi) &&
-        (stripos('10.1093/', $doi) === FALSE) &&
+        (strpos('10.1093/', $doi) === FALSE) &&
         $template->blank(DOI_BROKEN_ALIASES))
     {
           curl_setopt($ch, CURLOPT_URL, "https://dx.doi.org/" . urlencode($doi));

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -55,8 +55,8 @@ function query_url_api($ids, $templates) {
             $url_short         = strtok($url,               '?#');
             if (stripos($redirectedUrl_doi, 'cookie') !== FALSE) break;
             if (stripos($redirectedUrl_doi, 'denied') !== FALSE) break;
-            if ( preg_match('~^https?://[^/]+/pii/(S\d{4}[0-9]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {
-                 $redirectedUrl_doi = $matches[1] ;  // Grab PII numbers
+            if ( preg_match('~^https?://.+/(pii/|PII)(S\d{4}[0-9]+)~i', $redirectedUrl_doi, $matches ) === 1 ) {
+                 $redirectedUrl_doi = $matches[2] ;  // Grab PII numbers
             }
             $url_short = str_ireplace('https', 'http', $url_short);
             $redirectedUrl_doi = str_ireplace('https', 'http', $redirectedUrl_doi);

--- a/tests/phpunit/zoteroTest.php
+++ b/tests/phpunit/zoteroTest.php
@@ -143,15 +143,4 @@ class ZoteroTest extends testBaseClass {
      $expanded = $this->process_citation($text);
      $this->assertNull($expanded->get('url'));
   }
-  public function testDropUrlCode4() {
-    $text = '{{cite journal | url = https://www.cell.com/trends/genetics/fulltext/S0168-9525(18)30054-4 | doi = 10.1016/j.tig.2018.03.001 }}';
-    $expanded = $this->process_citation($text);
-    $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
-  }
- 
-   public function testDropUrlCode5() {
-     $text = '{{cite journal | url = https://www.thelancet.com/journals/laneur/article/PIIS1474-4422(17)30401-5/fulltext | doi = 10.1016/S1474-4422(17)30401-5 }}';
-     $expanded = $this->process_citation($text);
-     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
-   }
 }

--- a/tests/phpunit/zoteroTest.php
+++ b/tests/phpunit/zoteroTest.php
@@ -21,6 +21,16 @@ class ZoteroTest extends testBaseClass {
     $this->assertEquals('10.1016/j.laa.2012.05.036', $expanded->get('doi'));
     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
   }
+  public function testZoteroExpansionPII2() {
+    $text = '{{cite journal | url = https://www.cell.com/trends/genetics/fulltext/S0168-9525(18)30054-4 | doi = 10.1016/j.tig.2018.03.001 }}';
+    $expanded = $this->expand_via_zotero($text);
+    $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
+  }
+  public function testZoteroExpansionPII3() {
+    $text = '{{cite journal | url = https://www.thelancet.com/journals/laneur/article/PIIS1474-4422(17)30401-5/fulltext | doi = 10.1016/S1474-4422(17)30401-5 }}';
+    $expanded = $this->expand_via_zotero($text);
+    $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
+  }
 
   public function testZoteroExpansionNBK() {
     $text = '{{Cite journal|url=https://www.ncbi.nlm.nih.gov/books/NBK24662/|access-date=2099-12-12}}';  // Date is before access-date so will expand

--- a/tests/phpunit/zoteroTest.php
+++ b/tests/phpunit/zoteroTest.php
@@ -21,11 +21,6 @@ class ZoteroTest extends testBaseClass {
     $this->assertEquals('10.1016/j.laa.2012.05.036', $expanded->get('doi'));
     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
   }
-  public function testZoteroExpansionPII2() {
-    $text = '{{cite journal | url = https://www.thelancet.com/journals/laneur/article/PIIS1474-4422(17)30401-5/fulltext | doi = 10.1016/S1474-4422(17)30401-5 }}';
-    $expanded = $this->expand_via_zotero($text);
-    $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
-  }
 
   public function testZoteroExpansionNBK() {
     $text = '{{Cite journal|url=https://www.ncbi.nlm.nih.gov/books/NBK24662/|access-date=2099-12-12}}';  // Date is before access-date so will expand
@@ -153,4 +148,10 @@ class ZoteroTest extends testBaseClass {
     $expanded = $this->process_citation($text);
     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
   }
+ 
+   public function testDropUrlCode5() {
+     $text = '{{cite journal | url = https://www.thelancet.com/journals/laneur/article/PIIS1474-4422(17)30401-5/fulltext | doi = 10.1016/S1474-4422(17)30401-5 }}';
+     $expanded = $this->process_citation($text);
+     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
+   }
 }

--- a/tests/phpunit/zoteroTest.php
+++ b/tests/phpunit/zoteroTest.php
@@ -16,7 +16,7 @@ class ZoteroTest extends testBaseClass {
 //  }
       
   public function testZoteroExpansionPII() {
-    $text = '{{Cite journal|url = https://www.sciencedirect.com/science/article/pii/S0024379512004405}}';
+    $text = '{{Cite journal|url = http://www.sciencedirect.com/science/article/pii/S0024379512004405}}';
     $expanded = $this->expand_via_zotero($text);
     $this->assertEquals('10.1016/j.laa.2012.05.036', $expanded->get('doi'));
     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
@@ -133,4 +133,15 @@ class ZoteroTest extends testBaseClass {
      $expanded = $this->process_citation($text);
      $this->assertNull($expanded->get('url'));
   }
+  public function testDropUrlCode2() { // URL redirects to URL with the same DOI
+     $text = '{{cite journal | last = De Vivo | first = B. | title = New constraints on the pyroclastic eruptive history of the Campanian volcanic Plain (Italy) | url = http://www.springerlink.com/content/8r046aa9t4lmjwxj/ | doi = 10.1007/s007100170010 }}';
+     $expanded = $this->process_citation($text);
+     $this->assertNull($expanded->get('url'));
+  }
+  public function testDropUrlCode3() { // url is same as one doi points to, except for http vs. https
+     $text = "{{cite journal | first = Luca | last = D'Auria | year = 2015 | title = Magma injection beneath the urban area of Naples | url = http://www.nature.com/articles/srep13100 | doi=10.1038/srep13100 }}";
+     $expanded = $this->process_citation($text);
+     $this->assertNull($expanded->get('url'));
+  }
+
 }

--- a/tests/phpunit/zoteroTest.php
+++ b/tests/phpunit/zoteroTest.php
@@ -22,11 +22,6 @@ class ZoteroTest extends testBaseClass {
     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
   }
   public function testZoteroExpansionPII2() {
-    $text = '{{cite journal | url = https://www.cell.com/trends/genetics/fulltext/S0168-9525(18)30054-4 | doi = 10.1016/j.tig.2018.03.001 }}';
-    $expanded = $this->expand_via_zotero($text);
-    $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
-  }
-  public function testZoteroExpansionPII3() {
     $text = '{{cite journal | url = https://www.thelancet.com/journals/laneur/article/PIIS1474-4422(17)30401-5/fulltext | doi = 10.1016/S1474-4422(17)30401-5 }}';
     $expanded = $this->expand_via_zotero($text);
     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
@@ -153,5 +148,9 @@ class ZoteroTest extends testBaseClass {
      $expanded = $this->process_citation($text);
      $this->assertNull($expanded->get('url'));
   }
-
+  public function testDropUrlCode4() {
+    $text = '{{cite journal | url = https://www.cell.com/trends/genetics/fulltext/S0168-9525(18)30054-4 | doi = 10.1016/j.tig.2018.03.001 }}';
+    $expanded = $this->process_citation($text);
+    $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi
+  }
 }

--- a/tests/phpunit/zoteroTest.php
+++ b/tests/phpunit/zoteroTest.php
@@ -16,7 +16,7 @@ class ZoteroTest extends testBaseClass {
 //  }
       
   public function testZoteroExpansionPII() {
-    $text = '{{Cite journal|url = http://www.sciencedirect.com/science/article/pii/S0024379512004405}}';
+    $text = '{{Cite journal|url = https://www.sciencedirect.com/science/article/pii/S0024379512004405}}';
     $expanded = $this->expand_via_zotero($text);
     $this->assertEquals('10.1016/j.laa.2012.05.036', $expanded->get('doi'));
     $this->assertNull($expanded->get('url')); // Recognize canonical publisher URL as duplicate of valid doi


### PR DESCRIPTION
* Do not require URL to match some narrow regexes before resolving redirects.
* Fix regex typo introduced in 36c462860a6b003fd424bc3b6a7b98b1c962f740.