### PR TITLE
Do not throw away Unpaywall OAI-PMH matches

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1943,7 +1943,7 @@ final class Template {
         }
         if (@$best_location->evidence == 'oa repository (via OAI-PMH title and first author match)') {
           // false positives are too common
-          report_warning("Unpaywall found an OA match on a repository via OAI-PMH" . echoable($doi));
+          report_warning("Unpaywall found an OA match on a repository via OAI-PMH for DOI: " . echoable($doi));
         }  
         // sometimes url_for_landing_page = null, eg http://api.oadoi.org/v2/10.1145/3238147.3240474?email=m@f
         if ($best_location->url_for_landing_page != null) {

--- a/Template.php
+++ b/Template.php
@@ -1952,6 +1952,7 @@ final class Template {
         if (@$oa->journal_name == "Cochrane Database of Systematic Reviews" && @$best_location->evidence == 'oa repository (via OAI-PMH title and first author match)' && ) {
           // false positives are too common https://github.com/Impactstory/oadoi/issues/121
           report_warning("Ignored a blacklisted OA match on a repository via OAI-PMH for DOI: " . echoable($doi));
+          return FALSE;
         }  
         // sometimes url_for_landing_page = null, eg http://api.oadoi.org/v2/10.1145/3238147.3240474?email=m@f
         if ($best_location->url_for_landing_page != null) {

--- a/Template.php
+++ b/Template.php
@@ -1949,9 +1949,9 @@ final class Template {
           // The best location is already linked to by the doi link
           return TRUE;
         }
-        if (@$best_location->evidence == 'oa repository (via OAI-PMH title and first author match)') {
-          // false positives are too common
-          report_warning("Unpaywall found an OA match on a repository via OAI-PMH for DOI: " . echoable($doi));
+        if (@$oa->journal_name == "Cochrane Database of Systematic Reviews" && @$best_location->evidence == 'oa repository (via OAI-PMH title and first author match)' && ) {
+          // false positives are too common https://github.com/Impactstory/oadoi/issues/121
+          report_warning("Ignored a blacklisted OA match on a repository via OAI-PMH for DOI: " . echoable($doi));
         }  
         // sometimes url_for_landing_page = null, eg http://api.oadoi.org/v2/10.1145/3238147.3240474?email=m@f
         if ($best_location->url_for_landing_page != null) {

--- a/Template.php
+++ b/Template.php
@@ -1931,7 +1931,7 @@ final class Template {
     if (!$this->blank(DOI_BROKEN_ALIASES)) return;
     $doi = $this->get_without_comments_and_placeholders('doi');
     if (!$doi) return;
-    $url = "https://api.oadoi.org/v2/$doi?email=" . CROSSREFUSERNAME;
+    $url = "https://api.unpaywall.org/v2/$doi?email=" . CROSSREFUSERNAME;
     $json = @file_get_contents($url);
     if ($json) {
       $oa = @json_decode($json);
@@ -1943,7 +1943,7 @@ final class Template {
         }
         if (@$best_location->evidence == 'oa repository (via OAI-PMH title and first author match)') {
           // false positives are too common
-          return FALSE;
+          report_warning("Unpaywall found an OA match on a repository via OAI-PMH" . echoable($doi));
         }  
         // sometimes url_for_landing_page = null, eg http://api.oadoi.org/v2/10.1145/3238147.3240474?email=m@f
         if ($best_location->url_for_landing_page != null) {
@@ -2025,7 +2025,7 @@ final class Template {
           $headers_test = @get_headers($this->get('url'), 1);
           if($headers_test ===FALSE) {
             $this->forget('url');
-            report_warning("Open access URL was was unreachable from oiDOI API for doi: " . echoable($doi));
+            report_warning("Open access URL was was unreachable from Unpaywall API for doi: " . echoable($doi));
             return FALSE;
           }
           $response_code = intval(substr($headers_test[0], 9, 3)); 

--- a/Template.php
+++ b/Template.php
@@ -1949,7 +1949,7 @@ final class Template {
           // The best location is already linked to by the doi link
           return TRUE;
         }
-        if (@$oa->journal_name == "Cochrane Database of Systematic Reviews" && @$best_location->evidence == 'oa repository (via OAI-PMH title and first author match)' && ) {
+        if (@$oa->journal_name == "Cochrane Database of Systematic Reviews" && @$best_location->evidence == 'oa repository (via OAI-PMH title and first author match)' ) {
           // false positives are too common https://github.com/Impactstory/oadoi/issues/121
           report_warning("Ignored a blacklisted OA match on a repository via OAI-PMH for DOI: " . echoable($doi));
           return FALSE;


### PR DESCRIPTION
Since this blacklist was added, Unpaywall/OAdoi has improved accuracy.
OAI-PMH author and title match also gets higher priority compared to other
methods like trusting whatever the metadata claims about DOI relationships.