### PR TITLE
remove code coverage from CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -41,14 +41,4 @@ jobs:
          PHP_WP_OAUTH_SECRET: ${{ secrets.PHP_WP_OAUTH_SECRET }}
          PHP_WP_OAUTH_CONSUMER: ${{ secrets.PHP_WP_OAUTH_CONSUMER }}
          PHP_S2APIKEY: ${{ secrets.PHP_S2APIKEY }}
-      run: ./vendor/bin/phpunit --enforce-time-limit --default-time-limit 13000 --coverage-clover coverage.xml 1>&2
-
-    - name: Code Coverage
-      if: always()
-      env:
-         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      uses: codecov/codecov-action@v5.5.1
-
-    - name: Look for weird stuff
-      if: always()
-      run: /bin/cat ./CodeCoverage
+      run: ./vendor/bin/phpunit --enforce-time-limit --default-time-limit 13000 1>&2

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,6 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![PHP ](https://img.shields.io/badge/PHP-8.4-blue.svg)](https://www.php.net)
 [![GitHub issues](https://img.shields.io/github/issues/ms609/citation-bot.png)](https://github.com/ms609/citation-bot/issues)
-[![codecov](https://codecov.io/gh/ms609/citation-bot/branch/master/graph/badge.svg)](https://codecov.io/gh/ms609/citation-bot)
 
 
 # Citation bot


### PR DESCRIPTION
Why
- I think maintainers usually ignore the code coverage workflow when it turns red. If this is being ignored and we can still merge patches when this fails, then it is just causing noise (causes a red X on PRs and commits despite being safe to merge)

What
- Remove the CI workflow codecov/project