### PR TITLE
Fix PHPStan and Phan static analysis failures 

### DIFF
--- a/src/includes/api/APIBibCode.php
+++ b/src/includes/api/APIBibCode.php
@@ -524,7 +524,7 @@ function Bibcode_Response_Processing(array $curl_opts, string $adsabs_url): obje
             $retry_msg = '';                                                  // @codeCoverageIgnoreStart
             $time_to_sleep = null;
             $limit_action = null;
-            if (is_int($ratelimit_total) && is_int($ratelimit_left) && is_int($ratelimit_current) && ($ratelimit_left <= 0) && ($ratelimit_current >= $ratelimit_total) && preg_match('~\nretry-after:\s*(\d+)\r~i', $header, $retry_after)) {
+            if (is_int($ratelimit_total) && ($ratelimit_left <= 0) && ($ratelimit_current >= $ratelimit_total) && preg_match('~\nretry-after:\s*(\d+)\r~i', $header, $retry_after)) {
                 // AdsAbs limit reached: proceed according to the action configured in PHP_ADSABSAPILIMITACTION;
                 // available actions are: sleep, exit, ignore (default).
                 $rai = intval($retry_after[1]);

--- a/src/includes/api/APIdoi.php
+++ b/src/includes/api/APIdoi.php
@@ -307,7 +307,7 @@ function expand_doi_with_dx(Template $template, string $doi): void {
     }
     $json = @json_decode($data, true);
     unset($data);
-    if ($json === false || $json === null) {
+    if (!is_array($json)) {
         return;
     }
     process_doi_json($template, $doi, $json);

--- a/src/linked_pages.php
+++ b/src/linked_pages.php
@@ -48,7 +48,7 @@ if ($json === '') {
 }
 $array = json_decode($json, true);
 unset($json);
-if ($array === false || !isset($array['parse']['links']) || !is_array($array['parse']['links'])) {
+if (!is_array($array) || !isset($array['parse']['links']) || !is_array($array['parse']['links'])) {
     report_warning(' Error interpreting page list - perhaps page requested does not even exist');
     bot_html_footer();
     exit(0);


### PR DESCRIPTION
Three static analysis errors introduced in recent commits: one PHPStan `function.alreadyNarrowedType` and two Phan `PhanTypeComparisonFromArray` violations.

## Changes

- **`APIBibCode.php:527`** — Remove redundant `is_int($ratelimit_left) && is_int($ratelimit_current)` guards. After `is_int($ratelimit_total)` passes, PHPStan's flow analysis narrows all three variables to `int` (they're assigned together in the same branch), making the subsequent checks always-true.

- **`APIdoi.php:310`** / **`linked_pages.php:51`** — Replace `=== false` comparisons on `json_decode(..., true)` results. In PHP 8+, associative `json_decode` returns `array|null`, never `false`; Phan correctly flags the array-to-false comparison.

```php
// Before
if ($json === false || $json === null) { return; }

// After
if (!is_array($json)) { return; }
```