### PR TITLE
Update DOI from '10.1140/epjc' to '10.1140/epjconf'

### DIFF
--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -13496,7 +13496,7 @@ const DOI_FREE_PREFIX = [
     '10.1128/msystems',
     '10.1128/spectrum',
     '10.1136/bmjopen',
-    '10.1140/epjc',
+    '10.1140/epjconf',
     '10.11569/',
     '10.11646/megataxa',
     '10.11646/mesozoic',


### PR DESCRIPTION
more restrictive

/epjc only free after 2014. tagging on date requested but not implemented yet.