### PR TITLE
fast/slow mode clean up

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1246,7 +1246,7 @@ final class Template {
       }
     }
     
-    if (FAST_MODE || !$data['author'] || !($data['journal'] || $data['issn']) || !$data['start_page'] ) return FALSE;
+    if ( !$data['author'] || !($data['journal'] || $data['issn']) || !$data['start_page'] ) return FALSE;
     
     // If fail, try again with fewer constraints...
     report_info("Full search failed. Dropping author & end_page... ");

--- a/api_handlers/zotero.php
+++ b/api_handlers/zotero.php
@@ -2,8 +2,10 @@
 const ZOTERO_GIVE_UP = 5;
 
 function query_url_api($ids, $templates) {
+  global $SLOW_MODE;
   global $zotero_failures_count;
   $zotero_failures_count = 0;
+  if (!$SLOW_MODE) return; // Zotero takes time
   report_action("Using Zotero translation server to retrieve details from URLs.");
   foreach ($templates as $template) {
     if ($template->has('url')) {

--- a/expandFns.php
+++ b/expandFns.php
@@ -41,7 +41,6 @@ if (!getenv('TRAVIS')) {
 }
 ini_set("memory_limit", "256M");
 
-define("FAST_MODE", isset($_REQUEST["fast"]) ? $_REQUEST["fast"] : FALSE);
 if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 
 if (isset($_REQUEST["edit"]) && $_REQUEST["edit"]) {		


### PR DESCRIPTION
Set Zotero to not be used unless SLOW_MODE is set.
Remove FAST_MODE.  Not really used, not orthoganal to SLOW, etc.