### PR TITLE
Remove ?slow=1 query parameter from architecture.svg

### DIFF
--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -368,7 +368,7 @@
          y="133.89502"
          id="tspan3-9">gadgetapi.php<tspan
    style="font-weight:normal"
-   id="tspan79">?slow=1,</tspan></tspan><tspan
+   id="tspan79">,</tspan></tspan><tspan
          sodipodi:role="line"
          style="stroke-width:0.264583"
          x="176.07576"


### PR DESCRIPTION
Remove ?slow=1 query parameter from architecture.svg since it has been removed from MediaWiki:Gadget-citations.js as well now