### PR TITLE
rename `TRAVIS` constant to `CI`

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ parameters:
         - HTML_OUTPUT
         - SLOW_MODE
         - FLUSHING_OKAY
-        - TRAVIS
+        - CI
         - EDIT_AS_USER
         - BIG_JOB_MODE
         - MAX_TRIES

--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -782,7 +782,7 @@ class Page {
             return true;
         }
         // @codeCoverageIgnoreStart
-        if (TRAVIS) {
+        if (CI) {
             return false;
         }
         sleep(9);    // could be database being locked

--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -14,7 +14,7 @@ function drop_urls_that_match_dois(array &$templates): void {  // Pointer to sav
     static $ch_dx;
     static $ch_doi;
     if ($ch_dx === null) {
-        if (TRAVIS) {
+        if (CI) {
             $time = 3.0;
         } else {
             $time = 1.0; // @codeCoverageIgnore
@@ -1314,7 +1314,7 @@ function find_indentifiers_in_urls_INSIDE(Template $template, string $url, strin
     static $ch_jstor;
     static $ch_pmc;
     if ($ch_jstor === null) {
-        if (TRAVIS) {
+        if (CI) {
             $time = 3.0;
         } else {
             $time = 1.0; // @codeCoverageIgnore

--- a/src/includes/WikipediaBot.php
+++ b/src/includes/WikipediaBot.php
@@ -53,7 +53,7 @@ final class WikipediaBot {
         $this->user_client = new Client($conf);
         $this->user_token = new Token("", "");
 
-        if (TRAVIS) {
+        if (CI) {
             $this->the_user = 'Citation_bot';
             // @codeCoverageIgnoreStart
         } elseif (!HTML_OUTPUT) { // Running on the command line, and editing using main tokens
@@ -75,7 +75,7 @@ final class WikipediaBot {
     public static function ret_okay(?object $response): bool { // We send back true for thing that are page specific
         if (is_null($response)) {
             report_warning('Wikipedia response was not decoded.  Will sleep and move on.');
-            if (!TRAVIS) {
+            if (!CI) {
                 sleep(10);
             } else {
                 sleep(1);
@@ -115,7 +115,7 @@ final class WikipediaBot {
                 bot_debug_log($err_string); // Good to know about about these things
                 report_warning($err_string);
             }
-            if (!TRAVIS) {
+            if (!CI) {
                 sleep(10);
             } else {
                 sleep(1);

--- a/src/includes/api/APIBibCode.php
+++ b/src/includes/api/APIBibCode.php
@@ -380,7 +380,7 @@ function adsabs_api(array $ids, array &$templates, string $identifier): void {  
     }
 
     // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/API_documentation_UNIXshell/Search_API.ipynb
-    $adsabs_url = "https://" . (TRAVIS ? 'qa' : 'api')
+    $adsabs_url = "https://" . (CI ? 'qa' : 'api')
                     . ".adsabs.harvard.edu/v1/search/bigquery?q=*:*"
                     . "&fl=arxiv_class,author,bibcode,doi,doctype,identifier,"
                     . "issue,page,pub,pubdate,title,volume,year&rows=2000";
@@ -469,7 +469,7 @@ function query_adsabs(string $options): object {
     if (!PHP_ADSABSAPIKEY) {
         return (object) ['numFound' => 0]; // @codeCoverageIgnore
     }
-    $adsabs_url = "https://" . (TRAVIS ? 'qa' : 'api')
+    $adsabs_url = "https://" . (CI ? 'qa' : 'api')
                     . ".adsabs.harvard.edu/v1/search/query"
                     . "?q={$options}&fl=arxiv_class,author,bibcode,doi,doctype,identifier,"
                     . "issue,page,pub,pubdate,title,volume,year";

--- a/src/includes/api/APIieee.php
+++ b/src/includes/api/APIieee.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 function query_ieee_webpages(array &$templates): void {  // Pointer to save memory
     static $ch_ieee;
     if ($ch_ieee === null) {
-        if (TRAVIS) {
+        if (CI) {
             $time = 3.0;
         } else {
             $time = 1.0; // @codeCoverageIgnore

--- a/src/includes/api/APIpii.php
+++ b/src/includes/api/APIpii.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 function get_doi_from_pii(string $pii): string {
     static $ch_pii;
     if ($ch_pii === null) {
-        if (TRAVIS) {
+        if (CI) {
             $time = 3.0;
         } else {
             $time = 1.0; // @codeCoverageIgnore

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -41,7 +41,7 @@ final class Zotero {
             return;
         }
         $is_setup = true;
-        if (TRAVIS) {
+        if (CI) {
             $time = 3.0;
         } else {
             $time = 1.0; // @codeCoverageIgnore

--- a/src/includes/doiTools.php
+++ b/src/includes/doiTools.php
@@ -85,7 +85,7 @@ function doi_works(string $doi): ?bool {
     if (isset(NULL_DOI_ANNOYING[$doi])) {
         return false;
     }
-    if (!TRAVIS) {
+    if (!CI) {
         foreach (NULL_DOI_STARTS_BAD as $bad_start) { // @codeCoverageIgnoreStart
             if (mb_stripos($doi, $bad_start) === 0) {
                 return false; // all gone
@@ -815,7 +815,7 @@ function get_headers_array(string $url): false|array {
     static $context_insecure_hdl;
     if (!isset($context_insecure_doi)) {
         $timeout = BOT_HTTP_TIMEOUT * 1.0;
-        if (TRAVIS) {
+        if (CI) {
             $timeout = 5.0; // Give up fast
         }
         $context_insecure_doi = stream_context_create([
@@ -875,7 +875,7 @@ function doi_is_bad (string $doi): bool {
         $doi === '10.1093/oi/authority' || // over-truncated
         $doi === '10.1377/forefront' || // over-truncated
         $doi === '10.3905/jpm' || // over-truncated
-        (mb_strpos($doi, '10.0000/') === 0 && !TRAVIS) || // just urls that look like DOIs - TODO: Fix test suite
+        (mb_strpos($doi, '10.0000/') === 0 && !CI) || // just urls that look like DOIs - TODO: Fix test suite
         mb_strpos($doi, '10.5779/hypothesis') === 0 || // SPAM took over
         mb_strpos($doi, '10.5555/') === 0 || // Test DOI prefix
         mb_strpos($doi, '10.5860/choice.') === 0 || // Paywalled book review

--- a/src/includes/miscTools.php
+++ b/src/includes/miscTools.php
@@ -178,7 +178,7 @@ function prior_parameters(string $parameter, array $list = []): array {
         return prior_parameters('', [...GROUP29, ...$list]);
     } else {
         bot_debug_log("prior_parameters missed: " . $parameter);
-        if (TRAVIS && $parameter !== 'not-a-param' && $parameter !== 's2cid1') {
+        if (CI && $parameter !== 'not-a-param' && $parameter !== 's2cid1') {
             return [];  // errors in test suite that were not expected
         }
         return $list;

--- a/src/includes/setup.php
+++ b/src/includes/setup.php
@@ -61,7 +61,7 @@ require_once __DIR__ . '/constants.php';
 ini_set("user_agent", BOT_USER_AGENT);
 include_once __DIR__ . '/../../vendor/autoload.php';
 
-define("TRAVIS", (bool) getenv('CI') || defined('__PHPUNIT_PHAR__') || defined('PHPUNIT_COMPOSER_INSTALL') || (mb_strpos((string) @$_SERVER['argv'][0], 'phpunit') !== false));
+define("CI", (bool) getenv('CI') || defined('__PHPUNIT_PHAR__') || defined('PHPUNIT_COMPOSER_INSTALL') || (mb_strpos((string) @$_SERVER['argv'][0], 'phpunit') !== false));
 
 define('TRUST_DOI_GOOD', true); // TODO - this a bit too trusting
 
@@ -69,7 +69,7 @@ if ((string) @$_REQUEST["page"] . (string) @$argv[1] === "User:AManWithNoPlan/sa
     define('EDIT_AS_USER', true);
 }
 
-if (TRAVIS || isset($argv)) {
+if (CI || isset($argv)) {
     define("HTML_OUTPUT", false);
 } else {
     define("HTML_OUTPUT", true);
@@ -82,7 +82,7 @@ if (mb_strpos((string) @$_SERVER['PHP_SELF'], '/gadgetapi.php') === false) {
     define("FLUSHING_OKAY", false);
 }
 
-if (isset($_REQUEST["slow"]) || TRAVIS || (isset($argv) && in_array('--slow', $argv, true))) {
+if (isset($_REQUEST["slow"]) || CI || (isset($argv) && in_array('--slow', $argv, true))) {
     define("SLOW_MODE", true);
 } else {
     define("SLOW_MODE", false);
@@ -202,7 +202,7 @@ if (isset($argv)) {
     define("MAX_PAGES", 2);
 }
 
-if (!TRAVIS) { // This is explicitly "tested" in test suite
+if (!CI) { // This is explicitly "tested" in test suite
     Zotero::create_ch_zotero();
     WikipediaBot::make_ch();
 }

--- a/src/includes/user_messages.php
+++ b/src/includes/user_messages.php
@@ -7,13 +7,13 @@ const BORING_STUFF = ["boring", "removed", "added", "changed", "subsubitem", "su
 require_once __DIR__ . '/constants.php';   // @codeCoverageIgnore
 
 function html_echo(string $text, string $alternate_text = ''): void {
-    if (!TRAVIS) {
+    if (!CI) {
         echo HTML_OUTPUT ? $text : $alternate_text; // @codeCoverageIgnore
     }
 }
 
 function user_notice(string $symbol, string $class, string $text): void {
-    if (!TRAVIS) {
+    if (!CI) {
         // @codeCoverageIgnoreStart
         if (defined('BIG_JOB_MODE') && in_array($class, BORING_STUFF, true)) {
             echo '.'; // Echo something to keep the code alive, but not so much to overfill the cache
@@ -65,7 +65,7 @@ function report_forget(string $text): void {
 }
 
 function report_inline(string $text): void {
-    if (!TRAVIS && defined('BIG_JOB_MODE')) {
+    if (!CI && defined('BIG_JOB_MODE')) {
         echo " ", $text;   // @codeCoverageIgnore
     }
 }
@@ -75,7 +75,7 @@ function report_inline(string $text): void {
  * @codeCoverageIgnore
  */
 function report_error(string $text): never {
-    if (TRAVIS) {
+    if (CI) {
         trigger_error($text);  // Stop this test now
     } elseif (function_exists('bot_debug_log')) {
         bot_debug_log($text);  // Code logfile, if defined
@@ -91,7 +91,7 @@ function report_error(string $text): never {
  * @codeCoverageIgnore
  */
 function report_minor_error(string $text): void {  // For things we want to error in tests, but continue on Wikipedia
-    if (!HTML_OUTPUT) { // command line and TRAVIS
+    if (!HTML_OUTPUT) { // command line and CI
         report_error($text);
     } else {
         bot_debug_log($text);
@@ -100,7 +100,7 @@ function report_minor_error(string $text): void {  // For things we want to erro
 }
 
 function quietly(callable $function, string $text): void { // Stuff suppressed when running on the command line
-    if (HTML_OUTPUT || TRAVIS) {
+    if (HTML_OUTPUT || CI) {
         $function($text);
     }
 }

--- a/tests/phpunit/includes/PageTest.php
+++ b/tests/phpunit/includes/PageTest.php
@@ -211,7 +211,7 @@ final class PageTest extends testBaseClass {
             $trialCitation = '{{Cite journal | title Bot Testing | doi_broken_date=1986-01-01 | doi = 10.1038/nature09068}}';
             $page->overwrite_text($trialCitation);
             $page_result = $page->write($api, "Testing bot write function");
-            if (TRAVIS && !$page_result) {
+            if (CI && !$page_result) {
                 // ! API call failed: '''Your IP address is in a range which has been blocked on all wikis.''' The block was made by [//meta.wikimedia.org/wiki/User:Jon_Kolbert Jon Kolbert] (meta.wikimedia.org). The reason given is ''[[m:NOP|Open Proxy]]: Colocation webhost - Contact [[m:Special:Contact/stewards|stewards]] if you are affected ''. * Start of block: 02:23, 27 October 2019 * Expiration of block: 02:23, 27 October 2021
                 $page->get_text_from($writeTestPage);
                 $this->assertSame($origText, $page->parsed_text());
@@ -220,7 +220,7 @@ final class PageTest extends testBaseClass {
                 $page->get_text_from($writeTestPage);
                 $this->assertSame($trialCitation, $page->parsed_text());
             }
-            $this->assertTrue(TRAVIS || $page_result); // If we have tokens and are not in TRAVIS, then should have worked
+            $this->assertTrue(CI || $page_result); // If we have tokens and are not in CI, then should have worked
             $page->overwrite_text($trialCitation);
             $page->expand_text();
             $this->assertTrue(mb_strpos($page->edit_summary(), 'journal, ') > 3);


### PR DESCRIPTION
Why
- this repo doesn't use Travis CI, so this is confusing

What
- rename `TRAVIS` constant to `CI` (continuous integration)