### PR TITLE
Prevent the bot from mangling arXiV citations

### DIFF
--- a/apiFunctions.php
+++ b/apiFunctions.php
@@ -293,8 +293,24 @@ function arxiv_api(array $ids, array &$templates): void {  // Pointer to save me
         return;
     }
 
-    $this_template = current($templates); // advance at end of foreach loop
+    // Arxiv currently does not order the data recieved according to id_list. This is causing CitationBot to mix up
+    // which Arxiv ID is associated with which citation. As a result, we first perform a sorting pass to make sure we
+    // order the arxiv data based on our id_list so that we have a 1 to 1 ordering of both.
+    $entry_map = [];
     foreach ($xml->entry as $entry) {
+        $arxiv_id = preg_replace('#http://arxiv\.org/abs/([^v]+)v\d+#', '$1', (string)$entry->id);
+        $entry_map[$arxiv_id] = $entry;
+    }
+
+    $sorted_arxiv_data = [];
+    foreach ($ids as $id) {
+        if (isset($entry_map[$id])) {
+            $sorted_arxiv_data[] = $entry_map[$id];
+        }
+    }
+
+    $this_template = current($templates); // advance at end of foreach loop
+    foreach ($sorted_arxiv_data as $entry) {
         $i = 0;
         report_info("Found match for arXiv " . echoable($ids[$i]));
         if ($this_template->add_if_new("doi", (string) $entry->arxivdoi, 'arxiv')) {


### PR DESCRIPTION
TLDR, some of the recent issues like [1] and [2] are caused by what appears to be a API change on ArXiV's end. The current implementation assumes that the ArXiV URL data are ordered in the order they were requested (in the `$ids` variable in line 270 in apiFunctions.php).

This patch adds a step that cleans up the ordering of the data ArXiV returns so that before we start fixing templates, the `$ids` array has the same ordering as the data returned by arXiV.

[1]: https://en.wikipedia.org/wiki/User_talk:Citation_bot#CitationBot_merging_info_from_two_completely_different_references
[2]: https://en.wikipedia.org/wiki/User_talk:Citation_bot#ArXiv_references_getting_completely_messed_up
