### PR TITLE
Add 'VideoGIE' to capitalization constants

### DIFF
--- a/src/includes/constants/capitalization.php
+++ b/src/includes/constants/capitalization.php
@@ -1552,6 +1552,7 @@ const UCFIRST_JOURNAL_ACRONYMS = [ /* The following will be automatically update
     ' V Astronomicheskii Zhurna ',
     ' Van Het ',
     ' van Het ',
+    ' Videogie ',
     ' Virusdisease ',
     ' Vjesnik Historijskih Arhiva U Rijeci I Pazinu ',
     ' Vjesnik Historijskih Arhiva U Rijeci I Pazinu ',


### PR DESCRIPTION
This pull request makes a minor update to the `src/includes/constants/capitalization.php` file, adding a new entry to the list of capitalization exceptions.

* Added `' VideoGIE'` to the capitalization exceptions array to improve handling of journal titles.