### PR TITLE
phpcs: add rule for no ?> at end of PHP files

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -22,6 +22,7 @@
     <file>WikipediaBot.php</file>
     <file>./includes</file>
     <file>./tests</file>
+    <rule ref="PSR2.Files.ClosingTag"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent"/>
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>


### PR DESCRIPTION
We already did this in $4960, so no autofixes needed. Adding a rule keeps this from creeping back into the codebase.