### PR TITLE
Call @session_start() for all PHP pages that write()

### DIFF
--- a/category.php
+++ b/category.php
@@ -27,7 +27,6 @@ if (php_sapi_name() !== "cli") {
     define("HTML_OUTPUT", TRUE);// Not in cli-mode
 }
 require_once __DIR__ . '/expandFns.php';
-$api = new WikipediaBot();
 
 $category = $argument["cat"] ? $argument["cat"][0] : $_REQUEST["cat"];
 
@@ -57,6 +56,7 @@ if (HTML_OUTPUT) {
 }
 if ($category) {
   $attempts = 0;
+  $api = new WikipediaBot();
   $pages_in_category = $api->category_members($category);
   shuffle($pages_in_category);
   $page = new Page();

--- a/category.php
+++ b/category.php
@@ -26,6 +26,7 @@ if (php_sapi_name() !== "cli") {
     define("HTML_OUTPUT", TRUE);// Not in cli-mode
 }
 require_once __DIR__ . '/expandFns.php';
+$api = new WikipediaBot();
 
 $category = $argument["cat"] ? $argument["cat"][0] : $_REQUEST["cat"];
 
@@ -55,7 +56,6 @@ if (HTML_OUTPUT) {
 }
 if ($category) {
   $attempts = 0;
-  $api = new WikipediaBot();
   $pages_in_category = $api->category_members($category);
   shuffle($pages_in_category);
   $page = new Page();

--- a/category.php
+++ b/category.php
@@ -1,4 +1,5 @@
 <?php
+@session_start();
 error_reporting(E_ALL^E_NOTICE);
 if (!isset($argv)) $argv=[]; // When run as a webpage, this does not get set
 $argument["cat"] = NULL;

--- a/process_page.php
+++ b/process_page.php
@@ -28,7 +28,6 @@ if (HTML_OUTPUT) {?>
 <?php
 }
 require_once("expandFns.php");
-$api = new WikipediaBot();
 $user = isset($_REQUEST["user"]) ? $_REQUEST["user"] : NULL;
 if (is_valid_user($user)) {
   echo " Activated by $user. The bot will automatically make edit(s) if it can.\n";
@@ -51,6 +50,7 @@ foreach (explode('|', $pages) as $title) {
 
   report_phase("Expanding '" . echoable($title) . "'; " . ($ON ? "will" : "won't") . " commit edits.");
   $my_page = new Page();
+  $api = new WikipediaBot();
   if ($my_page->get_text_from($title, $api)) {
     $text_expanded = $my_page->expand_text();
     if ($text_expanded && $ON) {

--- a/process_page.php
+++ b/process_page.php
@@ -1,5 +1,5 @@
 <?php
-## Set up - including DOT_DECODE array
+@session_start();
 define("HTML_OUTPUT", !isset($argv));
 require_once("expandFns.php");
 $api = new WikipediaBot();

--- a/process_page.php
+++ b/process_page.php
@@ -1,8 +1,6 @@
 <?php
 @session_start();
 define("HTML_OUTPUT", !isset($argv));
-require_once("expandFns.php");
-$api = new WikipediaBot();
 if (HTML_OUTPUT) {?>
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
@@ -29,6 +27,8 @@ if (HTML_OUTPUT) {?>
 <pre id="botOutput">
 <?php
 }
+require_once("expandFns.php");
+$api = new WikipediaBot();
 $user = isset($_REQUEST["user"]) ? $_REQUEST["user"] : NULL;
 if (is_valid_user($user)) {
   echo " Activated by $user. The bot will automatically make edit(s) if it can.\n";

--- a/process_page.php
+++ b/process_page.php
@@ -1,6 +1,8 @@
 <?php
 ## Set up - including DOT_DECODE array
 define("HTML_OUTPUT", !isset($argv));
+require_once("expandFns.php");
+$api = new WikipediaBot();
 if (HTML_OUTPUT) {?>
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
@@ -27,7 +29,6 @@ if (HTML_OUTPUT) {?>
 <pre id="botOutput">
 <?php
 }
-require_once("expandFns.php");
 $user = isset($_REQUEST["user"]) ? $_REQUEST["user"] : NULL;
 if (is_valid_user($user)) {
   echo " Activated by $user. The bot will automatically make edit(s) if it can.\n";
@@ -50,7 +51,6 @@ foreach (explode('|', $pages) as $title) {
 
   report_phase("Expanding '" . echoable($title) . "'; " . ($ON ? "will" : "won't") . " commit edits.");
   $my_page = new Page();
-  $api = new WikipediaBot();
   if ($my_page->get_text_from($title, $api)) {
     $text_expanded = $my_page->expand_text();
     if ($text_expanded && $ON) {


### PR DESCRIPTION
Need to do this before everything else, if we are going to start authenticating users

@session_start() with @ symbol, so all errors are ignored, such as command-line not web, etc.

Any page we are going to call write() from