### PR TITLE
Fix work=/title= when converting from web to book

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -5185,6 +5185,14 @@ final class Template
    } elseif (!$this->blank(['chapter-url', 'chapterurl']) && str_i_same($this->get('chapter-url'), $this->get('url'))) {
     $this->forget('url');
    } // otherwise they are different urls
+
+   // If there is work=/title= pair and we are converting the template to a cite book
+   // we need to convert them to use the chapter=/title= pair instead as required by CS1
+   if ( $this->has( 'work' ) && $this->has( 'title' ) ) {
+    $tmp = $this->get( 'work' );
+    $this->rename( 'title', 'chapter' );
+    $this->add('title', $tmp);
+   }
   }
  }
 


### PR DESCRIPTION
Previously, when the bot converted a {{cite web}} template to {{cite book}} template it would keep the work=/title= parameters intact. However, this breaks CS1 templates. This was brought up in [1] and [2].

This patch adds code to switch the work= parameter to the title= parameter and copying the existing title parameter into the chapter parameter as required by CS1.

[1]: https://en.wikipedia.org/wiki/User_talk:Citation_bot#Mangles_cite_web_to_cite_book_conversion_by_failing_to_change_parameter_names
[2]: https://en.wikipedia.org/wiki/User_talk:Citation_bot#Cite_book_to_cite_web_conversion_breaks_citation_by_failing_to_migrate_title=/work=_to_chapter=/title=
