### PR TITLE
tests: refactor

### DIFF
--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1441,34 +1441,27 @@ final class TemplatePart1Test extends testBaseClass {
         $this->assertNull($prepared->get2('year'));
     }
 
-    public function testMalformedAccessDateWithHyphen(): void {
+    public function testAccessDateMalformedWithHyphen(): void {
         // Malformed parameter: access-date-2025-07-13 (missing equals sign)
         $text = '{{cite web |date=2025-05-01 |title=Test Title |url=https://example.com |access-date-2025-07-13 |website=example.com}}';
         $prepared = $this->prepare_citation($text);
         $access_date = $prepared->get2('access-date');
-        $this->assertNotNull($access_date, 'access-date should not be null');
-        $this->assertIsString($access_date);
-        $this->assertStringNotContainsString('-2025', (string)$access_date);
-        $this->assertStringContainsString('2025', (string)$access_date);
+        $this->assertSame('13 July 2025', $access_date);
     }
 
-    public function testProperlyFormattedAccessDate(): void {
+    public function testAccessDateProperlyFormatted(): void {
         // Properly formatted parameter should work correctly
         $text = '{{cite web |title=Test |url=https://example.com |access-date=2025-07-13}}';
         $prepared = $this->prepare_citation($text);
         $access_date = $prepared->get2('access-date');
-        $this->assertNotNull($access_date, 'access-date should be set');
-        $this->assertIsString($access_date);
-        $this->assertStringContainsString('2025', (string)$access_date);
-        $this->assertStringNotContainsString('-2025', (string)$access_date);
+        $this->assertSame('2025-07-13', $access_date);
     }
 
-    public function testMalformedParameterWithSpace(): void {
+    public function testDateMalformedWithSpace(): void {
         // Parameter with space separator instead of equals
         $text = '{{cite web |title=Test |url=https://example.com |date 2025-03-15}}';
         $prepared = $this->prepare_citation($text);
         $date = $prepared->get2('date');
-        // Verify date was parsed correctly
-        $this->assertTrue($date === null || str_contains((string)$date, '2025'));
+        $this->assertSame('15 March 2025', $date);
     }
 }


### PR DESCRIPTION
What
- rename tests
- greatly simplify assertions from 4 to 1. assertSame() checks type and value, so no need to check these things earlier in the test. probably a case of AI being too verbose

Notes
- not sure why 2 tests format their date as 13 July 2025, and 1 test formats its date as 2025-07-13. that might be a minor bug worth fixing in a follow up patch

related f18c419