### PR TITLE
move Novartis Foundation Symposia in bad data

### DIFF
--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -52,7 +52,6 @@ const HAS_NO_ISSUE = [
 const PREFER_VOLUMES = [
     'illinois classical studies',
     'novartis foundation symposia',
-
 ];
 
 const PREFER_ISSUES = [


### PR DESCRIPTION
We don't want to add issue for Novartis Foundation Symposia, it doesn't have issues, it only has volumes. But currently we somehow add issue, even if volume is already present as well. 

If I'm correct moving this here should fix that. (I probably places it wrong there first)

