### PR TITLE
The Curl errors on conecting to Wikipedia API were not reported, howe…

### DIFF
--- a/WikipediaBot.php
+++ b/WikipediaBot.php
@@ -130,7 +130,8 @@ final class WikipediaBot {
         $errorStr = curl_error(self::$ch_write);
         report_warning('Curl error #'.$errnoInt.' on a Wikipedia write query: '.$errorStr);
       }
-      $ret = @json_decode((string) $data);
+      $data = (string) $data
+      $ret = @json_decode($data);
       if (($ret === NULL) || ($ret === FALSE) || (isset($ret->error) && (   // @codeCoverageIgnoreStart
 	(string) $ret->error->code === 'assertuserfailed' ||
 	stripos((string) $ret->error->info, 'The database has been automatically locked') !== FALSE ||
@@ -385,11 +386,12 @@ final class WikipediaBot {
       $errorStr = curl_error(self::$ch_logout);
       report_warning('Curl error #'.$errnoInt.' on a Wikipedia API query: '.$errorStr);
     }
-    if ($data === false || $data === '') {
+    $data = (string) $data;
+    if ($data === '') {
        sleep(4);                                       // @codeCoverageIgnore
        $data = (string) @curl_exec(self::$ch_logout);  // @codeCoverageIgnore
     }
-    return (self::ret_okay(@json_decode((string) $data))) ? (string) $data : '';
+    return (self::ret_okay(@json_decode( $data))) ? $data : '';
     // @codeCoverageIgnoreStart
    } catch(Exception $E) {
       report_warning("Exception caught!!\n");

--- a/WikipediaBot.php
+++ b/WikipediaBot.php
@@ -117,14 +117,20 @@ final class WikipediaBot {
     $request->signRequest(new HmacSha1(), $consumer, $token);
     $authenticationHeader = $request->toHeader();
 
-try {
+    try {
 	  curl_setopt_array(self::$ch_write, [
 	    CURLOPT_POSTFIELDS => http_build_query($params),
 	    CURLOPT_HTTPHEADER => [$authenticationHeader],
 	  ]);
 
-      $data = (string) @curl_exec(self::$ch_write);
-      $ret = @json_decode($data);
+      $data = @curl_exec(self::$ch_write);
+      if ($data === false)
+      {
+        $errnoInt = curl_errno(self::$ch_write);
+        $errorStr = curl_error(self::$ch_write);
+        report_warning('Curl error #'.$errnoInt.' on a Wikipedia write query: '.$errorStr);
+      }
+      $ret = @json_decode((string) $data);
       if (($ret === NULL) || ($ret === FALSE) || (isset($ret->error) && (   // @codeCoverageIgnoreStart
 	(string) $ret->error->code === 'assertuserfailed' ||
 	stripos((string) $ret->error->info, 'The database has been automatically locked') !== FALSE ||
@@ -372,12 +378,18 @@ try {
 		CURLOPT_URL => API_ROOT,
 	  ]);
 
-    $data = (string) @curl_exec(self::$ch_logout);
-    if ($data === '') {
-       sleep(4);                                // @codeCoverageIgnore
+    $data = @curl_exec(self::$ch_logout);
+    if ($data === false)
+    {
+      $errnoInt = curl_errno(self::$ch_logout);
+      $errorStr = curl_error(self::$ch_logout);
+      report_warning('Curl error #'.$errnoInt.' on a Wikipedia API query: '.$errorStr);
+    }
+    if ($data === false || $data === '') {
+       sleep(4);                                       // @codeCoverageIgnore
        $data = (string) @curl_exec(self::$ch_logout);  // @codeCoverageIgnore
     }
-    return (self::ret_okay(@json_decode($data))) ? $data : '';
+    return (self::ret_okay(@json_decode((string) $data))) ? (string) $data : '';
     // @codeCoverageIgnoreStart
    } catch(Exception $E) {
       report_warning("Exception caught!!\n");
@@ -406,8 +418,14 @@ try {
     curl_setopt_array(self::$ch_logout,
 	      [CURLOPT_HTTPGET => TRUE,
 	       CURLOPT_URL => WIKI_ROOT . '?' . http_build_query(['title' => $title, 'action' =>'raw'])]);
-    $text = (string) @curl_exec(self::$ch_logout);
-    return $text;
+    $text = @curl_exec(self::$ch_logout);
+    if ($text === false)
+    {
+      $errnoInt = curl_errno(self::$ch_logout);
+      $errorStr = curl_error(self::$ch_logout);
+      report_warning('Curl error #'.$errnoInt.' on getting Wikipedia page '.$title.': '.$errorStr);
+    }
+    return (string) $text;
   }
 
 

--- a/WikipediaBot.php
+++ b/WikipediaBot.php
@@ -130,7 +130,7 @@ final class WikipediaBot {
         $errorStr = curl_error(self::$ch_write);
         report_warning('Curl error #'.$errnoInt.' on a Wikipedia write query: '.$errorStr);
       }
-      $data = (string) $data
+      $data = (string) $data;
       $ret = @json_decode($data);
       if (($ret === NULL) || ($ret === FALSE) || (isset($ret->error) && (   // @codeCoverageIgnoreStart
 	(string) $ret->error->code === 'assertuserfailed' ||


### PR DESCRIPTION
The Curl errors on connecting to Wikipedia API were not reported, however, there could be useful error messages such as those on local configuration errors of PHP that prevented connections or certificate verification. Reporting such errors could allow users to fix the issues.

Now there will be messages such as the following:

```
   !Curl error #60 on a Wikipedia API query: SSL certificate problem: unable to get local issuer certificate
   !Wikipedia response was not decoded.  Will sleep and move on.
```

Before the poposed fix, there will be no message on curl error, and only the following line was in the output:

```
   !Wikipedia response was not decoded.  Will sleep and move on.
```

