### PR TITLE
Not supposed to use global outside of functions

### DIFF
--- a/category.php
+++ b/category.php
@@ -23,10 +23,10 @@ foreach ($argv as $arg) {
     }
   }
 }
-global $SLOW_MODE;
-$SLOW_MODE = FALSE;
+
+$GLOBALS['SLOW_MODE'] = FALSE;
 if (isset($_REQUEST["slow"]) || isset($argument["slow"])) {
-  $SLOW_MODE = TRUE;
+  $GLOBALS['SLOW_MODE'] = TRUE;
 }
 
 $category = trim($argument["cat"] ? $argument["cat"][0] : $_REQUEST["cat"]);

--- a/category.php
+++ b/category.php
@@ -24,9 +24,9 @@ foreach ($argv as $arg) {
   }
 }
 
-$GLOBALS['SLOW_MODE'] = FALSE;
+$SLOW_MODE = FALSE;
 if (isset($_REQUEST["slow"]) || isset($argument["slow"])) {
-  $GLOBALS['SLOW_MODE'] = TRUE;
+  $SLOW_MODE = TRUE;
 }
 
 $category = trim($argument["cat"] ? $argument["cat"][0] : $_REQUEST["cat"]);

--- a/expandFns.php
+++ b/expandFns.php
@@ -40,8 +40,8 @@ if (!getenv('TRAVIS')) {
     ob_start();
 }
 ini_set("memory_limit", "256M");
-global $SLOW_MODE;
-if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
+
+if (!isset($GLOBALS['SLOW_MODE'])) $GLOBALS['SLOW_MODE'] = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 
 if (isset($_REQUEST["edit"]) && $_REQUEST["edit"]) {		
   $ON = TRUE;

--- a/expandFns.php
+++ b/expandFns.php
@@ -41,7 +41,7 @@ if (!getenv('TRAVIS')) {
 }
 ini_set("memory_limit", "256M");
 
-if (!isset($GLOBALS['SLOW_MODE'])) $GLOBALS['SLOW_MODE'] = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
+if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 
 if (isset($_REQUEST["edit"]) && $_REQUEST["edit"]) {		
   $ON = TRUE;

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -6,8 +6,8 @@ header("Content-Type: text/json");
 ob_start();
 define("FLUSHING_OKAY", FALSE);
 
-$GLOBALS['SLOW_MODE']  = FALSE;
-if (isset($_REQUEST["slow"])) $GLOBALS['SLOW_MODE'] = TRUE;
+$SLOW_MODE  = FALSE;
+if (isset($_REQUEST["slow"])) $SLOW_MODE = TRUE;
 
 //Set up tool requirements
 require_once('expandFns.php');

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -6,7 +6,7 @@ header("Content-Type: text/json");
 ob_start();
 define("FLUSHING_OKAY", FALSE);
 
-$SLOW_MODE  = FALSE;
+$SLOW_MODE = FALSE;
 if (isset($_REQUEST["slow"])) $SLOW_MODE = TRUE;
 
 //Set up tool requirements

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -5,9 +5,9 @@ header("Content-Type: text/json");
 // This is needed because the Gadget API expects only JSON back, therefore ALL output from the citation bot is thrown away
 ob_start();
 define("FLUSHING_OKAY", FALSE);
-global $SLOW_MODE;
-$SLOW_MODE = FALSE;
-if (isset($_REQUEST["slow"])) $SLOW_MODE = TRUE;
+
+$GLOBALS['SLOW_MODE']  = FALSE;
+if (isset($_REQUEST["slow"])) $GLOBALS['SLOW_MODE'] = TRUE;
 
 //Set up tool requirements
 require_once('expandFns.php');

--- a/process_page.php
+++ b/process_page.php
@@ -1,7 +1,7 @@
 <?php
 @session_start();
 define("HTML_OUTPUT", !isset($argv));
-global $SLOW_MODE;
+
 require_once("expandFns.php");
 $api = new WikipediaBot();
 if (HTML_OUTPUT) {?>
@@ -77,7 +77,7 @@ foreach (explode('|', $pages) as $title) {
     <input type="hidden" name="page" value="<?php echo $title;?>" />
     <input type="hidden" name="user" value="<?php echo $user;?>" />
     <input type="hidden" name="edit" value="on" />
-    <input type="hidden" name="slow" value="<?php echo $SLOW_MODE;?>" />
+    <input type="hidden" name="slow" value="<?php echo $GLOBALS['SLOW_MODE'];?>" />
     <input type="submit" value="Submit edits" />
   </form>
   <?php

--- a/process_page.php
+++ b/process_page.php
@@ -77,7 +77,7 @@ foreach (explode('|', $pages) as $title) {
     <input type="hidden" name="page" value="<?php echo $title;?>" />
     <input type="hidden" name="user" value="<?php echo $user;?>" />
     <input type="hidden" name="edit" value="on" />
-    <input type="hidden" name="slow" value="<?php echo $GLOBALS['SLOW_MODE'];?>" />
+    <input type="hidden" name="slow" value="<?php echo $SLOW_MODE;?>" />
     <input type="submit" value="Submit edits" />
   </form>
   <?php

--- a/tests/testBaseClass.php
+++ b/tests/testBaseClass.php
@@ -1,7 +1,7 @@
 <?php
 error_reporting(E_ALL); // All tests run this way
 if (!defined('VERBOSE')) define('VERBOSE', TRUE);
-global $SLOW_MODE;
+
 $SLOW_MODE = TRUE;
 
 abstract class testBaseClass extends PHPUnit\Framework\TestCase {


### PR DESCRIPTION
Why not?  Because PHP says so.  Because they are automatically global in scope.

Foolishly added by me, since I could not see why gadget api did not expand bibcodes.  I figured that out and it is in another pull #1547 