### PR TITLE
increase test memory limits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     "scripts": {
         "coverage-report": "php -d memory_limit=1G vendor/bin/phpunit --enforce-time-limit --default-time-limit 13000 --coverage-html coverage",
         "phan": "php -d memory_limit=1G vendor/bin/phan --analyze-twice --allow-polyfill-parser",
-        "phpcbf": "phpcbf -p -d memory_limit=1000M --warning-severity=0",
-        "phpcs": "phpcs -p -s -d memory_limit=1000M --warning-severity=0",
+        "phpcbf": "phpcbf -p -d memory_limit=1G --warning-severity=0",
+        "phpcs": "phpcs -p -s -d memory_limit=1G --warning-severity=0",
         "phplint": "php -d memory_limit=1G vendor/bin/phplint --exclude=vendor --no-interaction -vv ./",
         "phpstan": "phpstan --no-interaction analyse --memory-limit=2G src/*.php src/*/*.php src/*/*/*.php",
         "progpilot": "php -d memory_limit=1G vendor/bin/progpilot --configuration progpilot.yml src/*.php src/*/*.php src/*/*/*.php tests/*.php tests/*/*.php tests/*/*/*.php",


### PR DESCRIPTION
Update all memory limits for test to 1G.

Recently on my fork after some large changes to the code one of the test kept failing. After some investigation it seems that the test itself ran out of available memory. Some of the test do not have memory flags set. This means that they will use the default limit of 128MB. With this pull all test will be set to a minimum of 1G. If test already had a higher limit they will stay at that limit. These changes will cost us nothing (default GitHub action runners have 7G available), prevent out of memory errors on test and will possibly (not investigated) improve test performance. Also aligned values of 1000M to 1G.