### PR TITLE
Crossref disagree details are echoed (it was impossible to determine to which citation this message applied)

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -6329,7 +6329,8 @@ final class Template {
 	  if ($this->has('doi') && $this->has('issue') && ($this->get('issue') === $this->get('volume')) && // Issue = Volume and not NULL
 		($this->get('issue') === $this->get_without_comments_and_placeholders('issue')) &&
 		($this->get('volume') === $this->get_without_comments_and_placeholders('volume'))) { // No comments to flag problems
-		$crossRef = query_crossref($this->get_without_comments_and_placeholders('doi'));
+		$doi_template = $this->get_without_comments_and_placeholders('doi');
+		$crossRef = query_crossref($doi_template);
 		if ($crossRef) {
 		  $orig_data = trim($this->get('volume'));
 		   $possible_issue = trim((string) @$crossRef->issue);
@@ -6343,7 +6344,9 @@ final class Template {
 				 $this->set('issue', $possible_issue);
 				 report_action('Citation had volume and issue the same. Changing issue.');
 			   } else {
-				 report_inaction('Citation has volume and issue set to ' . echoable($orig_data) . ' which disagrees with CrossRef');  // @codeCoverageIgnore
+                                 $doi_crossref = $crossRef->doi;
+				 if (!is_string($doi_crossref) || (strlen($doi_crossref) < 2)) {$doi_crossref = $doi_template;}
+				 report_inaction('Citation for doi:' . echoable($doi_crossref) . ' has volume and issue set to ' . echoable($orig_data) . ' which disagrees with CrossRef (volume ' . echoable($possible_volume) . ', issue ' . echoable($possible_issue) . ')');  // @codeCoverageIgnore
 			   }
 			 }
 		   }


### PR DESCRIPTION
When there were CrossRef disagree on volume and issue, there was a message, but it was impossible to determine to which of the citations it was applied. Now the doi details are echoed, so it is now possible to understand to each template it applies. Also, it also prints the values of volume and issue listed in Crossref.

Example of the message as it was displayed in the past:
```
   .Citation has volume and issue set to 3 which disagrees with CrossRef
```

Example of the message in this pull request:
```
   .Citation for doi:10.1002/14651858.CD005612.pub5 has volume and issue set to 3 which disagrees with CrossRef (volume 2022, issue 4)
```

To reproduce the issue, run:
```
php process_page.php "Pregabalin" --savetofiles 
```

The proposed code change only affects the echo output when run from the command line (by displaying additional information), it does not affect the logic of citation expansion.