### PR TITLE
build: install phpunit 9 as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,8 @@
     "description": "Expands CS1/CS2 citation templates on Wikipedia",
     "require": {
         "mediawiki/oauthclient": "2.3.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9"
     }
 }


### PR DESCRIPTION
Why
- developer experience (DX)
    - in VS Code, makes it so that PHPUnit functions are recognized
    - allows the developer to run the tests locally with `composer exec phpunit tests`

What
- install phpunit 9 as a dev dependency

Notes
- phpunit 9 is what is hard-coded into CI, so use that for now
- no-op