### PR TITLE
Better GIT debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/*
 tmp/*
 env.php
 core
+coverage.xml

--- a/gitpull.php
+++ b/gitpull.php
@@ -1,5 +1,5 @@
 <?php
-echo "<pre>";
+echo "<!DOCTYPE html><html><head><title>Update</title></head><body><pre>";
 // Local changes seem to accumulate in capitalization.php, preventing a pull
 exec ("git checkout constants/capitalization.php", $output);
 exec ("git pull", $output, $return_var);
@@ -23,4 +23,4 @@ unset($output);
 exec("git show --oneline -s", $output, $return_var);
 foreach ($output as $line) echo "$line \n";
 
-echo "</pre>"
+echo "</pre></body></html>"

--- a/gitpull.php
+++ b/gitpull.php
@@ -10,7 +10,7 @@ exec ("git pull", $output, $return_var);
   if ($return_var == 1) {
     echo "\n Check that there are no uncommitted changes on the server.\n\n";
     unset($output);
-    exec("git status -uno", $output, $return_var);
+    exec("git status", $output, $return_var);
     foreach ($output as $line) echo "$line \n";
   }
 } else {

--- a/gitpull.php
+++ b/gitpull.php
@@ -1,24 +1,26 @@
 <?php
+echo "<pre>";
 // Local changes seem to accumulate in capitalization.php, preventing a pull
 exec ("git checkout constants/capitalization.php", $output);
 exec ("git pull", $output, $return_var);
-?><pre>
-<?php foreach($output as $line) echo "$line \n"; ?>
-<?php if ($return_var) {
-  echo "Returned error code $return_var \n";
+foreach($output as $line) echo "$line \n";
+
+if ($return_var) {
   if ($return_var == 1) {
-    echo "\n Check that there are no uncommitted changes on the server.\n\n";
+    echo "\n Failure.  Check that there are no uncommitted changes on the server.\n\n";
     unset($output);
     exec("git status", $output, $return_var);
     foreach ($output as $line) echo "$line \n";
+    echo "\n";
+  } else {
+    echo "\n Returned error code $return_var \n\n";
   }
 } else {
   echo "Successfully updated from Git repository.\n";
 }
-?>
-<?php
+
 unset($output);
 exec("git show --oneline -s", $output, $return_var);
 foreach ($output as $line) echo "$line \n";
-?>
-</pre>
+
+echo "</pre>"

--- a/gitpull.php
+++ b/gitpull.php
@@ -1,8 +1,7 @@
 <?php
 // Local changes seem to accumulate in capitalization.php, preventing a pull
-exec ("git checkout constants/capitalization.php", $output); 
+exec ("git checkout constants/capitalization.php", $output);
 exec ("git pull", $output, $return_var);
-#exec ("git fetch --all", $output, $return_var); // Doesn't seem to do much...
 ?><pre>
 <?php foreach($output as $line) echo "$line \n"; ?>
 <?php if ($return_var) {

--- a/gitpull.php
+++ b/gitpull.php
@@ -24,3 +24,4 @@ exec("git show --oneline -s", $output, $return_var);
 foreach ($output as $line) echo "$line \n";
 
 echo "</pre></body></html>"
+?>


### PR DESCRIPTION
It _appears_ that the GIT problems must be caused by files that we are creating that need to be added to git ignore.  Time to list them in debug output.

Also make the HTML text an "echo" instead of outside of PHP.

And add all the extra HTML tags too, just because.