### PR TITLE
add ?slow=1 ability back to API

### DIFF
--- a/src/gadgetapi.php
+++ b/src/gadgetapi.php
@@ -9,11 +9,6 @@ try {
     @header('Access-Control-Allow-Origin: *'); // Needed for gadget to work right
     @header('Content-Type: text/json');
 
-    // Force fast mode for gadget to prevent timeouts
-    // The gadget is designed for quick, in-browser citation expansion
-    // Slow mode operations (bibcode searches, URL expansions) can exceed the 120s timeout
-    unset($_GET['slow'], $_POST['slow'], $_REQUEST['slow']);
-
     //Set up tool requirements
     require_once __DIR__ . '/includes/setup.php';
 

--- a/tests/phpunit/gadgetapiTest.php
+++ b/tests/phpunit/gadgetapiTest.php
@@ -15,7 +15,7 @@ final class gadgetapiTest extends testBaseClass {
         ob_start();
         $_POST['text'] = '{{cite|pmid=34213}}';
         $_POST['summary'] = 'Something Nice';
-        // Note: gadgetapi.php always runs in fast mode to prevent timeouts
+        // Note: gadgetapi.php runs in fast mode by default to prevent timeouts
         require(__DIR__ . '/../../src/gadgetapi.php');
         $json_text = ob_get_contents();
         ob_end_clean();


### PR DESCRIPTION
Why
- as a developer, I want to be able to use a specially modified gadget that has ?slow=1 in the URL in order to trigger slow mode. this helps with manual testing. https://test.wikipedia.org/w/index.php?title=User:Novem_Linguae/Gadget-citations.js&diff=prev&oldid=720878
- I have removed ?slow=1 from the enwiki gadget URL, so for almost everyone else it will default to fast mode still. https://en.wikipedia.org/w/index.php?title=MediaWiki:Gadget-citations.js&diff=prev&oldid=1329736400

What
- allow gadgetapi.php to accept a ?slow=1 parameter again

Partial revert of #5211