### PR TITLE
EMERGENCY: Do not slam BIBCODE key on Travis

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1524,6 +1524,8 @@ final class Template {
   // URL-ENCODED search strings, separated by (unencoded) ampersands.
   // Surround search terms in (url-encoded) ""s, i.e. doi:"10.1038/bla(bla)bla"
   protected function query_adsabs($options) {  
+    global $DO_SECRET_TESTS;
+    if (@$DO_SECRET_TESTS !== TRUE && getenv('TRAVIS')) return (object) array('numFound' => 0);
     // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
     
     if (!getenv('PHP_ADSABSAPIKEY')) {

--- a/Template.php
+++ b/Template.php
@@ -1524,8 +1524,8 @@ final class Template {
   // URL-ENCODED search strings, separated by (unencoded) ampersands.
   // Surround search terms in (url-encoded) ""s, i.e. doi:"10.1038/bla(bla)bla"
   protected function query_adsabs($options) {  
-    global $SKIP_SECRET_TESTS; // Only set in TRAVIS
-    if (@$SKIP_SECRET_TESTS === TRUE) return (object) array('numFound' => 0);
+    global $DO_SECRET_TESTS; // Only set in TRAVIS
+    if (getenv('TRAVIS') && @$DO_SECRET_TESTS !== TRUE) return (object) array('numFound' => 0);
     // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
     
     if (!getenv('PHP_ADSABSAPIKEY')) {

--- a/Template.php
+++ b/Template.php
@@ -1524,8 +1524,7 @@ final class Template {
   // URL-ENCODED search strings, separated by (unencoded) ampersands.
   // Surround search terms in (url-encoded) ""s, i.e. doi:"10.1038/bla(bla)bla"
   protected function query_adsabs($options) {  
-    global $DO_SECRET_TESTS; // Only set in TRAVIS
-    if (getenv('TRAVIS') && @$DO_SECRET_TESTS !== TRUE) return (object) array('numFound' => 0);
+    if (getenv('TRAVIS')) return (object) array('numFound' => 0);
     // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
     
     if (!getenv('PHP_ADSABSAPIKEY')) {

--- a/Template.php
+++ b/Template.php
@@ -1524,8 +1524,8 @@ final class Template {
   // URL-ENCODED search strings, separated by (unencoded) ampersands.
   // Surround search terms in (url-encoded) ""s, i.e. doi:"10.1038/bla(bla)bla"
   protected function query_adsabs($options) {  
-    global $DO_SECRET_TESTS;
-    if (@$DO_SECRET_TESTS !== TRUE && getenv('TRAVIS')) return (object) array('numFound' => 0);
+    global $SKIP_SECRET_TESTS; // Only set in TRAVIS
+    if (@$SKIP_SECRET_TESTS === TRUE) return (object) array('numFound' => 0);
     // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
     
     if (!getenv('PHP_ADSABSAPIKEY')) {

--- a/tests/testBaseClass.php
+++ b/tests/testBaseClass.php
@@ -23,7 +23,10 @@ abstract class testBaseClass extends PHPUnit\Framework\TestCase {
       echo 'S'; // Skipping test: Risks exposing secret keys
       $this->assertNull(NULL); // Make Travis think we tested something
     } else {
+      global $DO_SECRET_TESTS;
+      $DO_SECRET_TESTS = TRUE;
       $function();
+      $DO_SECRET_TESTS = FALSE;
     }
   }
   

--- a/tests/testBaseClass.php
+++ b/tests/testBaseClass.php
@@ -26,7 +26,7 @@ abstract class testBaseClass extends PHPUnit\Framework\TestCase {
       global $DO_SECRET_TESTS;
       $DO_SECRET_TESTS = TRUE;
       $function();
-      $DO_SECRET_TESTS = FALSE;
+      unset($DO_SECRET_TESTS); // The default
     }
   }
   

--- a/tests/testBaseClass.php
+++ b/tests/testBaseClass.php
@@ -23,10 +23,7 @@ abstract class testBaseClass extends PHPUnit\Framework\TestCase {
       echo 'S'; // Skipping test: Risks exposing secret keys
       $this->assertNull(NULL); // Make Travis think we tested something
     } else {
-      global $DO_SECRET_TESTS;
-      $DO_SECRET_TESTS = TRUE;
       $function();
-      unset($DO_SECRET_TESTS); // The default
     }
   }
   


### PR DESCRIPTION
project members have it set in TRAVIS and just hammer on it.   My apologies.

@ms609 I think we need this because I did too many pull edits and the bot is being run **a lot**

Also, make the tests fail when we have used up our welcome