### PR TITLE
Fix PHPStan CI failure: suppress `identical.alwaysFalse` in `doiTools.php`

### DIFF
--- a/src/includes/doiTools.php
+++ b/src/includes/doiTools.php
@@ -268,6 +268,7 @@ function is_doi_works(string $doi): ?bool {
     // Got 404 - try again, since we cache this and add doi-broken-date to pages, we should be double sure
     $headers_test = get_headers_array($url);
     /** We trust previous failure, so fail and null are both false */
+    /** @phpstan-ignore identical.alwaysFalse */
     if ($headers_test === false) {
         return false;
     }


### PR DESCRIPTION
PHPStan 2.1.45 (released 2026-03-30, between two CI runs on the same commit) now infers that `get_headers_array()` never returns `false` — because `report_error()` is typed `never` and updated stubs for PHP's `get_headers()` no longer include `false`. This causes a spurious `identical.alwaysFalse` error on the defensive network-failure guard in `is_doi_works()`.

## Change

Added `@phpstan-ignore identical.alwaysFalse` to suppress the false positive on the `=== false` guard after the retry call to `get_headers_array()`:

```php
$headers_test = get_headers_array($url);
/** We trust previous failure, so fail and null are both false */
/** @phpstan-ignore identical.alwaysFalse */
if ($headers_test === false) {
    return false;
}
```

Consistent with existing suppressions in the codebase (`Template.php:7275`, `TextTools.php:431`, `APIgoogle.php:263`). The runtime guard itself is kept — `get_headers()` can legitimately return `false` on network failure regardless of what static analysis infers.