### PR TITLE
Fix false 'Save to file failed' warning by using strlen() instead of …

### DIFF
--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -44,7 +44,7 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
                 $filename = preg_replace('~[\/\\:*?"<>|\s]~', '_', $page_title) . '.md';
                 report_phase("Saving to file " . echoable($filename));
                 $body = $page->parsed_text();
-                $bodylen = strlen($body);
+                $bodylen = mb_strlen($body, '8bit'); // byte count, not character count
                 if (file_put_contents($filename, $body) === $bodylen) {
                     report_phase("Saved to file " . echoable($filename));
                 } else {


### PR DESCRIPTION
- `file_put_contents()` returns the number of **bytes** written, but the code compared it against `mb_strlen()` which returns **character** count. For any article with multi-byte UTF-8 characters, bytes > characters, so the check always failed -- showing "Save to file failed" even though the file was saved correctly.
- Fix: use `strlen()` (byte count) instead of `mb_strlen()` (character count).


To ensure the issue is fixed, run `php process_page.php "Ketotifen" --slow --savetofiles` on an article with multi-byte characters and confirm the warning no longer appears.

The php code sniffer complaint to use mb_strlen() is invalid because we need to know number of bytes, not characters.

 The complaint is invalid because `file_put_contents()` returns the number of **bytes** written, not the number of characters. Using `mb_strlen()` would give you the character count, which wouldn't match for multibyte characters.

To fix this while satisfying the code sniffer, you have a few options:

**Option 1: Suppress the specific rule for this line**
```php
// phpcs:ignore Generic.PHP.ForbiddenFunctions.Found
$bodylen = strlen($body);
```

**Option 2: Compare the file_put_contents return value directly (but does not handle partial writes?)**
```php
if (file_put_contents($filename, $body) !== false) {
    report_phase("Saved to file " . echoable($filename));
} else {
    report_warning("Save to file failed.");
}
```

**Option 3: Add a comment explaining why strlen is needed**
```php
// strlen() is correct here - we need byte count to match file_put_contents() return value
// phpcs:ignore Generic.PHP.ForbiddenFunctions.Found
$bodylen = strlen($body);
```
