### PR TITLE
phpcs: fix inline control structures

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -25,4 +25,5 @@
     <rule ref="Generic.WhiteSpace.ScopeIndent"/>
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>
+    <rule ref="Generic.ControlStructures.InlineControlStructure.NotAllowed"/>
 </ruleset>

--- a/Template.php
+++ b/Template.php
@@ -5117,7 +5117,9 @@ final class Template
                     }
                     if ($this->blank(WORK_ALIASES)) {
                         if (in_array(str_replace(['[', ']', '"', "'", 'www.'], '', $publisher), PUBLISHERS_ARE_WORKS, true)) {
-                            if ($this->wikiname() !== 'cite book') $this->rename($param, 'work'); // Don't think about which work it is
+                            if ($this->wikiname() !== 'cite book') {
+                                $this->rename($param, 'work'); // Don't think about which work it is
+                            }
                             return;
                         }
                     } elseif ($this->has('website')) {

--- a/includes/api/APIjstor.php
+++ b/includes/api/APIjstor.php
@@ -121,7 +121,9 @@ function expand_by_jstor(Template $template): void {
                     case "T2":
                     case "BT":
                         $new_title = mb_trim($ris_part[1]);
-                        if ($new_title) report_info("    Possible new title: " . echoable($new_title));
+                        if ($new_title) {
+                            report_info("    Possible new title: " . echoable($new_title));
+                        }
                         break;
                     default: // @codeCoverageIgnore
                 }

--- a/tests/phpunit/constantsTest.php
+++ b/tests/phpunit/constantsTest.php
@@ -146,7 +146,9 @@ final class constantsTest extends testBaseClass {
         $sections = explode($start_alpha, $old_contents);
         foreach ($sections as &$section) {
             $alpha_end = stripos($section, $end_alpha);
-            if (!$alpha_end) continue;
+            if (!$alpha_end) {
+                continue;
+            }
             $alpha_bit = substr($section, 0, $alpha_end);
             $alpha_bits = preg_split('~(?<=\'),~', $alpha_bit);
             $alpha_bits = array_map('mb_trim', $alpha_bits);
@@ -171,7 +173,9 @@ final class constantsTest extends testBaseClass {
                 $alphaed .= $bit ? ($bit . ",") : '';
                 $alphaed .= $new_line;
             }
-            if ($alphaed === $new_line) $alphaed = '';
+            if ($alphaed === $new_line) {
+                $alphaed = '';
+            }
             $section = $alphaed . substr($section, $alpha_end);
         }
         unset ($section); // Destroy pointer to be safe
@@ -366,7 +370,9 @@ final class constantsTest extends testBaseClass {
             sort($flat);
             $last = 'XXXXXXXX';
             foreach ($flat as $param) {
-                if ($param === $last) echo "\n" . $param . "\n";
+                if ($param === $last) {
+                    echo "\n" . $param . "\n";
+                }
                 $last = $param;
             }
             $this->flush();
@@ -462,7 +468,9 @@ final class constantsTest extends testBaseClass {
         $this->assertSame("END_OF_CITE_list_junk", end($italics));
         foreach ($italics as $item) {
             $spaces = substr_count($item, " ");
-            if ($spaces > $spaces_at) $in_order = false;
+            if ($spaces > $spaces_at) {
+                $in_order = false;
+            }
             $spaces_at = $spaces;
             $max_spaces = max($max_spaces, $spaces);
         }


### PR DESCRIPTION
Why
- more readable and less prone to bugs if the contents of braces always get their own line and indentation

What
- enforce the contents of braces always getting their own line and indentation
- autofix approximately 7 existing issues of this