### PR TITLE
remove ?>

### DIFF
--- a/authenticate.php
+++ b/authenticate.php
@@ -120,4 +120,3 @@ catch (Throwable $e) {
     /** fall through */
 }
 death_time("Unable to initiate OAuth.");
-?>

--- a/category.php
+++ b/category.php
@@ -81,5 +81,3 @@ if ($total > intval(MAX_PAGES / 4)) {
 }
 $edit_summary_end = "| Suggested by " . $api->get_the_user() . " | [[Category:{$category}]] | #UCB_Category ";
 edit_a_list_of_pages($pages_in_category, $api, $edit_summary_end);
-
-?>

--- a/env.php.example
+++ b/env.php.example
@@ -36,4 +36,3 @@ if (!getenv('PHP_OAUTH_CONSUMER_TOKEN')) {
         echo 'Error in env.php';
     }
 }
-?>

--- a/gadgetapi.php
+++ b/gadgetapi.php
@@ -63,5 +63,3 @@ try {
     @ob_end_clean(); // @codeCoverageIgnore
     // Above is paranoid panic code.    So paranoid that we even empty buffers two extra times
 }
-
-?>

--- a/generate_template.php
+++ b/generate_template.php
@@ -58,5 +58,3 @@ $text = $page->parsed_text();
 unset($page);
 
 echo "\n\n", echoable('<ref>' . $text . '</ref>'), "\n\n</pre></main></body></html>";
-
-?>

--- a/gitpull.php
+++ b/gitpull.php
@@ -19,4 +19,3 @@ if (@mkdir('git_pull.lock', 0700)) {
     echo 'Please try again';
 }
 echo '</pre></main></body></html>';
-?>

--- a/kill_big_job.php
+++ b/kill_big_job.php
@@ -18,4 +18,3 @@ if (!isset($_SESSION['citation_bot_user_id'])) {
 } else {
     echo '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>Killing the big job</title></head><body><main><pre>Existing large job flagged for stopping</pre></main></body></html>';
 }
-?>

--- a/linked_pages.php
+++ b/linked_pages.php
@@ -69,5 +69,3 @@ unset($links);
 $pages_in_category = array_unique($pages_in_category);
 
 edit_a_list_of_pages($pages_in_category, $api, $edit_summary_end);
-
-?>

--- a/process_page.php
+++ b/process_page.php
@@ -92,5 +92,3 @@ unset($pages);
 unset($_GET, $_POST, $_REQUEST); // Memory minimize
 
 edit_a_list_of_pages($pages_to_do, $api, $edit_summary_end);
-
-?>


### PR DESCRIPTION
Why
- this is a neat trick to prevent a certain kind of whitespace bug. the bug is: if you include a file that has something like `?> ` (note the space after) and then you send a `header()`, the header will give an error because you can only use header() if nothing has been echo'd yet

What
- remove ?> from the end of all PHP files