### PR TITLE
There were a few places where CURLOPT_FOLLOWLOCATION parameter was omitted (missing)

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2629,6 +2629,7 @@ final class Template {
 	$ch = curl_init();
 	curl_setopt_array($ch,
 			[CURLOPT_HEADER => FALSE,
+                         CURLOPT_FOLLOWLOCATION => TRUE,
 			 CURLOPT_RETURNTRANSFER => TRUE,
 			 CURLOPT_URL => $url,
 			 CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
@@ -2889,6 +2890,7 @@ final class Template {
 		$ch = curl_init();
 		curl_setopt_array($ch,
 				   [CURLOPT_USERAGENT => BOT_USER_AGENT,
+                                        CURLOPT_FOLLOWLOCATION => TRUE,
 					CURLOPT_HEADER => FALSE,
 					CURLOPT_RETURNTRANSFER => TRUE,
 					CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
@@ -2940,6 +2942,7 @@ final class Template {
 	$ch = curl_init();
 	curl_setopt_array($ch,
 		   [CURLOPT_USERAGENT => BOT_USER_AGENT,
+                        CURLOPT_FOLLOWLOCATION => TRUE,
 			CURLOPT_HEADER => FALSE,
 			CURLOPT_RETURNTRANSFER => TRUE,
 			CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
@@ -4205,6 +4208,7 @@ final class Template {
 			  $ch = curl_init($test_url);
 			  curl_setopt_array($ch,
 					   [CURLOPT_RETURNTRANSFER => TRUE,
+                                                CURLOPT_FOLLOWLOCATION => TRUE,
 						CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT * 1.5,
 						CURLOPT_CONNECTTIMEOUT => BOT_CONNECTION_TIMEOUT,
 						CURLOPT_USERAGENT => BOT_USER_AGENT]);

--- a/WikipediaBot.php
+++ b/WikipediaBot.php
@@ -124,6 +124,7 @@ final class WikipediaBot {
 
 try {
           curl_setopt_array(self::$ch, [
+            CURLOPT_FOLLOWLOCATION => TRUE,
             CURLOPT_POST => TRUE,
             CURLOPT_POSTFIELDS => http_build_query($params),
             CURLOPT_HTTPHEADER => [$authenticationHeader],
@@ -374,6 +375,7 @@ try {
     $params['format'] = 'json';
 
             curl_setopt_array(self::$ch, [
+                CURLOPT_FOLLOWLOCATION => TRUE,
                 CURLOPT_POST => TRUE,
                 CURLOPT_POSTFIELDS => http_build_query($params),
                 CURLOPT_URL => API_ROOT,
@@ -413,6 +415,7 @@ try {
   static public function GetAPage(string $title) : string {
     curl_setopt_array(self::$ch,
               [CURLOPT_HTTPGET => TRUE,
+               CURLOPT_FOLLOWLOCATION => TRUE,
                CURLOPT_HTTPHEADER => [],
                CURLOPT_URL => WIKI_ROOT . '?' . http_build_query(['title' => $title, 'action' =>'raw'])]);
     $text = (string) @curl_exec(self::$ch);

--- a/Zotero.php
+++ b/Zotero.php
@@ -46,7 +46,6 @@ public static function create_ch_zotero() : void {
           CURLOPT_FOLLOWLOCATION => TRUE,
           CURLOPT_HEADER => FALSE,
           CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
-          CURLOPT_FOLLOWLOCATION => TRUE,
           CURLOPT_MAXREDIRS => 10,
           CURLOPT_CONNECTTIMEOUT => BOT_CONNECTION_TIMEOUT,
           CURLOPT_COOKIESESSION => TRUE,

--- a/Zotero.php
+++ b/Zotero.php
@@ -31,6 +31,7 @@ public static function create_ch_zotero() : void {
   /** @psalm-suppress PossiblyNullArgument */ 
   curl_setopt_array(self::$zotero_ch,
          [CURLOPT_URL => CITOID_ZOTERO,
+          CURLOPT_FOLLOWLOCATION => TRUE,
           CURLOPT_HTTPHEADER => ['accept: application/json; charset=utf-8'],
           CURLOPT_RETURNTRANSFER => TRUE,
           CURLOPT_USERAGENT => BOT_USER_AGENT,
@@ -42,6 +43,7 @@ public static function create_ch_zotero() : void {
   self::$ch_ieee = curl_init();
   curl_setopt_array(self::$ch_ieee,
          [CURLOPT_RETURNTRANSFER => TRUE,
+          CURLOPT_FOLLOWLOCATION => TRUE,
           CURLOPT_HEADER => FALSE,
           CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
           CURLOPT_FOLLOWLOCATION => TRUE,
@@ -53,6 +55,7 @@ public static function create_ch_zotero() : void {
   self::$ch_jstor = curl_init();
   curl_setopt_array(self::$ch_jstor,
        [CURLOPT_RETURNTRANSFER => TRUE,
+        CURLOPT_FOLLOWLOCATION => TRUE,
         CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
         CURLOPT_CONNECTTIMEOUT => BOT_CONNECTION_TIMEOUT,
         CURLOPT_COOKIESESSION => TRUE,
@@ -72,6 +75,7 @@ public static function create_ch_zotero() : void {
   self::$ch_pmc = curl_init();
   curl_setopt_array(self::$ch_pmc,
         [CURLOPT_RETURNTRANSFER => TRUE,
+         CURLOPT_FOLLOWLOCATION => TRUE,
          CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
          CURLOPT_CONNECTTIMEOUT => BOT_CONNECTION_TIMEOUT,
          CURLOPT_COOKIESESSION => TRUE,
@@ -1306,6 +1310,7 @@ public static function find_indentifiers_in_urls(Template $template, ?string $ur
        } elseif ($template->blank('jstor')) {
           curl_setopt_array(self::$ch_jstor,
                             [CURLOPT_URL => 'https://www.jstor.org/citation/ris/' . $matches[1],
+                             CURLOPT_FOLLOWLOCATION => TRUE,
                              CURLOPT_HEADER => FALSE,
                              CURLOPT_NOBODY => FALSE]);
           $dat = (string) @curl_exec(self::$ch_jstor);
@@ -1452,6 +1457,7 @@ public static function find_indentifiers_in_urls(Template $template, ?string $ur
         // Need to encode the sici bit that follows sici?sici= [10 characters]
         $encoded_url = substr($url, 0, $sici_pos + 10) . urlencode(urldecode(substr($url, $sici_pos + 10)));
         curl_setopt_array(self::$ch_jstor, [CURLOPT_URL => $encoded_url,
+                                            CURLOPT_FOLLOWLOCATION => TRUE,
                                             CURLOPT_HEADER => TRUE,
                                             CURLOPT_NOBODY => TRUE]);
         if (@curl_exec(self::$ch_jstor)) {

--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -355,6 +355,7 @@ function adsabs_api(array $ids, array &$templates, string $identifier) : bool { 
 
   report_action("Expanding from BibCodes via AdsAbs API");
   $curl_opts=[CURLOPT_URL => $adsabs_url,
+              CURLOPT_FOLLOWLOCATION => TRUE,
               CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
               CURLOPT_CONNECTTIMEOUT => BOT_CONNECTION_TIMEOUT,
               CURLOPT_USERAGENT => BOT_USER_AGENT,
@@ -592,6 +593,7 @@ function query_crossref(string $doi) : ?object {
   $ch = curl_init();
   curl_setopt_array($ch,
             [CURLOPT_HEADER => FALSE,
+             CURLOPT_FOLLOWLOCATION => TRUE,
              CURLOPT_RETURNTRANSFER => TRUE,
              CURLOPT_URL =>  $url,
              CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
@@ -810,6 +812,7 @@ function expand_by_jstor(Template $template) : bool {
   $ch = curl_init();
   curl_setopt_array($ch,
            [CURLOPT_HEADER => FALSE,
+            CURLOPT_FOLLOWLOCATION => TRUE,
             CURLOPT_RETURNTRANSFER => TRUE,
             CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
             CURLOPT_CONNECTTIMEOUT => BOT_CONNECTION_TIMEOUT,
@@ -1376,6 +1379,7 @@ function xml_post(string $url, string $post) : ?SimpleXMLElement {
    $ch = curl_init();
       curl_setopt_array($ch,
                [CURLOPT_URL => $url,
+                CURLOPT_FOLLOWLOCATION => TRUE,
                 CURLOPT_POST => TRUE,
                 CURLOPT_POSTFIELDS => $post,
                 CURLOPT_RETURNTRANSFER => TRUE,
@@ -1496,6 +1500,7 @@ function query_adsabs(string $options) : object {
                   . "?q=$options&fl=arxiv_class,author,bibcode,doi,doctype,identifier,"
                   . "issue,page,pub,pubdate,title,volume,year";
     $curl_opts=[CURLOPT_HTTPHEADER => ['Authorization: Bearer ' . PHP_ADSABSAPIKEY],
+                CURLOPT_FOLLOWLOCATION => TRUE,
                 CURLOPT_RETURNTRANSFER => TRUE,
                 CURLOPT_HEADER => TRUE,
                 CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
@@ -1511,6 +1516,7 @@ function curl_init_crossref(string $url) : CurlHandle {
      // see https://api.crossref.org/swagger-ui/index.html
      curl_setopt_array($ch,
             [CURLOPT_HEADER => FALSE,
+             CURLOPT_FOLLOWLOCATION => TRUE,
              CURLOPT_RETURNTRANSFER => TRUE,
              CURLOPT_URL => $url,
              CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,

--- a/expandFns.php
+++ b/expandFns.php
@@ -1193,6 +1193,7 @@ function check_doi_for_jstor(string $doi, Template $template) : void {
   $ch = curl_init();
   curl_setopt_array($ch,
           [CURLOPT_RETURNTRANSFER => TRUE,
+           CURLOPT_FOLLOWLOCATION => TRUE,
            CURLOPT_TIMEOUT => BOT_HTTP_TIMEOUT,
            CURLOPT_CONNECTTIMEOUT => BOT_CONNECTION_TIMEOUT,
            CURLOPT_URL => "https://www.jstor.org/citation/ris/" . $doi,


### PR DESCRIPTION
There were a few places where CURLOPT_FOLLOWLOCATION parameter was omitted (missing), which might have resulted errors such as '!CrossRef server error loading headers for DOI 10.1128/MCB.00807-06 : HTTP/1.1 302 Found' when working via a proxy. With this option, Curl handles all the redirects, including 302 Found and continues, returning proper content.
