### PR TITLE
Add 'international review of neurobiology' to constants

### DIFF
--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -13061,6 +13061,7 @@ const JOURNAL_IS_BOOK_SERIES = [
     'inorganic syntheses',
     'int rev cyt',
     'international review of cytology',
+    'international review of neurobiology',
     'international studies on childhood and adolescence',
     'lecture notes in computer science',
     'lecture notes in mathematics',


### PR DESCRIPTION
This pull request makes a small update to the list of journal names in the `bad_data.php` constants file by adding "international review of neurobiology". as requested on the bot talk page