### PR TITLE
Disregard - 10.1140/epjc is not actually always free

### DIFF
--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -13496,7 +13496,6 @@ const DOI_FREE_PREFIX = [
     '10.1128/msystems',
     '10.1128/spectrum',
     '10.1136/bmjopen',
-    '10.1140/epjc',
     '10.11569/',
     '10.11646/megataxa',
     '10.11646/mesozoic',


### PR DESCRIPTION
Removed '10.1140/epjc' from the bad data constants free doi list. 

Only after 2014 is free. Automatic tagging based on dates has been requested but not implemented yet. Therefore remove this one for now
