### PR TITLE
remove unused {{cite doi}} code

### DIFF
--- a/WikipediaBot.php
+++ b/WikipediaBot.php
@@ -290,14 +290,6 @@ class WikipediaBot {
     return $list;
   }
 
-  /**
-   * Unused
-   * @codeCoverageIgnore
-   */
-  public function wikititle_encode($in) {
-    return str_replace(DOT_DECODE, DOT_ENCODE, $in);
-  }
-
   public function get_last_revision($page) {
     $res = $this->fetch(Array(
         "action" => "query",

--- a/WikipediaBot.php
+++ b/WikipediaBot.php
@@ -452,18 +452,4 @@ class WikipediaBot {
     return $results['page_id'];
   }
 
-  /**
-   * Unused
-   * @codeCoverageIgnore
-   */
-  public function touch_page($page) {
-    $text = $this->get_raw_wikitext($page);
-    if ($text) {
-      $this->write_page($page, $text, " Touching page to update categories.  ** THIS EDIT SHOULD PROBABLY BE REVERTED ** as page content will only be changed if there was an edit conflict.");
-      return TRUE;
-    } else {
-      return FALSE;
-    }
-  }
-
 }


### PR DESCRIPTION
Unlike some other unused code.  I cannot imagine this ever being useful.
Especially since Wikipedia now has a purge url for this 
It is a code path to writing a page, so eliminating it is a good step towards using oauth with users.