### PR TITLE
Fix output buffering code

### DIFF
--- a/category.php
+++ b/category.php
@@ -62,7 +62,6 @@ if ($category) {
   if (!is_array($pages_in_category) || empty($pages_in_category)) {
     echo('Category appears to be empty');
     html_echo(' </pre></body></html>', "\n");
-    ob_end_flush(); 
     exit(0);
   }
   shuffle($pages_in_category);
@@ -94,5 +93,4 @@ if ($category) {
   echo ("You must specify a category.  Try appending ?cat=Blah+blah to the URL, or -cat Category_name at the command line.");
 }
 html_echo(' # # #</pre></body></html>', "\n");
-ob_end_flush(); 
 exit(0);

--- a/expandFns.php
+++ b/expandFns.php
@@ -38,7 +38,7 @@ mb_internal_encoding('UTF-8'); // Avoid ??s
 
 //Optimisation
 ob_implicit_flush();
-if (!getenv('TRAVIS')) {
+if (!getenv('TRAVIS') && (ob_get_level() == 0)) { // The gadget API turns this on earlier
     ob_start();
 }
 ini_set("memory_limit", "256M");

--- a/expandFns.php
+++ b/expandFns.php
@@ -17,7 +17,7 @@ if (!defined("FLUSHING_OKAY")) {  // Default when not gadget API
 
 //Optimisation
 ob_implicit_flush();
-if (!getenv('TRAVIS') && (ob_get_level() == 0)) { // The gadget API turns this on earlier
+if (!getenv('TRAVIS')) {
     ob_start();
 }
 

--- a/expandFns.php
+++ b/expandFns.php
@@ -6,7 +6,6 @@
 */
 
 ini_set("user_agent", "Citation_bot; citations@tools.wmflabs.org");
-ini_set("memory_limit", "256M");
 include_once("./vendor/autoload.php");
 
 if (!defined("HTML_OUTPUT") || getenv('TRAVIS')) {  // Fail safe code
@@ -43,6 +42,7 @@ foreach ($api_files as $file) {
 }
 
 mb_internal_encoding('UTF-8'); // Avoid ??s
+ini_set("memory_limit", "256M");
 
 if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 

--- a/expandFns.php
+++ b/expandFns.php
@@ -6,6 +6,7 @@
 */
 
 ini_set("user_agent", "Citation_bot; citations@tools.wmflabs.org");
+ini_set("memory_limit", "256M");
 include_once("./vendor/autoload.php");
 
 if (!defined("HTML_OUTPUT") || getenv('TRAVIS')) {  // Fail safe code
@@ -14,6 +15,13 @@ if (!defined("HTML_OUTPUT") || getenv('TRAVIS')) {  // Fail safe code
 if (!defined("FLUSHING_OKAY")) {  // Default when not gadget API
   define("FLUSHING_OKAY", TRUE);
 }
+
+//Optimisation
+ob_implicit_flush();
+if (!getenv('TRAVIS') && (ob_get_level() == 0)) { // The gadget API turns this on earlier
+    ob_start();
+}
+
 if (!getenv('PHP_OAUTH_CONSUMER_TOKEN') && file_exists('env.php')) {
   // An opportunity to set the PHP_OAUTH_ environment variables used in this function,
   // if they are not set already. Remember to set permissions (not readable!)
@@ -35,13 +43,6 @@ foreach ($api_files as $file) {
 }
 
 mb_internal_encoding('UTF-8'); // Avoid ??s
-
-//Optimisation
-ob_implicit_flush();
-if (!getenv('TRAVIS') && (ob_get_level() == 0)) { // The gadget API turns this on earlier
-    ob_start();
-}
-ini_set("memory_limit", "256M");
 
 if (!isset($SLOW_MODE)) $SLOW_MODE = isset($_REQUEST["slow"]) ? $_REQUEST["slow"] : FALSE;
 

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -32,8 +32,6 @@ if ($newText !== $originalText) {
 
 if (isset($_REQUEST['debug']) && $_REQUEST['debug']==='1') {
   $debug_text = @ob_get_flush();
-  $debug_text = @ob_get_flush() . $debug_text;
-  $debug_text = @ob_get_flush() . $debug_text;
 } else {
   $debug_text = '';
 }
@@ -45,6 +43,6 @@ $result = array(
 );
 
 // Throw away all output
-@ob_end_clean(); @ob_end_clean(); @ob_end_clean();  // Other parts of the code might open a buffer
+@ob_end_clean();
 
 echo @json_encode($result);  // On error returns "FALSE", which makes echo print nothing.  Thus we do not have to check for FALSE

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -31,7 +31,7 @@ if ($newText !== $originalText) {
 }
 
 if (isset($_REQUEST['debug']) && $_REQUEST['debug']==='1') {
-  $debug_text = @ob_get_contents() . @ob_get_contents() . @ob_get_contents(); // Just in case some other part of the code sets up a buffer
+  $debug_text = @ob_end_flush() . @ob_end_flush() . @ob_end_flush(); // Just in case some other part of the code sets up a buffer
 } else {
   $debug_text = '';
 }

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -31,9 +31,9 @@ if ($newText !== $originalText) {
 }
 
 if (isset($_REQUEST['debug']) && $_REQUEST['debug']==='1') {
-  $debug_text = @ob_end_flush();
-  $debug_text = @ob_end_flush() . $debug_text;
-  $debug_text = @ob_end_flush() . $debug_text;
+  $debug_text = @ob_get_flush();
+  $debug_text = @ob_get_flush() . $debug_text;
+  $debug_text = @ob_get_flush() . $debug_text;
 } else {
   $debug_text = '';
 }

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -31,9 +31,10 @@ if ($newText !== $originalText) {
 }
 
 if (isset($_REQUEST['debug']) && $_REQUEST['debug']==='1') {
-  $debug_text = @ob_get_flush();
+  $debug_text = ob_get_flush();
 } else {
   $debug_text = '';
+  ob_end_clean();
 }
 
 $result = array(
@@ -41,8 +42,5 @@ $result = array(
   'editsummary' => $editSummary,
   'debug' => $debug_text,
 );
-
-// Throw away all output
-@ob_end_clean();
 
 echo @json_encode($result);  // On error returns "FALSE", which makes echo print nothing.  Thus we do not have to check for FALSE

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -31,7 +31,9 @@ if ($newText !== $originalText) {
 }
 
 if (isset($_REQUEST['debug']) && $_REQUEST['debug']==='1') {
-  $debug_text = @ob_end_flush() . @ob_end_flush() . @ob_end_flush(); // Just in case some other part of the code sets up a buffer
+  $debug_text = @ob_end_flush();
+  $debug_text = @ob_end_flush() . $debug_text;
+  $debug_text = @ob_end_flush() . $debug_text;
 } else {
   $debug_text = '';
 }

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -3,7 +3,6 @@ header("Access-Control-Allow-Origin: *"); //This is ok because the API is not au
 header("Content-Type: text/json");
 
 // This is needed because the Gadget API expects only JSON back, therefore ALL output from the citation bot is thrown away
-ob_start();
 define("FLUSHING_OKAY", FALSE);
 
 $SLOW_MODE = FALSE;


### PR DESCRIPTION
Move buffer starting higher up on code to catch "Reading tokens...." text in buffer too.
This means that we no longer need to start buffering in gadget page.
Lastly this means we only have to free one buffer in gadget.

Lastly — I really mean it this time — exit() Call’s flush too, so no need to call right before exit() calls.