### PR TITLE
Add warnings for MathML and all-caps author names

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3627,12 +3627,10 @@ final class Template
 
                 case 'author':
                     $the_author = $this->get($param);
-
                     // Check for all-caps author names
                     if ($the_author && preg_match('/^[A-Z\s]{4,}$/', $the_author) && !preg_match('/^[IVX]+$/', $the_author)) {
                         report_warning("Author name is in all-caps and should be properly capitalized: " . echoable($the_author));
                     }
-
                     if ($this->blank('agency') && in_array(mb_strtolower($the_author), ['associated press', 'reuters'], true) && $this->wikiname() !== 'cite book') {
                         $this->rename('author' . $pmatch[2], 'agency');
                         if ($pmatch[2] === '1' || $pmatch[2] === '') {
@@ -3683,7 +3681,6 @@ final class Template
                             report_warning("Author last name is in all-caps and should be properly capitalized: " . echoable($the_last));
                         }
                     }
-
                     if (!$this->had_initial_author()) {
                         if ($pmatch[2]) {
                             $translator_regexp = "~\b([Tt]r(ans(lat...?(by)?)?)?\.?)\s([\w\p{L}\p{M}\s]+)$~u";
@@ -3823,7 +3820,6 @@ final class Template
                     if ($this->blank('date') && $this->has('year')) {
                         $this->forget('date');
                     }
-                    
                     if (preg_match('~^([A-Za-z]+)\-([A-Za-z]+ \d{4})$~', $this->get('date'), $matched)) {
                         $this->set('date', $matched[1] . '–' . $matched[2]);
                     }
@@ -4287,7 +4283,6 @@ final class Template
                     if ($this->blank('isbn')) {
                         return;
                     }
-                    
                     $this->set('isbn', safe_preg_replace('~\s?-\s?~', '-', $this->get('isbn'))); // a White space next to a dash
                     $this->set('isbn', $this->isbn10Toisbn13($this->get('isbn'), false));
                     if ($this->blank('journal') || $this->has('chapter') || $this->wikiname() === 'cite web') {
@@ -4336,7 +4331,6 @@ final class Template
                     if ($this->blank($param)) {
                         return;
                     }
-                    
                     if ($this->get($param) === 'Undefined' || $this->get($param) === 'Semantic Scholar' || $this->get($param) === '[[Semantic Scholar]]') {
                         $this->forget($param);
                         return;
@@ -5221,12 +5215,10 @@ final class Template
                         return;
                     }
                     $title = $this->get($param);
-
                     // Check for MathML
                     if (preg_match('~<(?:mml:)?m(?:sup|sub|subsup|frac|root|under|over|underover|row|i|n|o|text|multiscripts)[\s>]~', $title)) {
                         report_warning("Title contains MathML markup that should be converted to LaTeX: " . echoable(mb_substr($title, 0, 100)));
                     }
-
                     if (preg_match('~^(.+) # # # CITATION_BOT_PLACEHOLDER_TEMPLATE \d+ # # # Reuters(?:|\.com)$~i', $title, $matches)) {
                         if (mb_stripos($this->get('agency') . $this->get('work') . $this->get('website') . $this->get('newspaper') . $this->get('website') . $this->get('publisher'), 'reuters') !== false) {
                             $title = $matches[1];


### PR DESCRIPTION
## Add warnings for MathML and all-caps author names

This PR adds user warnings for problematic content that the Citation Bot skips when tidying existing parameters.

## Warnings Added

**1. MathML Markup**
- **Parameters:** title
- **Issue:** Content contains MathML tags
- **Why warn:** Bot converts MathML to LaTeX via `wikify_external_text()` only when adding new content, not in `tidy_parameter()`
- **Example:** `|title=Study of <msup>x<mn>2</mn></msup>` → warning issued
- **Detection:** Covers all MathML tags handled by MathTools: `mmultiscripts`, `msup`, `msub`, `msubsup`, `mfrac`, `mroot`, `munder`, `munderover`, plus element tags `mi`, `mn`, `mo`, `mrow`, `mtext`

**2. All-Caps Author Names**
- **Parameters:** author, last, surname
- **Issue:** Names are in all capital letters
- **Why warn:** Bot formats names via `format_author()` / `format_surname()` only when adding new authors, not in `tidy_parameter()`
- **Example:** `|author=JOHN SMITH` → warning issued (except for Roman numerals like `III`, `IV`)