### PR TITLE
Fix spelling typos in documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Class files:
   `Template::add_if_new()` is generally (but not always) used to add
    parameters to the updated template; `Template::tidy()` cleans up the
    template, but may add parameters as well and have side effects.
-* `Comment.php`: Handles comments, nokwiki, etc. tags
+* `Comment.php`: Handles comments, nowiki, etc. tags
 * `Parameter.php`: contains information about template parameter names, values,
    and metadata, and methods to parse template parameters.
 
@@ -94,7 +94,7 @@ In order to run on the command line one needs OAuth tokens as documented in `env
 
     /usr/bin/php ./process_page.php "Covid Watch|Water|COVID-19_apps" --slow --savetofiles
     
-The command line tool will also accept `page_list.txt` and `page_list2.txt` as page names.  In those cases the bot expect a file of such name to contain a single line of | seperated page names.  This code requires PHP 8.2 with optional packages included: php82-mbstring php82-sockets php82-opcache php82-openssl php82-xmlrpc php82-gettext php82-curl php82-intl php82-iconv
+The command line tool will also accept `page_list.txt` and `page_list2.txt` as page names.  In those cases the bot expect a file of such name to contain a single line of | separated page names.  This code requires PHP 8.2 with optional packages included: php82-mbstring php82-sockets php82-opcache php82-openssl php82-xmlrpc php82-gettext php82-curl php82-intl php82-iconv
 
 Command line parameters:
 * `--slow` - retrieve bibcodes and expand urls

--- a/constants/bad_data.php
+++ b/constants/bad_data.php
@@ -1280,7 +1280,7 @@ const HOSTNAME_MAP = [
     'youtube.com' => '[[YouTube]]',
     'zap2it.com' => '[[Zap2it]]',
     'zdnet.com' => '[[ZDNet]]',
-]; // Be warned, some website host a seperate sunday edition, etc.  Be careful and when in doubt link to hostname
+]; // Be warned, some website host a separate sunday edition, etc.  Be careful and when in doubt link to hostname
 
 const NO_DATE_WEBSITES = [
     'laws-lois.justice.gc.ca',

--- a/tests/phpunit/PageTest.php
+++ b/tests/phpunit/PageTest.php
@@ -105,7 +105,7 @@ final class PageTest extends testBaseClass {
         $this->assertTrue(strlen($page->parsed_text()) > 200);
     }
 
-    public function testBotReadNonExistant(): void {
+    public function testBotReadNonExistent(): void {
         $page = new TestPage();
         $this->assertFalse($page->get_text_from('User:Blocked Testing Account/readtest/NOT_REAL_EVER'));
     }

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -1726,7 +1726,7 @@ final class TemplateTest extends testBaseClass {
         $this->assertSame($text, $prepared->parsed_text());
     }
 
-    public function testChangeParamaters1(): void {
+    public function testChangeParameters1(): void {
         // publicationplace
         $text = '{{citation|publicationplace=Home}}';
         $prepared = $this->prepare_citation($text);
@@ -1734,14 +1734,14 @@ final class TemplateTest extends testBaseClass {
         $this->assertSame('{{citation|publication-place=Home}}', $prepared->parsed_text());
     }
 
-    public function testChangeParamaters2(): void {
+    public function testChangeParameters2(): void {
         $text = '{{citation|publication-place=Home|location=Away}}';
         $prepared = $this->prepare_citation($text);
         $prepared->final_tidy();
         $this->assertSame($text, $prepared->parsed_text());
     }
 
-    public function testChangeParamaters3(): void {
+    public function testChangeParameters3(): void {
         // publicationdate
         $text = '{{citation|publicationdate=2000}}';
         $prepared = $this->prepare_citation($text);
@@ -1749,14 +1749,14 @@ final class TemplateTest extends testBaseClass {
         $this->assertSame('{{citation|publication-date=2000}}', $prepared->parsed_text());
     }
 
-    public function testChangeParamaters4(): void {
+    public function testChangeParameters4(): void {
         $text = '{{citation|publicationdate=2000|date=1999}}';
         $prepared = $this->prepare_citation($text);
         $prepared->final_tidy();
         $this->assertSame('{{citation|publication-date=2000|date=1999}}', $prepared->parsed_text());
     }
 
-    public function testChangeParamaters5(): void {
+    public function testChangeParameters5(): void {
         // origyear
         $text = '{{citation|origyear=2000}}';
         $prepared = $this->prepare_citation($text);
@@ -1764,7 +1764,7 @@ final class TemplateTest extends testBaseClass {
         $this->assertSame('{{citation|orig-date=2000}}', $prepared->parsed_text());
     }
 
-    public function testChangeParamaters6(): void {
+    public function testChangeParameters6(): void {
         $text = '{{citation|origyear=2000|date=1999}}';
         $prepared = $this->prepare_citation($text);
         $prepared->final_tidy();

--- a/tests/phpunit/constantsTest.php
+++ b/tests/phpunit/constantsTest.php
@@ -664,7 +664,7 @@ final class constantsTest extends testBaseClass {
         $pg = new TestPage(); unset($pg); // Fill page name with test name for debugging
         $errors = '';
         $all_maps = array_merge(COMMON_MISTAKES, COMMON_MISTAKES_TOOL);
-        $okay_to_be_bad = ['coauthors', 'deadurl', 'lay-date', 'lay-source', 'lay-url', 'month', 'authors'];  // We upgrade dead paramters to better dead parameters
+        $okay_to_be_bad = ['coauthors', 'deadurl', 'lay-date', 'lay-source', 'lay-url', 'month', 'authors'];  // We upgrade dead parameters to better dead parameters
         foreach ($all_maps as $map_me => $mapped) {
             if (isset($all_maps[$mapped])) {
                 $errors .= ' re-mapped: ' . $map_me . '/' . $mapped . '    ';
@@ -680,7 +680,7 @@ final class constantsTest extends testBaseClass {
             }
             if (!in_array($mapped, $okay_to_be_bad, true)) {
             	if (!in_array($mappedp, PARAMETER_LIST, true)) {
-                	$errors .= ' mapped to non-existant parameter: ' . $map_me . '/' . $mapped . '    ';
+                	$errors .= ' mapped to non-existent parameter: ' . $map_me . '/' . $mapped . '    ';
             	}
             	if (in_array($mappedp, DEAD_PARAMETERS, true) || in_array($mapped, DEAD_PARAMETERS, true)) {
                 	$errors .= ' mapped to dead parameter: ' . $map_me . '/' . $mapped . '    ';


### PR DESCRIPTION
## Summary
- Fix typo in README.md: `nokwiki` -> `nowiki`
- Fix typo in README.md: `seperated` -> `separated`
- Fix typo in constants/bad_data.php comment: `seperate` -> `separate`
- Fix typos in tests/phpunit/constantsTest.php: `paramters` -> `parameters`, `existant` -> `existent`
- Fix typos in tests/phpunit/TemplateTest.php: `testChangeParamaters` -> `testChangeParameters` (6 occurrences)
- Fix typo in tests/phpunit/PageTest.php: `testBotReadNonExistant` -> `testBotReadNonExistent`

## Test plan
- [x] Changes are limited to comments, documentation, and test method names
- [ ] Verify tests still pass after method name changes