### PR TITLE
When a DOI check or a HDL check returned with a timeout, do not try gain multiple time this DOI

### DIFF
--- a/expandFns.php
+++ b/expandFns.php
@@ -19,23 +19,15 @@ function doi_active(string $doi) : ?bool {
   // For really long category runs
   if (count($cache_bad) > MAX_CACHE_SIZE) $cache_bad = [];
   if (count($cache_good) > MAX_CACHE_SIZE) $cache_good = [];
-  $start_time = time();
   $works = doi_works($doi);
   if ($works === NULL) {
-    // if little time passed, we will recheck again, otherwise mark as fail
-    if (abs(time()-$start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
-    {
-      return NULL;
-    } else {
-      $works = FALSE;
-    }
+    return NULL;
   }
   if ($works === FALSE) {
     $cache_bad[$doi] = TRUE; 
     return FALSE;
   }
-  // DX.DOI.ORG works, but does crossref?
-  $start_time = time();
+  // DX.DOI.ORG works, but is it on CrossRef
   $works = is_doi_active($doi);
   if ($works === NULL) { // Nothing to retry, since nothing it followed
       return NULL;

--- a/expandFns.php
+++ b/expandFns.php
@@ -14,20 +14,39 @@ function doi_active(string $doi) : ?bool {
   if (isset($cache_good[$doi])) return TRUE;
   if (isset($cache_bad[$doi]))  return FALSE;
   // For really long category runs
-  if (count($cache_bad) > 2500) $cache_bad = [];
-  if (count($cache_good) > 100000) $cache_good = [];
+  if (!defined('BOT_INFINITE_DOI_CACHE'))
+  {
+    if (count($cache_bad) > 2500) $cache_bad = [];
+    if (count($cache_good) > 100000) $cache_good = [];
+  }
+  $start_time = time();
   $works = doi_works($doi);
   if ($works === NULL) {
-    return NULL; // @codeCoverageIgnore
+    // if little time passed, we will recheck again, otherwise mark as fail
+    if (abs(time()-$start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
+    {
+      return NULL; // @codeCoverageIgnore
+    } else
+    {
+      $works = FALSE;
+    }
   }
   if ($works === FALSE) {
-    // $cache_bad[$doi] = TRUE; do not store to save memory
+    $cache_bad[$doi] = TRUE; 
     return FALSE;
   }
   // DX.DOI.ORG works, but does crossref?
+  $start_time = time();
   $works = is_doi_active($doi);
   if ($works === NULL) {
-    return NULL; // @codeCoverageIgnore
+    // if little time passed, we will recheck again, otherwise mark as fail
+    if (abs(time() - $start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
+    {
+      return NULL; // @codeCoverageIgnore
+    } else
+    {
+      $works = FALSE;
+    }
   }
   if ($works === FALSE) {
     $cache_bad[$doi] = TRUE;
@@ -45,12 +64,22 @@ function doi_works(string $doi) : ?bool {
   if (isset($cache_good[$doi])) return TRUE;
   if (isset($cache_bad[$doi]))  return FALSE;
   // For really long category runs
-  if (count($cache_bad) > 2500) $cache_bad = BAD_DOI_ARRAY;
-  if (count($cache_good) > 100000) $cache_good = [];
+  if (!defined('BOT_INFINITE_DOI_CACHE'))
+  {
+    if (count($cache_bad) > 2500) $cache_bad = BAD_DOI_ARRAY;
+    if (count($cache_good) > 100000) $cache_good = [];
+  }
+  $start_time = time();
   $works = is_doi_works($doi);
   if ($works === NULL) {
-    // bot_debug_log($doi . " returns NULL from dx.doi.org");
-    return NULL; // @codeCoverageIgnore
+    // if little time passed, we will recheck again, otherwise mark as fail
+    if (abs(time() - $start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
+    {
+      return NULL; // @codeCoverageIgnore
+    } else
+    {
+      $works = FALSE;
+    }
   }
   if ($works === FALSE) {
     $cache_bad[$doi] = TRUE;
@@ -1322,11 +1351,22 @@ function hdl_works(string $hdl) {
   $hdl = trim($hdl);
   if (isset($cache_good[$hdl])) return $cache_good[$hdl];
   if (isset($cache_bad[$hdl]))  return FALSE;
-  if (count($cache_bad) > 250) $cache_bad = []; // Lots of things that look like handles are not handles
-  if (count($cache_good) > 1000) $cache_good = [];
+  if (!defined('BOT_INFINITE_HDL_CACHE'))
+  {
+    if (count($cache_bad) > 250) $cache_bad = []; // Lots of things that look like handles are not handles
+    if (count($cache_good) > 1000) $cache_good = [];
+  }
+  $start_time = time();
   $works = is_hdl_works($hdl);
   if ($works === NULL) {
-    return NULL; // @codeCoverageIgnore
+    // if little time passed, we will recheck again, otherwise mark as fail
+    if (abs(time()-$start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
+    {
+      return NULL; // @codeCoverageIgnore
+    } else
+    {
+      $works = FALSE;
+    }
   }
   if ($works === FALSE) {
     $cache_bad[$hdl] = TRUE;

--- a/expandFns.php
+++ b/expandFns.php
@@ -29,8 +29,8 @@ function doi_active(string $doi) : ?bool {
   }
   // DX.DOI.ORG works, but is it on CrossRef
   $works = is_doi_active($doi);
-  if ($works === NULL) { // Nothing to retry, since nothing it followed
-      return NULL;
+  if ($works === NULL) {
+    return NULL;
   }
   if ($works === FALSE) {
     $cache_bad[$doi] = TRUE;

--- a/expandFns.php
+++ b/expandFns.php
@@ -42,8 +42,7 @@ function doi_active(string $doi) : ?bool {
     if (abs(time() - $start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
     {
       return NULL;
-    } else
-    {
+    } else {
       $works = FALSE;
     }
   }

--- a/expandFns.php
+++ b/expandFns.php
@@ -1259,13 +1259,11 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
         if (file_put_contents($filename, $body)===$bodylen)
         {
           report_phase("Saved to file " . echoable($filename));
-        } else
-        {
+        } else {
           report_warning("Save to file failed.");
         }
         unset($body);
-      } else
-      {
+      } else {
         report_phase("Writing to " . echoable($page_title) . '... ');
         $attempts = 0;
         if ($total === 1) {

--- a/expandFns.php
+++ b/expandFns.php
@@ -25,9 +25,8 @@ function doi_active(string $doi) : ?bool {
     // if little time passed, we will recheck again, otherwise mark as fail
     if (abs(time()-$start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
     {
-      return NULL; // @codeCoverageIgnore
-    } else
-    {
+      return NULL;
+    } else {
       $works = FALSE;
     }
   }
@@ -1364,9 +1363,8 @@ function hdl_works(string $hdl) {
     // if little time passed, we will recheck again, otherwise mark as fail
     if (abs(time()-$start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
     {
-      return NULL; // @codeCoverageIgnore
-    } else
-    {
+      return NULL;
+    } else {
       $works = FALSE;
     }
   }

--- a/expandFns.php
+++ b/expandFns.php
@@ -37,14 +37,8 @@ function doi_active(string $doi) : ?bool {
   // DX.DOI.ORG works, but does crossref?
   $start_time = time();
   $works = is_doi_active($doi);
-  if ($works === NULL) {
-    // if little time passed, we will recheck again, otherwise mark as fail
-    if (abs(time() - $start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
-    {
+  if ($works === NULL) { // Nothing to retry, since nothing it followed
       return NULL;
-    } else {
-      $works = FALSE;
-    }
   }
   if ($works === FALSE) {
     $cache_bad[$doi] = TRUE;

--- a/expandFns.php
+++ b/expandFns.php
@@ -42,7 +42,7 @@ function doi_active(string $doi) : ?bool {
     // if little time passed, we will recheck again, otherwise mark as fail
     if (abs(time() - $start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
     {
-      return NULL; // @codeCoverageIgnore
+      return NULL;
     } else
     {
       $works = FALSE;
@@ -73,7 +73,7 @@ function doi_works(string $doi) : ?bool {
     // if little time passed, we will recheck again, otherwise mark as fail
     if (abs(time() - $start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
     {
-      return NULL; // @codeCoverageIgnore
+      return NULL;
     } else
     {
       $works = FALSE;

--- a/expandFns.php
+++ b/expandFns.php
@@ -72,8 +72,7 @@ function doi_works(string $doi) : ?bool {
     if (abs(time() - $start_time) < max(BOT_HTTP_TIMEOUT, BOT_CONNECTION_TIMEOUT))
     {
       return NULL;
-    } else
-    {
+    } else {
       $works = FALSE;
     }
   }

--- a/progpilot.json
+++ b/progpilot.json
@@ -1,6 +1,7 @@
 {
     "false_positives":
         [
-            {"vuln_id":"4ef47a53ea5e838f1ff0df23016596dd83cf06f45604af01d04e017bf0296e25"}
+            {"vuln_id":"4ef47a53ea5e838f1ff0df23016596dd83cf06f45604af01d04e017bf0296e25"},
+            {"vuln_id":"29fd132b20d55dd94bb4ab9995f99af9d5ebfebbbc0ea404c7a54c84d407f4a6"},
         ]
 }

--- a/progpilot.json
+++ b/progpilot.json
@@ -1,6 +1,6 @@
 {
     "false_positives":
         [
-            {"vuln_id":"3ebc6e2037b72efa545724b3ba31e57c35e5284699a158123ba6dcead5f87b64"}
+            {"vuln_id":"50a06388d819c3aa0c57c8f56c5015f162222c39a4628fe52c225f67322f9713"}
         ]
 }

--- a/progpilot.json
+++ b/progpilot.json
@@ -1,6 +1,6 @@
 {
     "false_positives":
         [
-            {"vuln_id":"50a06388d819c3aa0c57c8f56c5015f162222c39a4628fe52c225f67322f9713"}
+            {"vuln_id":"8147614783e521ec03739be9653ab9f9453cba9558ca372201a7d85c8e28a4e4"}
         ]
 }


### PR DESCRIPTION
When a DOI check or a HDL check returned with a timeout, do not try gain multiple time this DOI.

A DOI check can return one of the following results:
* TRUE: DOI OK
* FALSE: DOI Fail
* NULL: check again later

In the past, DOIs such as 10.3746/pnf.2017.22.2.67 took about a minute to check to pass all the timeouts, still that URL returned NULL and was rechecked over and over again. Now, with this pull request, a time is measured low long did it take to check a DOI. If it took more than a timeout (BOT_CONNECTION_TIMEOUT or BOT_HTTP_TIMEOUT, whichever larger), than we consider that this check returned FALSE (Fail) rather than NULL, so we would not recheck such slow DOIs. Only DOIs which returned quickly will be rechecked.

With this pull request, the bot no longer spends hours on DOIs such as 10.3746/pnf.2017.22.2.67. This DOI presents on the page Cholesterol, so you can check it there.