### PR TITLE
Error str ireplace on PHP 8.3

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2642,6 +2642,7 @@ final class Template {
             if ($this->get('url') !== $oa_url) $this->get_identifiers_from_url($oa_url);  // Maybe we can get a new link type
             return 'have url';
         }
+        $is_canonical_publisher=FALSE;
         if (preg_match("~^https?://([^\/]+)/~", $oa_url, $match) === 1)
         {
           $host_name = @$match[1];

--- a/Template.php
+++ b/Template.php
@@ -2642,9 +2642,18 @@ final class Template {
             if ($this->get('url') !== $oa_url) $this->get_identifiers_from_url($oa_url);  // Maybe we can get a new link type
             return 'have url';
         }
-        preg_match("~^https?://([^\/]+)/~", $oa_url, $match);
-        $host_name = @$match[1];
-        if (str_ireplace(CANONICAL_PUBLISHER_URLS, '', $host_name) !== $host_name) return 'publisher';
+        if (preg_match("~^https?://([^\/]+)/~", $oa_url, $match) === 1)
+        {
+          $host_name = @$match[1];
+          if ($host_name)
+          {
+            if (str_ireplace(CANONICAL_PUBLISHER_URLS, '', $host_name) === $host_name) {$is_canonical_publisher=TRUE;}
+          }
+        }
+        if ($is_canonical_publisher!==TRUE)
+        {
+           return 'publisher';
+        }
         if (stripos($oa_url, 'bioone.org/doi') !== FALSE) return 'publisher';
         if (stripos($oa_url, 'gateway.isiknowledge.com') !== FALSE) return 'nothing';
         if (stripos($oa_url, 'orbit.dtu.dk/en/publications') !== FALSE) return 'nothing'; // Abstract only

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1411,6 +1411,8 @@ function process_bibcode_data(Template $this_template, object $record) : void {
        unset($record->issue);
       } elseif (preg_match('~[A-Za-z]~', $tmp)) { // Do not trust anything with letters
        unset($record->page);
+      } elseif (($tmp === $this_template->get('issue')) || ($tmp === $this_template->get('volume'))) {
+       unset($record->page); // Probably is journal without pages, but article numbers and got mis-encoded
       }
     }
     if (isset($record->volume)) $this_template->add_if_new('volume', (string) $record->volume, 'adsabs');


### PR DESCRIPTION
There was the following code
```
preg_match("~^https?://([^\/]+)/~", $oa_url, $match);
$host_name = @$match[1];
str_ireplace(CANONICAL_PUBLISHER_URLS, '', $host_name)
```
It could produce $host_name as null as an argument for str_ireplace if there was no match.

To reproduce it, use it with PHP 8.3, on the wikipedia page "Steroid"