### PR TITLE
Done: API is not page specific - remove unused code

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -10,7 +10,6 @@
 require_once('Comment.php');
 require_once('Template.php');
 require_once('apiFunctions.php');
-require_once('WikipediaBot.php');
 
 class Page {
 

--- a/Page.php
+++ b/Page.php
@@ -15,11 +15,11 @@ require_once('WikipediaBot.php');
 class Page {
 
   protected $text, $title, $modifications, $date_style;
-  protected $read_at, $api, $namespace, $touched, $start_text, $last_write_time;
+  protected $read_at, $namespace, $touched, $start_text, $last_write_time;
   public $lastrevid;
 
   function __construct() {
-    $this->api = new WikipediaBot();
+    ;
   }
     
   /*

--- a/Page.php
+++ b/Page.php
@@ -16,10 +16,6 @@ class Page {
   protected $text, $title, $modifications, $date_style;
   protected $read_at, $namespace, $touched, $start_text, $last_write_time;
   public $lastrevid;
-
-  function __construct() {
-    ;
-  }
     
   /*
  * cannot be tested on Travis

--- a/Page.php
+++ b/Page.php
@@ -16,7 +16,9 @@ class Page {
   protected $text, $title, $modifications, $date_style;
   protected $read_at, $namespace, $touched, $start_text, $last_write_time;
   public $lastrevid;
-    
+
+  function __construct() { ; }
+
   /*
  * cannot be tested on Travis
  * @codeCoverageIgnore


### PR DESCRIPTION
Should be faster without creating extra $api class objects all over the place.

Also remove false oauth references from code that make adding User oauth impossible