### PR TITLE
improve Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# If you make any changes to this file, don't forget to rebuild the Docker image using the --build flag:
+# docker-compose up --build -d
+
+FROM php:8.4-apache
+
+# Install composer. Once the container is built and running, you can do `composer update` with the following shell command: `docker exec -it citation-bot-php-1 composer update`
+RUN apt-get update && apt-get install -y git zip unzip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/composer
+
+# Allow directory listings. Not a security issue since this is a test environment. Makes it easier to navigate.
+RUN a2enmod autoindex
+RUN echo "<Directory /var/www/html>\n    Options +Indexes\n    AllowOverride All\n</Directory>" > /etc/apache2/conf-available/directory-listing.conf \
+    && a2enconf directory-listing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-version: '3.8'
 services:
   php:
-    image: php:8.4-apache
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
       - "8081:80" # https://localhost:8081
     volumes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,4 +110,8 @@ Command line parameters:
 * `--savetofiles` - save processed pages as files (with .md extension) instead of submitting them to Wikipedia
 
 ## Running in web browser locally
-One way to set up a localhost that runs in your web browser is to use Docker. A docker-compose.yml file is provided with the necessary configuration settings. Simply create an .env file (see above), install Docker, open a shell, `cd` to the root directory of this repo, type `docker compose up -d`, then visit https://localhost:8081.
+One way to set up a localhost that runs in your web browser is to use Docker. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) on your computer, open a shell, `cd` to the root directory of this repo, type `docker compose up -d`, then visit https://localhost:8081.
+
+To install Composer dependencies, start the container as noted above, then type `docker exec -it citation-bot-php-1 composer update`.
+
+To do most bot tasks, you'll need to create an env.php file and populate it with API keys. See env.php.example in the root.


### PR DESCRIPTION
Why
- Docker is software that lets you spin up a PHP 8.4 server to do localhost testing
- We added basic support for this in #4914, but `composer update` doesn't work yet

What
- Add support for `composer update`