### PR TITLE
Upgrade actions/checkout from V3 to V4

### DIFF
--- a/.github/workflows/DesignSecurity.yml
+++ b/.github/workflows/DesignSecurity.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/PHPChecker.yml
+++ b/.github/workflows/PHPChecker.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/ThePHPChecker.yml
+++ b/.github/workflows/ThePHPChecker.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/psalm-security.yml
+++ b/.github/workflows/psalm-security.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.3.1
 
     - name: Setup PHP with PCOV
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
V3 is no longer in development. V4 is already used in trivy-analysis.yml 
V5 and V6 are also available, but V4 is proven to work on trivy-analysis.yml

