### PR TITLE
Better error handling

### DIFF
--- a/Page.php
+++ b/Page.php
@@ -361,7 +361,7 @@ class Page {
       }
       if ($preg_ok === FALSE) {
         // PHP 5 segmentation faults in preg_match when it fails.  PHP 7 returns FALSE.
-        trigger_error('Regular expression failure in ' . htmlspecialchars($this->title) . ' when extracting ' . $class . 's', E_USER_ERROR);
+        report_error('Regular expression failure in ' . htmlspecialchars($this->title) . ' when extracting ' . $class . 's');
       }
     }
     $this->text = $text;

--- a/Page.php
+++ b/Page.php
@@ -335,8 +335,8 @@ class Page {
               $this->edit_summary() . $edit_summary_end,
               $this->lastrevid, $this->read_at);
     } else {
-      trigger_error("Can't write to " . htmlspecialchars($this->title) . 
-        " - prohibited by {{bots}} template.", E_USER_NOTICE);
+      report_warning("Can't write to " . htmlspecialchars($this->title) . 
+        " - prohibited by {{bots}} template.");
       return FALSE;
     }
   }

--- a/Template.php
+++ b/Template.php
@@ -3669,7 +3669,7 @@ final class Template {
              $url .=  $part . "&" ;
              break;
           default:
-             if (getenv('TRAVIS')) trigger_error("Unexpected Google URL component:  " . $part, E_USER_NOTICE);
+             if (getenv('TRAVIS')) trigger_error("Unexpected Google URL component:  " . $part);
              $url .=  $part . "&" ;
              break;
         }

--- a/Template.php
+++ b/Template.php
@@ -150,7 +150,7 @@ final class Template {
   }
   
   public function api_has_used($api, $param) {
-    if (!isset($this->used_by_api[$api])) trigger_error("Invalid API: $api", E_USER_ERROR);
+    if (!isset($this->used_by_api[$api])) report_error("Invalid API: $api");
     return count(array_intersect($param, $this->used_by_api[$api]));
   }
   

--- a/Template.php
+++ b/Template.php
@@ -1626,11 +1626,11 @@ final class Template {
       return $response;
     } catch (Exception $e) {
       if ($e->getCode() == 5000) { // made up code for AdsAbs error
-        trigger_error(sprintf("API Error in query_adsabs: %s",
-                      $e->getMessage()), E_USER_NOTICE);
+        report_warning(sprintf("API Error in query_adsabs: %s",
+                      $e->getMessage()));
       } else if (strpos($e->getMessage(), 'HTTP') === 0) {
-        trigger_error(sprintf("HTTP Error %d in query_adsabs: %s",
-                      $e->getCode(), $e->getMessage()), E_USER_NOTICE);
+        report_warning(sprintf("HTTP Error %d in query_adsabs: %s",
+                      $e->getCode(), $e->getMessage()));
       } else {
         report_warning(sprintf("Error %d in query_adsabs: %s",
                       $e->getCode(), $e->getMessage()));
@@ -3669,7 +3669,7 @@ final class Template {
              $url .=  $part . "&" ;
              break;
           default:
-             if (getenv('TRAVIS')) trigger_error("Unexpected Google URL component:  " . $part);
+             if (getenv('TRAVIS')) trigger_error("Unexpected Google URL component:  " . $part, E_USER_NOTICE);
              $url .=  $part . "&" ;
              break;
         }

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -256,14 +256,14 @@ function adsabs_api($ids, $templates, $identifier) {
     }
   } catch (Exception $e) {
     if ($e->getCode() == 5000) { // made up code for AdsAbs error
-      trigger_error(sprintf("API Error in query_adsabs: %s",
-                    $e->getMessage()), E_USER_NOTICE);
+      report_warning(sprintf("API Error in query_adsabs: %s",
+                    $e->getMessage()));
     } else if (strpos($e->getMessage(), 'HTTP') === 0) {
-      trigger_error(sprintf("HTTP Error %d in query_adsabs: %s",
-                    $e->getCode(), $e->getMessage()), E_USER_NOTICE);
+      report_warning(sprintf("HTTP Error %d in query_adsabs: %s",
+                    $e->getCode(), $e->getMessage()));
     } else {
-      trigger_error(sprintf("Error %d in query_adsabs: %s",
-                    $e->getCode(), $e->getMessage()), E_USER_WARNING);
+      report_warning(sprintf("Error %d in query_adsabs: %s",
+                    $e->getCode(), $e->getMessage()));
       curl_close($ch);
     }
   }

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -265,7 +265,7 @@ function adsabs_api($ids, $templates, $identifier) {
       report_warning(sprintf("Error %d in query_adsabs: %s",
                     $e->getCode(), $e->getMessage()));
     }
-    @curl_close($ch);
+    @curl_close($ch); // Some code paths have it closed, others do not
     return FALSE;
   }
   

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -264,8 +264,9 @@ function adsabs_api($ids, $templates, $identifier) {
     } else {
       report_warning(sprintf("Error %d in query_adsabs: %s",
                     $e->getCode(), $e->getMessage()));
-      curl_close($ch);
     }
+    @curl_close($ch);
+    return FALSE;
   }
   
   foreach ($response->docs as $record) {

--- a/user_messages.php
+++ b/user_messages.php
@@ -21,7 +21,7 @@ function report_modification($text) { user_notice("  ~", "changed", $text); }
 function report_add($text) { user_notice("  +", "added", $text); }
 function report_forget($text) { user_notice("  -", "removed", $text); }
 function report_inline($text) { if (!getenv('TRAVIS')) echo " $text"; }
-function report_error($text) { report_warning($text); trigger_error($text, E_USER_ERROR) }; // call report_warning to give users a message before we die
+function report_error($text) { report_warning($text); trigger_error($text, E_USER_ERROR); } // call report_warning to give users a message before we die
   
 function quietly($function = report_info, $text) {
   if (defined('VERBOSE') || HTML_OUTPUT ) {

--- a/user_messages.php
+++ b/user_messages.php
@@ -21,7 +21,8 @@ function report_modification($text) { user_notice("  ~", "changed", $text); }
 function report_add($text) { user_notice("  +", "added", $text); }
 function report_forget($text) { user_notice("  -", "removed", $text); }
 function report_inline($text) { if (!getenv('TRAVIS')) echo " $text"; }
-
+function report_error($text) { report_warning($text); trigger_error($text, E_USER_ERROR) }; // call report_warning to give users a message before we die
+  
 function quietly($function = report_info, $text) {
   if (defined('VERBOSE') || HTML_OUTPUT ) {
     $function($text);


### PR DESCRIPTION
Report an error message for semi-recoverable conditions, instead of dieing in trigger_error().  

Instead of calling  trigger_error() for fatal problems call new report_error() which prints the error if not TRAVIS and then that calls trigger_error() to die -- and give error in TRAVIS.

This pull came about because blocked bot gives no error messages when trigger_error() is called.