### PR TITLE
final_tidy: remove title if dictionary and entry are set

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -628,7 +628,7 @@ final class Template
     }
 
     /**
-     * Adds a parameter to a template if the parameter and its equivalents are blank
+     * Adds a parameter to a template if the parameter and its equivalents are blank.
      * $api (string) specifies the API route by which a parameter was found; this will log the
      * parameter so it is not used to trigger a new search via the same API.
      */
@@ -5734,11 +5734,13 @@ final class Template
         }
     }
 
+    /**
+     * Should only be run once (perhaps when template is first loaded).
+     * Future tidying should occur when parameters are added using tidy_parameter.
+     * Called in final_tidy when the template type is changed.
+     * We do this again when anything changes - up to three times.
+     */
     public function tidy(): void {
-        // Should only be run once (perhaps when template is first loaded)
-        // Future tidying should occur when parameters are added using tidy_parameter.
-        // Called in final_tidy when the template type is changed
-        // We do this again when anything changes - up to three times
         $orig = $this->parsed_text();
         foreach ($this->param as $param) {
             $this->tidy_parameter($param->param);
@@ -6150,6 +6152,10 @@ final class Template
             }
             if ($this->get('url-status') === 'live' && $this->blank(['archive-url', 'archivedate', 'archiveurl', 'archived-date'])) {
                 $this->forget('url-status');
+            }
+            // If dictionary and entry are set, don't set a title.
+            if ($this->wikiname() === 'cite dictionary' && $this->get('dictionary') && $this->get('entry') && $this->get('title')) {
+                $this->forget('title');
             }
         } elseif (in_array($this->wikiname(), TEMPLATES_WE_SLIGHTLY_PROCESS, true)) {
             $this->tidy_parameter('publisher');

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1866,4 +1866,10 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertSame('X', $template->get2('work'));
     }
 
+    public function testRemoveTitleIfDictionaryAndEntryAreSet(): void {
+        $text = "{{cite dictionary|title=Supernatural &#124; Definition of Supernatural by Merriam-Webster|dictionary=Merriam-Webster|entry=supernatural}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('title'));
+    }
 }


### PR DESCRIPTION
- fixes https://en.wikipedia.org/wiki/User_talk:Citation_bot#Don't_add_title_when_entry_and_dictionary_are_already_set_(cite_dictionary)
- manually tested