### PR TITLE
Ability to specify PubMed API Key and email via enrvironment variable

### DIFF
--- a/.github/workflows/php-static2.yml
+++ b/.github/workflows/php-static2.yml
@@ -44,7 +44,7 @@ jobs:
       run: composer install --prefer-dist  -vvv --no-progress
 
     - name: PHP phpstan
-      run: php ./vendor/bin/phpstan --no-interaction analyse --memory-limit=2G constants/*.php html_headers.php Parameter.php user_messages.php constants.php big_jobs.php expandFns.php Zotero.php apiFunctions.php NameTools.php Comment.php Page.php WikipediaBot.php Template.php setup.php category.php generate_template.php linked_pages.php process_page.php authenticate.php
+      run: php ./vendor/bin/phpstan --no-interaction analyse --memory-limit=2G constants/*.php html_headers.php Parameter.php user_messages.php constants.php big_jobs.php setup.php expandFns.php Zotero.php apiFunctions.php NameTools.php Comment.php Page.php WikipediaBot.php Template.php category.php generate_template.php linked_pages.php process_page.php authenticate.php
 
     - name: PHP phan
       run: php ./vendor/bin/phan --analyze-twice --allow-polyfill-parser --target-php-version='7.4' --minimum-target-php-version='7.4'

--- a/Template.php
+++ b/Template.php
@@ -2176,16 +2176,9 @@ final class Template {
     $xml = get_entrez_xml('esearch_pubmed', $query);
     // @codeCoverageIgnoreStart
     if ($xml === NULL) {
-      if (!has_nlm_apikey())
-      {
-        // only retry if we have no api_key
-        sleep(1);
-        $xml = get_entrez_xml('esearch_pubmed', $query);
-      }
-      if ($xml === NULL) {
-         report_inline("no results.");
-         return array('', 0, array());
-      }
+       sleep(1); // You should get a key
+       report_inline("no results.");
+       return array('', 0, array());
     }
     if (isset($xml->ErrorList)) { // Could look at $xml->ErrorList->PhraseNotFound for list of what was not found
       report_inline('no results.');

--- a/Template.php
+++ b/Template.php
@@ -2176,7 +2176,7 @@ final class Template {
     $xml = get_entrez_xml('esearch_pubmed', $query);
     // @codeCoverageIgnoreStart
     if ($xml === NULL) {
-       sleep(1); // You should get a key
+       sleep(1);
        report_inline("no results.");
        return array('', 0, array());
     }

--- a/Template.php
+++ b/Template.php
@@ -2176,8 +2176,12 @@ final class Template {
     $xml = get_entrez_xml('esearch_pubmed', $query);
     // @codeCoverageIgnoreStart
     if ($xml === NULL) {
-      sleep(1);
-      $xml = get_entrez_xml('esearch_pubmed', $query);
+      if (!has_nlm_apikey())
+      {
+        // only retry if we have no api_key
+        sleep(1);
+        $xml = get_entrez_xml('esearch_pubmed', $query);
+      }
       if ($xml === NULL) {
          report_inline("no results.");
          return array('', 0, array());

--- a/Zotero.php
+++ b/Zotero.php
@@ -1516,7 +1516,7 @@ public static function find_indentifiers_in_urls(Template $template, ?string $ur
           $new_pmc = @$match[1] . @$match[2];
           if (is_null($url_sent)) {
             if (stripos($url, ".pdf") !== FALSE) {
-              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $new_pmc . "/" . get_nlm_apikey();
+              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $new_pmc . "/" . NLM_APIKEY;
               curl_setopt_array(self::$ch_pmc, [CURLOPT_URL => $test_url]);
               @curl_exec(self::$ch_pmc);
               $httpCode = (int) @curl_getinfo(self::$ch_pmc, CURLINFO_HTTP_CODE);

--- a/Zotero.php
+++ b/Zotero.php
@@ -1516,7 +1516,7 @@ public static function find_indentifiers_in_urls(Template $template, ?string $ur
           $new_pmc = @$match[1] . @$match[2];
           if (is_null($url_sent)) {
             if (stripos($url, ".pdf") !== FALSE) {
-              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $new_pmc . "/";
+              $test_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC" . $new_pmc . "/" . get_nlm_apikey();
               curl_setopt_array(self::$ch_pmc, [CURLOPT_URL => $test_url]);
               @curl_exec(self::$ch_pmc);
               $httpCode = (int) @curl_getinfo(self::$ch_pmc, CURLINFO_HTTP_CODE);

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1362,9 +1362,7 @@ function get_entrez_xml(string $type, string $query) : ?SimpleXMLElement {
    }
    $xml = xml_post($url, $post);
    if ($xml === NULL) {
-      // @codeCoverageIgnoreStart
-      sleep(1); // You should get an API key
-      // @codeCoverageIgnoreEnd
+      sleep(1); // @codeCoverageIgnore
    }
    return $xml;
 }

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1368,13 +1368,8 @@ function get_entrez_xml(string $type, string $query) : ?SimpleXMLElement {
    $xml = xml_post($url, $post);
    if ($xml === NULL) {
       // @codeCoverageIgnoreStart
-     if (!has_nlm_apikey())
-     {
-       // only sleep if we have no API key; otherwise there is no reason to sleep
-       sleep(3);
-       $xml = xml_post($url, $post);
-       // @codeCoverageIgnoreEnd
-     }
+      sleep(1); // You should get an API key
+      // @codeCoverageIgnoreEnd
    }
    return $xml;
 }

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1345,11 +1345,6 @@ function get_nlm_apikey() : string {
   }
 }
 
-function has_nlm_apikey() : bool {
-  return strlen(get_nlm_apikey()) > 0;
-}
-
-
 function get_entrez_xml(string $type, string $query) : ?SimpleXMLElement {
    $url =  "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
    $post=  "tool=WikipediaCitationBot&email=" . NLM_EMAIL . get_nlm_apikey();

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1332,9 +1332,27 @@ function Bibcode_Response_Processing(string $return, $ch, string $adsabs_url) : 
   // @codeCoverageIgnoreEnd
 }
 
+function get_nlm_apikey() : string {
+// see https://www.ncbi.nlm.nih.gov/books/NBK25497/ for more information
+// Without an API key, any site (IP address) posting more than 3 requests per second to the E-utilities will receive an error message. 
+  $nlm_apikey = NLM_APIKEY;
+  if (strlen($nlm_apikey) > 0)
+  {
+    return '&api_key='.urlencode($nlm_apikey);
+  } else
+  {
+    return "";
+  }
+}
+
+function has_nlm_apikey() : bool {
+  return strlen(get_nlm_apikey()) > 0;
+}
+
+
 function get_entrez_xml(string $type, string $query) : ?SimpleXMLElement {
    $url =  "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
-   $post=  "tool=WikipediaCitationBot&email=" . PUBMEDUSERNAME;
+   $post=  "tool=WikipediaCitationBot&email=" . urlencode(NLM_EMAIL) . get_nlm_apikey();
    if ($type === "esearch_pubmed") {
       $url  .= "esearch.fcgi";
       $post .= "&db=pubmed&term=" . $query;
@@ -1350,9 +1368,13 @@ function get_entrez_xml(string $type, string $query) : ?SimpleXMLElement {
    $xml = xml_post($url, $post);
    if ($xml === NULL) {
       // @codeCoverageIgnoreStart
-     sleep(3);
-     $xml = xml_post($url, $post);
-     // @codeCoverageIgnoreEnd
+     if (!has_nlm_apikey())
+     {
+       // only sleep if we have no API key; otherwise there is no reason to sleep
+       sleep(3);
+       $xml = xml_post($url, $post);
+       // @codeCoverageIgnoreEnd
+     }
    }
    return $xml;
 }

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1352,7 +1352,7 @@ function has_nlm_apikey() : bool {
 
 function get_entrez_xml(string $type, string $query) : ?SimpleXMLElement {
    $url =  "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
-   $post=  "tool=WikipediaCitationBot&email=" . urlencode(NLM_EMAIL) . get_nlm_apikey();
+   $post=  "tool=WikipediaCitationBot&email=" . NLM_EMAIL . get_nlm_apikey();
    if ($type === "esearch_pubmed") {
       $url  .= "esearch.fcgi";
       $post .= "&db=pubmed&term=" . $query;

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1332,22 +1332,9 @@ function Bibcode_Response_Processing(string $return, $ch, string $adsabs_url) : 
   // @codeCoverageIgnoreEnd
 }
 
-function get_nlm_apikey() : string {
-// see https://www.ncbi.nlm.nih.gov/books/NBK25497/ for more information
-// Without an API key, any site (IP address) posting more than 3 requests per second to the E-utilities will receive an error message. 
-  $nlm_apikey = NLM_APIKEY;
-  if (strlen($nlm_apikey) > 0)
-  {
-    return '&api_key='.urlencode($nlm_apikey);
-  } else
-  {
-    return "";
-  }
-}
-
 function get_entrez_xml(string $type, string $query) : ?SimpleXMLElement {
    $url =  "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
-   $post=  "tool=WikipediaCitationBot&email=" . NLM_EMAIL . get_nlm_apikey();
+   $post=  "tool=WikipediaCitationBot&email=" . NLM_EMAIL . NLM_APIKEY;
    if ($type === "esearch_pubmed") {
       $url  .= "esearch.fcgi";
       $post .= "&db=pubmed&term=" . $query;

--- a/env.php.example
+++ b/env.php.example
@@ -20,6 +20,8 @@ if (!getenv('PHP_OAUTH_CONSUMER_TOKEN')) {
   // API keys
   @putenv('PHP_ADSABSAPIKEY=xxxxx'); // https://ui.adsabs.harvard.edu/help/api/
   @putenv('PHP_S2APIKEY=xxxxx');     // Doing lots of requests to semanticscholar.org without a key gets you blocked
+  @putenv('NLM_APIKEY=xxxxx');       // API key for *nlm.nih.gov, can be obtained at https://account.ncbi.nlm.nih.gov/settings/
+  @putenv('NLM_EMAIL=xxxxx');        // Email address for *nlm.nih.gov
   @putenv('GITHUB_PAT=xxxxx');       // This is for doing gitpull, etc.  But not running bot
  }
  catch (Throwable $e) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,5 +12,7 @@ parameters:
 		- MAX_PAGES
 		- WIKI_ROOT
 		- API_ROOT
+                - NLM_APIKEY
+                - NLM_EMAIL
 		- BOT_USER_AGENT
 		

--- a/setup.php
+++ b/setup.php
@@ -107,8 +107,8 @@ if ((string) getenv("PHP_S2APIKEY") !== "") {
 $nlm_apikey = (string) getenv("NLM_APIKEY");
 // see https://www.ncbi.nlm.nih.gov/books/NBK25497/ for more information
 // Without an API key, any site (IP address) posting more than 3 requests per second to the E-utilities will receive an error message.
-// NLM uses long API keys, values shorter than 8 characters will not be used, but we still test on default "xxxxx"
-if (($nlm_apikey !== "") && ($nlm_apikey !== "xxxxx") && (strlen($nlm_apikey) >= 8)) {
+// NLM uses long API keys, values shorter than 8 characters will not be used
+if (strlen($nlm_apikey) >= 8) {
   define("NLM_APIKEY", '&api_key=' . urlencode($nlm_apikey));
 } else {
   define("NLM_APIKEY", "");

--- a/setup.php
+++ b/setup.php
@@ -108,25 +108,21 @@ if ((string) getenv("PHP_S2APIKEY") !== "") {
   define("CONTEXT_S2", array());
 }
 
-$nlm_apikey = (string) getenv("NLM_APIKEY");
 // see https://www.ncbi.nlm.nih.gov/books/NBK25497/ for more information
-// Without an API key, any site (IP address) posting more than 3 requests per second to the E-utilities will receive an error message.
-// NLM uses long API keys, values shorter than 8 characters will not be used
+// Without an API key, any site IP address posting more than 3 requests per second will receive an error message.
+$nlm_apikey = (string) getenv("NLM_APIKEY");
+$nlm_email = (string) getenv("NLM_EMAIL");
 if (strlen($nlm_apikey) >= 8) {
   define("NLM_APIKEY", '&api_key=' . urlencode($nlm_apikey));
 } else {
-  define("NLM_APIKEY", "");
+  define("NLM_APIKEY", "");  // Probably "xxxxx"
 }
-unset($nlm_apikey);
-
-$nlm_email = (string) getenv("NLM_EMAIL");
-// if no email is specified in the NLM_EMAIL environment variable, use default value from constants.php
 if (strpos($nlm_email, '@') > 0) {
   define("NLM_EMAIL", urlencode($nlm_email));
 } else {
   define("NLM_EMAIL", urlencode(PUBMEDUSERNAME));
 }
-unset($nlm_email);
+unset($nlm_email, $nlm_apikey);
 
 function check_blocked() : void {
   if (!TRAVIS && ! WikipediaBot::is_valid_user('Citation_bot')) {

--- a/setup.php
+++ b/setup.php
@@ -108,24 +108,19 @@ $nlm_apikey = (string) getenv("NLM_APIKEY");
 // NLM uses long API keys, values shorter than 8 characters will not be used, but we still test on default "xxxxx"
 if (($nlm_apikey !== "") && ($nlm_apikey !== "xxxxx") && (strlen($nlm_apikey) >= 8)) {
   define("NLM_APIKEY", $nlm_apikey);
-} else
-{
+} else {
   define("NLM_APIKEY", "");
 }
 unset($nlm_apikey);
 
 $nlm_email = (string) getenv("NLM_EMAIL");
 // if no email is specified in the NLM_EMAIL environment variable, use default value from constants.php
-if (($nlm_email !== "") && ($nlm_email !== "xxxxx") && (strpos($nlm_email, '@') > 0)) {
-  define("NLM_EMAIL", $nlm_email);
-} else
-{
-  define("NLM_EMAIL", PUBMEDUSERNAME); // if NLM_EMAIL is not defined, use default email from config
+if (strpos($nlm_email, '@') > 0)) {
+  define("NLM_EMAIL", urlencode($nlm_email));
+} else {
+  define("NLM_EMAIL", urlencode(PUBMEDUSERNAME));
 }
 unset($nlm_email);
-
-
-
 
 function check_blocked() : void {
   if (!TRAVIS && ! WikipediaBot::is_valid_user('Citation_bot')) {

--- a/setup.php
+++ b/setup.php
@@ -104,6 +104,29 @@ if ((string) getenv("PHP_S2APIKEY") !== "") {
   define("CONTEXT_S2", array());
 }
 
+$nlm_apikey = (string) getenv("NLM_APIKEY");
+// NLM uses long API keys, values shorter than 8 characters will not be used, but we still test on default "xxxxx"
+if (($nlm_apikey !== "") && ($nlm_apikey !== "xxxxx") && (strlen($nlm_apikey) >= 8)) {
+  define("NLM_APIKEY", $nlm_apikey);
+} else
+{
+  define("NLM_APIKEY", "");
+}
+unset($nlm_apikey);
+
+$nlm_email = (string) getenv("NLM_EMAIL");
+// if no email is specified in the NLM_EMAIL environment variable, use default value from constants.php
+if (($nlm_email !== "") && ($nlm_email !== "xxxxx") && (strpos($nlm_email, '@') > 0)) {
+  define("NLM_EMAIL", $nlm_email);
+} else
+{
+  define("NLM_EMAIL", PUBMEDUSERNAME); // if NLM_EMAIL is not defined, use default email from config
+}
+unset($nlm_email);
+
+
+
+
 function check_blocked() : void {
   if (!TRAVIS && ! WikipediaBot::is_valid_user('Citation_bot')) {
     echo '</pre><div style="text-align:center"><h1>The Citation Bot is currently blocked because of disagreement over its usage.</h1><br/><h2><a href="https://en.wikipedia.org/wiki/User_talk:Citation_bot" title="Join the discussion" target="_blank">Please join in the discussion</a></h2></div><footer><a href="./" title="Use Citation Bot again">Another&nbsp;page</a>?</footer></body></html>';

--- a/setup.php
+++ b/setup.php
@@ -105,9 +105,11 @@ if ((string) getenv("PHP_S2APIKEY") !== "") {
 }
 
 $nlm_apikey = (string) getenv("NLM_APIKEY");
+// see https://www.ncbi.nlm.nih.gov/books/NBK25497/ for more information
+// Without an API key, any site (IP address) posting more than 3 requests per second to the E-utilities will receive an error message.
 // NLM uses long API keys, values shorter than 8 characters will not be used, but we still test on default "xxxxx"
 if (($nlm_apikey !== "") && ($nlm_apikey !== "xxxxx") && (strlen($nlm_apikey) >= 8)) {
-  define("NLM_APIKEY", $nlm_apikey);
+  define("NLM_APIKEY", '&api_key=' . urlencode($nlm_apikey));
 } else {
   define("NLM_APIKEY", "");
 }
@@ -115,7 +117,7 @@ unset($nlm_apikey);
 
 $nlm_email = (string) getenv("NLM_EMAIL");
 // if no email is specified in the NLM_EMAIL environment variable, use default value from constants.php
-if (strpos($nlm_email, '@') > 0)) {
+if (strpos($nlm_email, '@') > 0) {
   define("NLM_EMAIL", urlencode($nlm_email));
 } else {
   define("NLM_EMAIL", urlencode(PUBMEDUSERNAME));


### PR DESCRIPTION
This pull request adds ability to specify PubMed API Key and email via enrvironment variable.

See `env.php.example`:

```
  @putenv('NLM_APIKEY=xxxxx');       // API key for *nlm.nih.gov, can be obtained at https://account.ncbi.nlm.nih.gov/settings/
  @putenv('NLM_EMAIL=xxxxx');        // Email address for *nlm.nih.gov
```

If no PubMed email is specified in the environment variable (or `xxxxx` is specified), the default value from constants.php will be used. If no API Key is specified (or `xxxxx` is specified, or a value shorter than 8 characters is specified, then this parameter will not be passed to PubMed as was before. The API key allows higher request rate. You can get one from https://account.ncbi.nlm.nih.gov/settings/

Also, if you specify the PubMed API key, then it will not try one more time after sleeping 1 or 3 seconds on failure, because there is no reason to do so when using an API key; request count is not an issue; moreover, when using an API key, you can contact them to increase rate even higher.

I tried with my API Key and it works pretty well!

