### PR TITLE
Update translations.php

### DIFF
--- a/constants/translations.php
+++ b/constants/translations.php
@@ -37,7 +37,7 @@ const RU_TRANS = [
     'Use this bot]].' => 'Как использовать бота]].',
     '|Report bugs]]' => '|Сообщить об ошибке]]',
     'Formatted ' => 'Отформатировано ',
-    '| Suggested by ' => '| Предложено ',
-    '| Linked from ' => '| Ссылки с ',
-    '| [[Category:' => '| [[Категория:',
+    'Suggested by' => 'Предложено',
+    'Linked from' => 'Ссылки с',
+    '[[Category:' => '[[Категория:',
 ];


### PR DESCRIPTION
For some reason this piece is not processed, I suspect it is because of the pipe: https://ru.wikipedia.org/w/index.php?diff=141739308&oldid=128942948&title=Большая_Вязовка_%28нижний_приток_Чапаевки%29

Fixes # .

Changes implemented in this pull request:
-
-
