### PR TITLE
Try to increase concurrency by half

### DIFF
--- a/.lighttpd.conf
+++ b/.lighttpd.conf
@@ -2,7 +2,7 @@ fastcgi.server += ( ".php" =>
         ((
                 "bin-path" => "/usr/bin/php-cgi",
                 "socket" => "/var/run/lighttpd/php.socket.citations",
-                "max-procs" => 4,
+                "max-procs" => 6,
                 "bin-environment" => (
                         "PHP_FCGI_CHILDREN" => "3",
                         "PHP_FCGI_MAX_REQUESTS" => "500"


### PR DESCRIPTION
The bot is currently impossibly slow to use for single pages while it is
successfully managing two large categories at once.
https://en.wikipedia.org/w/index.php?title=Special:Contributions&dir=prev&offset=20190828081954&limit=500&target=Citation+bot