### PR TITLE
Errors that were not related to rate limit reached were erroneously understood as rate limit reached for AdsAbs

### DIFF
--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -1248,11 +1248,29 @@ function Bibcode_Response_Processing(array $curl_opts, string $adsabs_url) : obj
     $header = substr($return, 0, $header_length);
     $body = substr($return, $header_length);
     $decoded = @json_decode($body);
+
+    $ratelimit_total = NULL;
+    $ratelimit_left = NULL;
+    $ratelimit_current = NULL;
+
+    if (preg_match_all('~\nx\-ratelimit\-\w+:\s*(\d+)\r~i', $header, $rate_limit)) {
+      // @codeCoverageIgnoreStart
+      if ($rate_limit[1][2]) {
+	$ratelimit_total = intval($rate_limit[1][0]);
+	$ratelimit_left = intval($rate_limit[1][1]);
+	$ratelimit_current = $ratelimit_total - $ratelimit_left;
+	report_info("AdsAbs search " . strval($ratelimit_current) . "/" . strval($ratelimit_total));
+      } else {
+	throw new Exception('Too many requests', $http_response_code);
+      }
+      // @codeCoverageIgnoreEnd
+    }
+
     if (is_object($decoded) && isset($decoded->error)) {
       $retry_msg='';
       $time_to_sleep = NULL;
       $limit_action = NULL;
-      if (preg_match('~\nretry-after:\s*(\d+)\r~i', $header, $retry_after)) {
+      if (is_int($ratelimit_total) && is_int($ratelimit_left) && is_int($ratelimit_current) && ($ratelimit_left <= 0) && ($ratelimit_current >= $ratelimit_total) && preg_match('~\nretry-after:\s*(\d+)\r~i', $header, $retry_after)) {
          // AdsAbs limit reached: proceed according to the action configured in PHP_ADSABSAPILIMITACTION;
          // available actions are: sleep, exit, ignore (default).
          $rai=intval($retry_after[1]);
@@ -1312,18 +1330,6 @@ function Bibcode_Response_Processing(array $curl_opts, string $adsabs_url) : obj
       // @codeCoverageIgnoreEnd
     }
 
-    if (preg_match_all('~\nx\-ratelimit\-\w+:\s*(\d+)\r~i', $header, $rate_limit)) {
-      // @codeCoverageIgnoreStart
-      if ($rate_limit[1][2]) {
-	$ratelimit_total = intval($rate_limit[1][0]);
-	$ratelimit_left = intval($rate_limit[1][1]);
-	$ratelimit_current  = $ratelimit_total - $ratelimit_left;
-	report_info("AdsAbs search " . strval($ratelimit_current) . "/" . strval($ratelimit_total));
-      } else {
-	throw new Exception('Too many requests', $http_response_code);
-      }
-      // @codeCoverageIgnoreEnd
-    }
     if (!is_object($decoded)) {
       bot_debug_log("Could not decode ADSABS API response:\n" . $body . "\nURL was:  " . $adsabs_url);
       throw new Exception("Could not decode API response:\n" . $body, 5000);  // @codeCoverageIgnore


### PR DESCRIPTION
Errors that were not related to rate limit reached were erroneously understood as rate limit reached for AdsAbs. For example on some data parsing errors the bot did react as the limit reached for accessing AdsAbs database. This was because the exact values of limits for AdsAbs were not checked. 

The error could be reproduced on the page "Stomach cancer":

```
php process_page.php "Stomach cancer" --slow
```

This pull request institutes the proper checking of the limits.