### PR TITLE
Reduce dependabot updates to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@ updates:
 - package-ecosystem: "composer"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
     
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-   interval: "daily"
+   interval: "weekly"


### PR DESCRIPTION
Since we now have had dependabot check all our dependencies for updates, the frequency can be reduced to a weekly check. 
This will also build in some extra safeguard for us by ways of letting updates for dependencies be outstanding for a few days, so that should the new update for the dependency contain bugs, we would not immediately use it.


