### PR TITLE
increase mediawiki-codesniffer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "designsecurity/progpilot": "^1",
-        "mediawiki/mediawiki-codesniffer": "^40.0.1",
+        "mediawiki/mediawiki-codesniffer": "^48.0.0",
         "overtrue/phplint": "^9",
         "phan/phan": "^5",
         "phpstan/phpstan": "^2.1.32",


### PR DESCRIPTION
accidentally downgraded in 9895bb1. this restores the correct version