### PR TITLE
Prevent undefined variable errors from $the_example_user

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 if (isset($_SESSION['citation_bot_user_id']) && is_string($_SESSION['citation_bot_user_id'])) {
   $the_example_user = @htmlspecialchars($_SESSION['citation_bot_user_id']);
 }
-if (!$the_example_user) {
+if (empty($the_example_user)) {
   $the_example_user = 'YourUserID';
 }
 ?>

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -308,9 +308,11 @@ final class PageTest extends testBaseClass {
   }
                         
   public function testUrlReferencesWithText17() : void {
+    $this->requires_google(function() : void {
       $text = "<ref>{{oclc|23454}}</ref>";
       $page = $this->process_page($text);
       $this->assertTrue((bool) strpos($page->parsed_text(), 'it'));
+    });
   }                    
                         
   public function testMagazine() : void {


### PR DESCRIPTION
This prevents an undefined variable error being thrown every time someone loads the index page.