### PR TITLE
Initial test against QA.adsabs

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1557,38 +1557,31 @@ final class Template {
     }
   
     report_action("Checking AdsAbs database");
-    if ($bibcode = $this->has('bibcode')) {
-      $result = $this->query_adsabs("bibcode:" . urlencode('"' . $this->get("bibcode") . '"'));
-    } elseif ($this->has('doi') 
-              && preg_match(REGEXP_DOI, $this->get_without_comments_and_placeholders('doi'), $doi)) {
-      $result = $this->query_adsabs("doi:" . urlencode('"' . $doi[0] . '"'));
-      if ($result->numFound == 0) { // there's a slew of citations, mostly in mathematics, that never get anything but an arxiv bibcode
-        if ($this->has('eprint')) {
-          $result = $this->query_adsabs("arXiv:" . urlencode('"' .$this->get('eprint') . '"'));
-        } elseif ($this->has('arxiv')) {
-          $result = $this->query_adsabs("arXiv:" . urlencode('"' .$this->get('arxiv') . '"'));
-        }
-      }
-    } elseif ($this->has('title') || $this->has('eprint') || $this->has('arxiv')) {
-      if ($this->has('eprint')) {
-        $result = $this->query_adsabs("arXiv:" . urlencode('"' .$this->get('eprint') . '"'));
-      } elseif ($this->has('arxiv')) {
-        $result = $this->query_adsabs("arXiv:" . urlencode('"' .$this->get('arxiv') . '"'));
-      } else {
-        $result = (object) array("numFound" => 0);
-      }
-      if (($result->numFound != 1) && $this->has('title')) { // Do assume failure to find arXiv means that it is not there
-        $result = $this->query_adsabs("title:" . urlencode('"' .  trim(str_replace('"', ' ', $this->get_without_comments_and_placeholders("title"))) . '"'));
-        if ($result->numFound == 0) return FALSE;
-        $record = $result->docs[0];
-        if (titles_are_dissimilar($record->title[0], $this->get('title'))) {
-          report_info("Similar title not found in database");
-          return FALSE;
-        }
+    $identifiers = array_filter(array(
+      ($bibcode = $this->has('bibcode')) ? $this->get("bibcode") : NULL,
+      ($this->has('doi') 
+       && preg_match(REGEXP_DOI, $this->get_without_comments_and_placeholders('doi'), $doi)) ?  
+        $doi[0] : NULL,
+      ($this->has('eprint')) ? $this->get('eprint') :
+        (($this->has('arxiv')) ? $this->get('arxiv') : NULL)
+    ));
+    
+    $result = empty($identifiers) ? 
+      (object) array("numFound" => 0) :
+      $this->query_adsabs("identifier:" . urlencode('"' . implode(' OR ', $identifiers) . '"'));
+    
+    if (($result->numFound != 1) && $this->has('title')) { // Do assume failure to find arXiv means that it is not there
+      $result = $this->query_adsabs("title:" . urlencode('"' .  trim(str_replace('"', ' ', $this->get_without_comments_and_placeholders("title"))) . '"'));
+      if ($result->numFound == 0) return FALSE;
+      $record = $result->docs[0];
+      if (titles_are_dissimilar($record->title[0], $this->get('title'))) {
+        report_info("Similar title not found in database");
+        return FALSE;
       }
     } else {
       $result = (object) array("numFound" => 0);
     }
+    
     if ($result->numFound != 1 && $this->has('journal')) {
       $journal = $this->get('journal');
       // try partial search using bibcode components:

--- a/Template.php
+++ b/Template.php
@@ -1737,8 +1737,7 @@ final class Template {
     
     try {
       $ch = curl_init();
-      curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Bearer ' . 
-      (getenv('TRAVIS') ? getenv('PHP_ADSABSQAKEY') : getenv('PHP_ADSABSAPIKEY'))));
+      curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Bearer ' . getenv('PHP_ADSABSAPIKEY')));
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
       curl_setopt($ch, CURLOPT_HEADER, TRUE);
       $adsabs_url = "https://" . (getenv('TRAVIS') ? 'qa' : 'api')

--- a/Template.php
+++ b/Template.php
@@ -1744,10 +1744,12 @@ final class Template {
     
     try {
       $ch = curl_init();
-      curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Bearer ' . getenv('PHP_ADSABSAPIKEY')));
+      curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Bearer ' . 
+      (getenv('TRAVIS') ? getenv('PHP_ADSABSQAKEY') : getenv('PHP_ADSABSAPIKEY'))));
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
       curl_setopt($ch, CURLOPT_HEADER, TRUE);
-      $adsabs_url = "https://api.adsabs.harvard.edu/v1/search/query"
+      $adsabs_url = "https://" . (getenv('TRAVIS') ? 'qa' : 'api')
+                  . ".adsabs.harvard.edu/v1/search/query"
                   . "?q=$options&fl=arxiv_class,author,bibcode,doi,doctype,identifier,"
                   . "issue,page,pub,pubdate,title,volume,year";
       curl_setopt($ch, CURLOPT_URL, $adsabs_url);

--- a/Template.php
+++ b/Template.php
@@ -1557,31 +1557,38 @@ final class Template {
     }
   
     report_action("Checking AdsAbs database");
-    $identifiers = array_filter(array(
-      ($bibcode = $this->has('bibcode')) ? $this->get("bibcode") : NULL,
-      ($this->has('doi') 
-       && preg_match(REGEXP_DOI, $this->get_without_comments_and_placeholders('doi'), $doi)) ?  
-        $doi[0] : NULL,
-      ($this->has('eprint')) ? $this->get('eprint') :
-        (($this->has('arxiv')) ? $this->get('arxiv') : NULL)
-    ));
-    
-    $result = empty($identifiers) ? 
-      (object) array("numFound" => 0) :
-      $this->query_adsabs("identifier:" . urlencode('"' . implode(' OR ', $identifiers) . '"'));
-    
-    if (($result->numFound != 1) && $this->has('title')) { // Do assume failure to find arXiv means that it is not there
-      $result = $this->query_adsabs("title:" . urlencode('"' .  trim(str_replace('"', ' ', $this->get_without_comments_and_placeholders("title"))) . '"'));
-      if ($result->numFound == 0) return FALSE;
-      $record = $result->docs[0];
-      if (titles_are_dissimilar($record->title[0], $this->get('title'))) {
-        report_info("Similar title not found in database");
-        return FALSE;
+    if ($bibcode = $this->has('bibcode')) {
+      $result = $this->query_adsabs("bibcode:" . urlencode('"' . $this->get("bibcode") . '"'));
+    } elseif ($this->has('doi') 
+              && preg_match(REGEXP_DOI, $this->get_without_comments_and_placeholders('doi'), $doi)) {
+      $result = $this->query_adsabs("doi:" . urlencode('"' . $doi[0] . '"'));
+      if ($result->numFound == 0) { // there's a slew of citations, mostly in mathematics, that never get anything but an arxiv bibcode
+        if ($this->has('eprint')) {
+          $result = $this->query_adsabs("arXiv:" . urlencode('"' .$this->get('eprint') . '"'));
+        } elseif ($this->has('arxiv')) {
+          $result = $this->query_adsabs("arXiv:" . urlencode('"' .$this->get('arxiv') . '"'));
+        }
+      }
+    } elseif ($this->has('title') || $this->has('eprint') || $this->has('arxiv')) {
+      if ($this->has('eprint')) {
+        $result = $this->query_adsabs("arXiv:" . urlencode('"' .$this->get('eprint') . '"'));
+      } elseif ($this->has('arxiv')) {
+        $result = $this->query_adsabs("arXiv:" . urlencode('"' .$this->get('arxiv') . '"'));
+      } else {
+        $result = (object) array("numFound" => 0);
+      }
+      if (($result->numFound != 1) && $this->has('title')) { // Do assume failure to find arXiv means that it is not there
+        $result = $this->query_adsabs("title:" . urlencode('"' .  trim(str_replace('"', ' ', $this->get_without_comments_and_placeholders("title"))) . '"'));
+        if ($result->numFound == 0) return FALSE;
+        $record = $result->docs[0];
+        if (titles_are_dissimilar($record->title[0], $this->get('title'))) {
+          report_info("Similar title not found in database");
+          return FALSE;
+        }
       }
     } else {
       $result = (object) array("numFound" => 0);
     }
-    
     if ($result->numFound != 1 && $this->has('journal')) {
       $journal = $this->get('journal');
       // try partial search using bibcode components:

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -187,7 +187,8 @@ function adsabs_api($ids, $templates, $identifier) {
   if (count($ids) == 0) return TRUE; // None left after removing books and & symbol
 
   // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
-  $adsabs_url = "https://api.adsabs.harvard.edu/v1/search/bigquery?q=*:*"
+  $adsabs_url = "https://" . (getenv('TRAVIS') ? 'qa' : 'api')
+              . ".adsabs.harvard.edu/v1/search/bigquery?q=*:*"
               . "&fl=arxiv_class,author,bibcode,doi,doctype,identifier,"
               . "issue,page,pub,pubdate,title,volume,year&rows=2000";
 


### PR DESCRIPTION
Use qa.adsabs for testing, to avoid depleting api.adsabs queries.