### PR TITLE
Comment and test name corrections

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -5692,7 +5692,7 @@ final class Template
                     }
                     if ($this->get($param) === 'n.d.') {
                         return;
-                    } // Special no-date code that citation template recognize.
+                    } // Special no-date code that the citation template recognizes.
                     // Issue should follow year with no break.  [A bit of redundant execution but simpler.]
                     // no break
                 case 'issue':

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -116,8 +116,8 @@ final class Zotero {
                 if ($template->has('citeseerx')) {
                     self::expand_by_zotero($template, ' https://citeseerx.ist.psu.edu/viewdoc/summary?doi=' . $template->get('citeseerx'));
                 }
-                //  Has a CAPCHA -- if ($template->has('jfm'))
-                //  Has a CAPCHA -- if ($template->has('zbl'))
+                //  Has a CAPTCHA -- if ($template->has('jfm'))
+                //  Has a CAPTCHA -- if ($template->has('zbl'))
                 //  Do NOT do MR -- it is a review not the article itself. Note that html does have doi, but do not use it.
                 if ($template->has('hdl')) {
                     self::expand_by_zotero($template, 'https://hdl.handle.net/' . $template->get('hdl'));

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1022,7 +1022,7 @@ final class TemplatePart1Test extends testBaseClass {
     }
 
     public function testId2Param5(): void {
-        $text = '{{cite book|pages=1–2|id={{arxiv|astr.ph|1234.5678}}}}{{cite book|pages=1–3|id={{arxiv|astr.ph|1234.5678}}}}'; // Two of the same sub-template, but in different tempalates
+        $text = '{{cite book|pages=1–2|id={{arxiv|astr.ph|1234.5678}}}}{{cite book|pages=1–3|id={{arxiv|astr.ph|1234.5678}}}}'; // Two of the same sub-template, but in different templates
         $expanded = $this->process_page($text);
         $this->assertSame('{{cite book|pages=1–2|arxiv=astr.ph/1234.5678 }}{{cite book|pages=1–3|arxiv=astr.ph/1234.5678 }}', $expanded->parsed_text());
     }

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../testBaseClass.php';
 
 final class TemplatePart3Test extends testBaseClass {
-    public function testND(): void {  // n.d. is special case that template recognize.  Must protect final period.
+    public function testND(): void {  // n.d. is special case that the template recognizes.  Must protect final period.
         $text = '{{Cite journal|date =n.d.}}';
         $expanded = $this->process_citation($text);
         $this->assertSame($text, $expanded->parsed_text());
@@ -675,7 +675,7 @@ EP - 999 }}';
         $this->assertNotNull($expanded->get2('accessdate'));
     }
 
-    public function testIgnoreUnkownCiteTemplates(): void {
+    public function testIgnoreUnknownCiteTemplates(): void {
         $text = "{{Cite imaginary source | http://google.com | title  I am a title | auhtor = Other, A. N. | issue- 9 | vol. 22 pp. 5-6|doi=10.0001/Rubbish_bot_failure_test }}";
         $expanded = $this->process_citation($text);
         $this->assertSame($text, $expanded->parsed_text());


### PR DESCRIPTION
This pull request makes minor improvements to code comments and test names for clarity and correctness. The changes are primarily focused on fixing typos and improving readability, without affecting functionality.

Comment and test name corrections:

* Fixed typos in comments to correctly state "the citation template recognizes" instead of "template recognize" in both `src/includes/Template.php` and `tests/phpunit/includes/TemplatePart3Test.php`. [[1]](diffhunk://#diff-5083c2986dc71cf3fd2d32433c35f9385d669a823734972e5893cac38c9e7011L5695-R5695) [[2]](diffhunk://#diff-d724184286d16e43b1c15e8931770e8e9d3bb2dca60128ff897469dc34accbc6L11-R11)
* Corrected spelling of "CAPTCHA" in comments within `src/includes/api/APIzotero.php`.
* Fixed typo in a test comment, changing "tempalates" to "templates" in `tests/phpunit/includes/TemplatePart1Test.php`.
* Renamed test method from `testIgnoreUnkownCiteTemplates` to `testIgnoreUnknownCiteTemplates` in `tests/phpunit/includes/TemplatePart3Test.php`.