### PR TITLE
Update bad_data.php

### DIFF
--- a/constants/bad_data.php
+++ b/constants/bad_data.php
@@ -478,6 +478,7 @@ const BAD_ZOTERO_TITLES = [
     '.org',
     '{{',
     '}}',
+    '403 Forbidden',
     '404 - - ',
     '404 - ',
     '404 - File or directory not found',


### PR DESCRIPTION
Adding 403 Forbidden to bad title list seems to prevent it from being added to references without a title, or with a blank title= but it still changes Archived copy to 403 Forbidden.

https://en.wikipedia.org/w/index.php?title=User:Redalert2fan/sandbox4&curid=57742189&diff=1317504310&oldid=1317504281

Suspect that this should fix it.