### PR TITLE
Error on reference within citation template

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -55,6 +55,11 @@ final class Template {
     // Clean up outdated redirects
     if ($this->name === 'cite') $this->name = 'citation';
     if ($this->name === 'Cite') $this->name = 'Citation';
+    if (substr($this->wikiname(),0,5) === 'cite ' || $this->wikiname() === 'citation') {
+      if (preg_match('~< */? *ref *>~i', $this->rawtext) {
+         report_error('reference within citation template: most likely unclosed template');
+      }
+    }
 
     // extract initial parameters/values from Parameters in $this->param
     if ($this->param) foreach ($this->param as $p) {

--- a/Template.php
+++ b/Template.php
@@ -56,7 +56,7 @@ final class Template {
     if ($this->name === 'cite') $this->name = 'citation';
     if ($this->name === 'Cite') $this->name = 'Citation';
     if (substr($this->wikiname(),0,5) === 'cite ' || $this->wikiname() === 'citation') {
-      if (preg_match('~< */? *ref *>~i', $this->rawtext) {
+      if (preg_match('~< */? *ref *>~i', $this->rawtext)) {
          report_error('reference within citation template: most likely unclosed template');
       }
     }


### PR DESCRIPTION
This often happens when a template is unclosed and all the parsing goes insanely wrong

https://en.wikipedia.org/w/index.php?title=Calcium_carbonate&type=revision&diff=887674726&oldid=885707535

