### PR TITLE
Add code to remove #no-access-message from OUP URLs

### DIFF
--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -1038,6 +1038,10 @@ function clean_existing_urls_INSIDE(Template $template, string $param): void {
         $template->set($param, 'https://' . $matches[1]);
     }
 
+    if (preg_match("~^(https?://academic\.oup\.com/.+)#no-access-message$~", $template->get($param), $matches)) {
+        $template->set($param, $matches[1]);
+    }
+
     // Proxy stuff
     if (mb_stripos($template->get($param), 'proxy') !== false) {
         // Look for proxy first for speed, this list will grow and grow

--- a/tests/phpunit/includes/urlToolsTest.php
+++ b/tests/phpunit/includes/urlToolsTest.php
@@ -888,4 +888,11 @@ final class urlToolsTest extends testBaseClass {
         $this->assertNull($prepared->get2('archiveurl'));
     }
 
+    public function testRemoveNoAccessMessageFromOUP(): void {
+        $text = '{{cite journal|url=https://academic.oup.com/gji/article-abstract/230/1/50/6522179#no-access-message}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('url');
+        $this->assertSame('https://academic.oup.com/gji/article-abstract/230/1/50/6522179', $template->get2('url'));
+    }
+
 }


### PR DESCRIPTION
This pull request introduces a targeted improvement to URL handling for Oxford University Press (OUP) journal links. Specifically, it ensures that URLs ending with `#no-access-message` are cleaned to remove this fragment, which is not needed for citation purposes. A corresponding unit test has been added to verify this behavior.

URL normalization improvements:

* Updated the `clean_existing_urls_INSIDE` function in `URLtools.php` to strip the `#no-access-message` fragment from OUP journal URLs, ensuring cleaner and more consistent citation links.

Testing enhancements:

* Added a new test, `testRemoveNoAccessMessageFromOUP`, in `urlToolsTest.php` to confirm that the URL cleaning logic correctly removes the `#no-access-message` fragment from OUP journal URLs.