### PR TITLE
Fix test file naming inconsistency - rename templatePart2Test to TemplatePart2Test

### DIFF
--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../testBaseClass.php';
 
-final class templatePart2Test extends testBaseClass {
+final class TemplatePart2Test extends testBaseClass {
 
     public function testTidy1(): void {
         $text = '{{cite web|postscript = <!-- A comment only --> }}';


### PR DESCRIPTION

This pull request makes a minor update to the test suite by renaming the `templatePart2Test` class to `TemplatePart2Test` for consistency with naming conventions.