### PR TITLE
Add --show-info flag to psalm command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phplint": "php -d memory_limit=1G vendor/bin/phplint --exclude=vendor --no-interaction -vv ./",
         "phpstan": "phpstan --no-interaction analyse --memory-limit=2G src/*.php src/*/*.php src/*/*/*.php",
         "progpilot": "php -d memory_limit=1G vendor/bin/progpilot --configuration progpilot.yml src/*.php src/*/*.php src/*/*/*.php tests/*.php tests/*/*.php tests/*/*/*.php",
-        "psalm": "PSALM_ALLOW_XDEBUG=1 php ./vendor/bin/psalm --memory-limit=4G",
+        "psalm": "PSALM_ALLOW_XDEBUG=1 php ./vendor/bin/psalm --memory-limit=4G --show-info=true",
         "psalm-taint": "PSALM_ALLOW_XDEBUG=1 php ./vendor/bin/psalm --taint-analysis --memory-limit=4G",
         "test": "php -d memory_limit=1G vendor/bin/paratest --processes=auto --runner=WrapperRunner --enforce-time-limit --default-time-limit=60000 --cache-directory=.phpunit.cache --coverage-clover=coverage.xml --log-junit=junit.xml --verbose 1>&2; TEST_EXIT=$?; sync; sync; php -d memory_limit=1G tests/parse_junit.php; sync; exit $TEST_EXIT"
     }


### PR DESCRIPTION
There are over 500 psalm warnings. While not breaking like errors it is worth investigating them. Therefore we should first enable this to show them.