### PR TITLE
Refactor ADS curl API calls

### DIFF
--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -372,10 +372,10 @@ function adsabs_api(array $ids, array &$templates, string $identifier) : bool { 
       $body = '';
       curlGetResponse($adsabs_url, $return, $ch, $http_response_code, $header, $body);
       unset($ch);
+      $response = Bibcode_Response_Processing($adsabs_url, $http_response_code, $header, $body);
   } catch (Exception $e) {
       return FALSE;
   }
-  $response = Bibcode_Response_Processing($adsabs_url, $http_response_code, $header, $body);
 
   if (!isset($response->docs)) return TRUE;
 
@@ -1518,6 +1518,7 @@ function query_adsabs(string $options) : object {
       $header = ''; 
       $body = '';
       curlGetResponse($adsabs_url, $return, $ch, $http_response_code, $header, $body);
+      unset($ch);
       $response = Bibcode_Response_Processing($adsabs_url, $http_response_code, $header, $body);
     } catch (Exception $e) {
       return (object) array('numFound' => 0);

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1278,7 +1278,7 @@ function curlGetResponse(string $url, string $return, CurlHandle $ch, int &$http
     // @codeCoverageIgnoreStart
     $errorStr = curl_error($ch);
     $errnoInt = curl_errno($ch);
-    throw new Exception('Curl error from adsabs website' . $errorStr), $errnoInt);
+    throw new Exception('Curl error from adsabs website: ' . $errorStr), $errnoInt);
     // @codeCoverageIgnoreEnd
   } 
   $http_response_code = (int) @curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1259,19 +1259,6 @@ function expand_templates_from_archives(array &$templates) : void { // This is d
   }
 }
 
