### PR TITLE
Fix config key for minimum stability in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
             "third-party/required-plugin": true
         },
         "prefer-stable": true,
-        "config minimum-stability": "dev",
+        "minimum-stability": "dev",
         "preferred-install": "dist"
     }
 }


### PR DESCRIPTION
Composer expects a top-level "minimum-stability" key, not "config minimum-stability". That typo will be ignored by Composer and means the intended minimum-stability setting is not applied.

