### PR TITLE
LOW PRIORITY BUT EASY: Remove old {{Cite pmid}} and {{cite doi}} code

### DIFF
--- a/expandFns.php
+++ b/expandFns.php
@@ -45,7 +45,7 @@ define("FAST_MODE", isset($_REQUEST["fast"]) ? $_REQUEST["fast"] : FALSE);
 if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 
 if (isset($_REQUEST["edit"]) && $_REQUEST["edit"]) {		
-   $ON = TRUE;		
+  $ON = TRUE;		
 }
 
 ################ Functions ##############

--- a/expandFns.php
+++ b/expandFns.php
@@ -44,18 +44,7 @@ ini_set("memory_limit", "256M");
 define("FAST_MODE", isset($_REQUEST["fast"]) ? $_REQUEST["fast"] : FALSE);
 if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 
-if (isset($_REQUEST["crossrefonly"])) {
-  $crossRefOnly = TRUE;
-} elseif (isset($_REQUEST["turbo"])) {
-  $crossRefOnly = $_REQUEST["turbo"];
-} else {
-  $crossRefOnly = FALSE;
-}
-$edit = isset($_REQUEST["edit"]) ? $_REQUEST["edit"] : NULL;
-
-if ($edit || isset($_GET["doi"]) || isset($_GET["pmid"])) {
-  $ON = TRUE;
-}
+$ON = isset($_REQUEST["edit"]) ? $_REQUEST["edit"] : NULL;
 
 ################ Functions ##############
 

--- a/expandFns.php
+++ b/expandFns.php
@@ -45,7 +45,7 @@ define("FAST_MODE", isset($_REQUEST["fast"]) ? $_REQUEST["fast"] : FALSE);
 if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 
 if (isset($_REQUEST["edit"]) && $_REQUEST["edit"]) {		
-  $ON = TRUE;		
+  $ON = TRUE;
 }
 
 ################ Functions ##############

--- a/expandFns.php
+++ b/expandFns.php
@@ -44,7 +44,9 @@ ini_set("memory_limit", "256M");
 define("FAST_MODE", isset($_REQUEST["fast"]) ? $_REQUEST["fast"] : FALSE);
 if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 
-$ON = isset($_REQUEST["edit"]) ? $_REQUEST["edit"] : NULL;
+if (isset($_REQUEST["edit"]) && $_REQUEST["edit"]) {		
+   $ON = TRUE;		
+}
 
 ################ Functions ##############
 


### PR DESCRIPTION
$crossRefOnly is not used anymore
pmid=##### and doi=10.####/##### code is gone