-function formatUrlResponse(string $url, string $errorMessage1 = "", int $errorMessage2 = -9999) : string {
-  $message = '';
-  if (strlen($url) > 0) {
-    $host = parse_url($url, PHP_URL_HOST);
-    if (is_string($host) && (strlen($host) > 0)) {
-      $message = trim ($message.' Host: '.$host);
-    }
-  }
-  if ($errorMessage1 !== "") $message = trim($message.' '.$errorMessage1);
-  if ($errorMessage2 !== -9999) $message = trim($message.' '.$errorMessage2);
-  return $message;
-}
-
 function curlGetResponse(string $url, string $return, CurlHandle $ch, int &$http_response_code, string &$header, string &$body) : void
 {
   if ($return === "") {
@@ -1309,10 +1296,10 @@ function Bibcode_Response_Processing(string $adsabs_url, int $http_response_code
 
       // @codeCoverageIgnoreStart
       if (isset($decoded->error->trace)) {
-        throw new Exception(formatUrlResponse($adsabs_url, 'ADSABS website returned a stack trace'),
+        throw new Exception("ADSABS website returned a stack trace" . "\n - URL was:  " . $adsabs_url,
         (isset($decoded->error->code) ? $decoded->error->code : 999));
       } else {
-         throw new Exception(((isset($decoded->error->msg)) ? $decoded->error->msg : $decoded->error)),
+         throw new Exception(((isset($decoded->error->msg)) ? $decoded->error->msg : $decoded->error) . "\n - URL was:  " . $adsabs_url,
         (isset($decoded->error->code) ? $decoded->error->code : 999));
       }
       // @codeCoverageIgnoreEnd

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1278,12 +1278,12 @@ function curlGetResponse(string $url, string $return, CurlHandle $ch, int &$http
     // @codeCoverageIgnoreStart
     $errorStr = curl_error($ch);
     $errnoInt = curl_errno($ch);
-    throw new Exception(formatUrlResponse($url, 'Curl error from adsabs website', $errorStr), $errnoInt);
+    throw new Exception('Curl error from adsabs website' . $errorStr), $errnoInt);
     // @codeCoverageIgnoreEnd
   } 
   $http_response_code = (int) @curl_getinfo($ch, CURLINFO_HTTP_CODE);
   $header_length = (int) @curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-  if ($http_response_code === 0 || $header_length === 0) throw new Exception(formatUrlResponse($url, 'Size of zero from adsabs website'));
+  if ($http_response_code === 0 || $header_length === 0) throw new Exception('Size of zero from adsabs website');
   $header = substr($return, 0, $header_length);
   $body = substr($return, $header_length);
 }
@@ -1323,7 +1323,7 @@ function Bibcode_Response_Processing(string $adsabs_url, int $http_response_code
       $message = (string) strtok($header, "\n");
       /** @psalm-suppress UnusedFunctionCall */
       @strtok('',''); // Free internal buffers with empty unused call
-      throw new Exception(formatUrlResponse($adsabs_url, $message), $http_response_code);
+      throw new Exception($message, $http_response_code);
       // @codeCoverageIgnoreEnd
     }
 
@@ -1332,18 +1332,18 @@ function Bibcode_Response_Processing(string $adsabs_url, int $http_response_code
       if ($rate_limit[1][2]) {
         report_info("AdsAbs search " . (string)((int) $rate_limit[1][0] - (int) $rate_limit[1][1]) . "/" . (string)(int)$rate_limit[1][0]);
       } else {
-        throw new Exception(formatUrlResponse($adsabs_url, 'Too many requests'), $http_response_code);
+        throw new Exception('Too many requests', $http_response_code);
       }
       // @codeCoverageIgnoreEnd
     }
     if (!is_object($decoded)) {
-      throw new Exception(formatUrlResponse($adsabs_url, "Could not decode API response:\n" . $body), 5000);  // @codeCoverageIgnore
+      throw new Exception("Could not decode API response:\n" . $body, 5000);  // @codeCoverageIgnore
     } elseif (isset($decoded->response)) {
       return $decoded->response;
     } elseif (isset($decoded->error)) {                   // @codeCoverageIgnore
-      throw new Exception(formatUrlResponse($adsabs_url, "" . $decoded->error), 5000);    // @codeCoverageIgnore
+      throw new Exception("" . $decoded->error, 5000);    // @codeCoverageIgnore
     } else {
-      throw new Exception(formatUrlResponse($adsabs_url, "Could not decode AdsAbs response"), 5000);        // @codeCoverageIgnore
+      throw new Exception("Could not decode AdsAbs response", 5000);        // @codeCoverageIgnore
     }
   // @codeCoverageIgnoreStart
   } catch (Exception $e) {

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1258,7 +1258,7 @@ function expand_templates_from_archives(array &$templates) : void { // This is d
   }
 }
 
-function formatUrlResponse(string $url, string $errorMessage1 = NULL, string $errorMessage2 = NULL) : string {
+function formatUrlResponse(string $url, string $errorMessage1 = "", int $errorMessage2 = -9999) : string {
   $message = '';
   if (strlen($url) > 0) {
     $host = parse_url($url, PHP_URL_HOST);
@@ -1266,8 +1266,8 @@ function formatUrlResponse(string $url, string $errorMessage1 = NULL, string $er
       $message = trim ($message.' Host: '.$host);
     }
   }
-  if ($errorMessage1 !== NULL) $message = trim($message.' '.$errorMessage1);
-  if ($errorMessage2 !== NULL) $message = trim($message.' '.$errorMessage2);
+  if ($errorMessage1 !== "") $message = trim($message.' '.$errorMessage1);
+  if ($errorMessage2 !== -9999) $message = trim($message.' '.$errorMessage2);
   return $message;
 }
 

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1312,8 +1312,7 @@ function Bibcode_Response_Processing(string $adsabs_url, int $http_response_code
         throw new Exception(formatUrlResponse($adsabs_url, 'ADSABS website returned a stack trace'),
         (isset($decoded->error->code) ? $decoded->error->code : 999));
       } else {
-         throw new Exception(formatUrlResponse($adsabs_url, 
-        ((isset($decoded->error->msg)) ? $decoded->error->msg : $decoded->error)),
+         throw new Exception(((isset($decoded->error->msg)) ? $decoded->error->msg : $decoded->error)),
         (isset($decoded->error->code) ? $decoded->error->code : 999));
       }
       // @codeCoverageIgnoreEnd

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -372,6 +372,8 @@ function adsabs_api(array $ids, array &$templates, string $identifier) : bool { 
     $body = '';
     curlGetResponse($adsabs_url, $return, $ch, $http_response_code, $header, $body);
     unset($ch);
+  } catch (Exception $e) {
+    return FALSE;
   }
   $response = Bibcode_Response_Processing($adsabs_url, $http_response_code, $header, $body);
   if (!isset($response->docs)) return TRUE;

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1523,7 +1523,7 @@ function query_adsabs(string $options) : object {
       return (object) array('numFound' => 0);
     }
     return $response;
-}
+}dsafdsfdsfsd
 
 function curl_init_crossref(string $url) : CurlHandle {
      $ch = curl_init();

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -376,7 +376,6 @@ function adsabs_api(array $ids, array &$templates, string $identifier) : bool { 
   } catch (Exception $e) {
       return FALSE;
   }
-
   if (!isset($response->docs)) return TRUE;
 
   foreach ($response->docs as $record) { // Check for remapped bibcodes

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1531,6 +1531,11 @@ function query_adsabs(string $options) : object {
       $header = ''; 
       $body = '';
       curlGetResponse($adsabs_url, $return, $ch, $http_response_code, $header, $body);
+    } (catch Exception $e) {
+      $return = '';
+      $http_response_code = 6000;
+      $header = ''; 
+      $body = '';
     }
     $response = Bibcode_Response_Processing($adsabs_url, $http_response_code, $header, $body);
     return $response;

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1278,7 +1278,7 @@ function curlGetResponse(string $url, string $return, CurlHandle $ch, int &$http
     // @codeCoverageIgnoreStart
     $errorStr = curl_error($ch);
     $errnoInt = curl_errno($ch);
-    throw new Exception('Curl error from adsabs website: ' . $errorStr), $errnoInt);
+    throw new Exception('Curl error from adsabs website: ' . $errorStr, $errnoInt);
     // @codeCoverageIgnoreEnd
   } 
   $http_response_code = (int) @curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Refactored ADS curl API calls to make them less monolithic, easier to understand and expand. It also allows to close curl handle before starting analyzing the response. There are the following functions added:
1) curlGetResponse - retrieves http status code, headers and body from the curl handle, gives fully documented exceptions in case of errors.
2) formatUrlResponse - returns a formatted error (warning) message when request to a particular URL failed, accepts an URL, optionally two error messages as strings. This message can be logged as warning or error or raised as an exception.
3) Bibcode_Response_Processing parameters are updated; removed the curl handle ($ch) and instead added http_response_code, header, and body. Therefore, we can start processing the bibcode response when curl handle is already closed. The http_response_code integer and header + body strings are returned by curlGetResponse.
4) made curl close handle in "finally" block to prevent handle leak.

