### PR TITLE
JSTOR sometimes sends first page as end page too

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1710,7 +1710,7 @@ final class Template {
     }
     if ($ris_review) $this->add_if_new('title', trim($ris_review));  // Do at end in case we have real title
     if (isset($start_page)) { // Have to do at end since might get end pages before start pages
-      if (isset($end_page)) {
+      if (isset($end_page) && ($start_page != $end_page)) {
          $this->add_if_new("pages", $start_page . '–' . $end_page);
       } else {
          $this->add_if_new("pages", $start_page);


### PR DESCRIPTION
GIGO protection.  This might seem silly, since pages=33-33 gets fixed later, but this means the existing page=33 gets changed to pages=33-33 and then to pages=33, which is a cosmetic change.