### PR TITLE
phan: simplify config

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -13,10 +13,10 @@ return [
     // information should be included.
     //
     'exclude_analysis_directory_list' => [
-        './vendor/'
+        './vendor'
     ],
     'directory_list' => [
-        './src', './vendor/', './tests/'
+        './src', './vendor', './tests'
     ],
 ];
 


### PR DESCRIPTION
I tested this locally by putting `echo $undefined_variable;` in a src/include/ file. Phan caught it both with the old config and the new config. This tells me that Phan recurses the subdirectories of its folders, so those don't need to be stated explicitly.