### PR TITLE
phpunit: treat PHP deprecation notices as errors

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
   failOnRisky="true"
   failOnWarning="true"
   cacheResult="false"
+  failOnDeprecation="true"
 >
   <source>
     <include>


### PR DESCRIPTION
Why
- if we want to change PHP versions in the future, this will alert us to things to fix
- we currently have no deprecation notices, so this will be a no-op for now, with no additional work needed at this time

What
- configure PHPUnit to mark tests with deprecation notices as errors