### PR TITLE
setup: move comment down

### DIFF
--- a/includes/setup.php
+++ b/includes/setup.php
@@ -43,10 +43,10 @@ if (isset($_REQUEST["wiki_base"])){
 } else {
     $wiki_base = 'en';
 }
-/** The wiki language code. For example, en, simple, or mdwiki. Note that mdwiki is non-standard */
 if ($wiki_base === 'mdwiki') {
     define('WIKI_ROOT', 'https://mdwiki.org/w/index.php');
     define('API_ROOT', 'https://mdwiki.org/w/api.php');
+    /** The wiki language code. For example, en, simple, or mdwiki. Note that mdwiki is non-standard */
     define('WIKI_BASE', 'mdwiki');
     define('EDIT_AS_USER', true); // TODO - does this work?
 } else {


### PR DESCRIPTION
Why
- this docblock is for the WIKI_BASE constant. the idea is you hover over the constant WIKI_BASE with your mouse, and it'll provide that docblock. if the comment is higher, the IDE (e.g. VS Code) doesn't know that this docblock goes with this constant

What
- move WIKI_BASE docblock to be right above WIKI_BASE constant declaration