### PR TITLE
Typos and repetitions in constants

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -19,7 +19,7 @@ const REJECT_NEW = ['null', 'n/a', 'undefined', '0 0', '(:none)', '-'];
 const GOOFY_TITLES = ['Archived copy', "{title}", 'ScienceDirect', 'Google Books', 'None', 'usurped title'];
 const BAD_NEW_PAGES = ['0', '0-0', '0–0'];
 const BAD_ISBN = ['9780918678072', '978-0-918678-07-2', '0918678072', '0-918678-07-2'];
-const SHORT_STRING = ['the', 'and', 'a', 'for', 'in', 'on', 's', 're', 't', 'an', 'as', 'at', 'and', 'but', 'how', 'why', 'by', 'when', 'with', 'who', 'where', ''];
+const SHORT_STRING = ['the', 'and', 'a', 'for', 'in', 'on', 's', 're', 't', 'an', 'as', 'at', 'but', 'how', 'why', 'by', 'when', 'with', 'who', 'where', ''];
 const RIS_IS_BOOK = ['CHAP', 'BOOK', 'EBOOK', 'ECHAP', 'EDBOOK', 'DICT', 'ENCYC', 'GOVDOC'];
 const RIS_IS_FULL_BOOK = ['BOOK', 'EBOOK', 'EDBOOK'];
 const GOOD_FREE = ['publisher', 'projectmuse', 'have free'];
@@ -32,12 +32,12 @@ const BAD_AGENT_PUBS = ['United States Department of Health and Human Services',
 const NO_LANGS = ['n', 'no', 'live', 'alive', 'কার্যকর', 'hayır', 'não', 'nao', 'false'];
 const YES_LANGS = ['y', 'yes', 'dead', 'si', 'sì', 'ja', 'evet', 'ei tööta', 'sim', 'ano', 'true'];
 const PDF_LINKS = ['pdf', 'portable document format', '[[portable document format|pdf]]', '[[portable document format]]', '[[pdf]]'];
-const DEPARMENTS = ['local', 'editorial', 'international', 'national', 'communication', 'letter to the editor',
+const DEPARTMENTS = ['local', 'editorial', 'international', 'national', 'communication', 'letter to the editor',
         'review', 'coronavirus', 'race & reckoning', 'politics', 'opinion', 'opinions', 'investigations', 'tech',
-        'technology', 'world', 'sports', 'world', 'arts & entertainment', 'arts', 'entertainment', 'u.s.', 'n.y.',
+        'technology', 'world', 'sports', 'arts & entertainment', 'arts', 'entertainment', 'u.s.', 'n.y.',
         'business', 'science', 'health', 'books', 'style', 'food', 'travel', 'real estate', 'magazine', 'economy',
         'markets', 'life & arts', 'uk news', 'world news', 'health news', 'lifestyle', 'photos', 'education',
-        'arts', 'life', 'puzzles'];
+        'life', 'puzzles'];
 const BAD_VIA = [ '', 'project muse', 'wiley', 'springer', 'questia', 'elsevier', 'wiley online library',
         'wiley interscience', 'interscience', 'sciencedirect', 'science direct', 'ebscohost', 'proquest',
         'google scholar', 'google', 'bing', 'yahoo'];
@@ -6613,7 +6613,7 @@ final class Template
        }
       }
       if (
-       in_array(strtolower($this->get('work')), DEPARMENTS, true) &&
+       in_array(strtolower($this->get('work')), DEPARTMENTS, true) &&
        $this->blank('department')
       ) {
        $this->rename('work', 'department');


### PR DESCRIPTION
Changes implemented in this pull request:
- removed duplicate `and` from the `SHORT_STRING` constant;
- `DEPARMENTS` renamed to `DEPARTMENTS` to fix typo in the constant name; removed duplicate `world` and `arts` entries from this list.
