### PR TITLE
Fix first/last name swap for digital.library.unt.edu URLs

### DIFF
--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -452,6 +452,29 @@ final class Zotero {
             unset($result->creators);
             unset($result->author); // EATCS Joomla CMS records the posting admin as "author", not a content creator
         }
+        if (mb_stripos($url, 'digital.library.unt.edu') !== false) {
+            // UNT Digital Library metadata lists names in "Family, Given" order but Zotero
+            // misparses them, placing the family name in firstName and the given name in lastName
+            if (isset($result->creators) && is_array($result->creators)) {
+                foreach ($result->creators as $i => $creator) {
+                    if (isset($creator->firstName) && isset($creator->lastName) &&
+                        (string) $creator->firstName !== '' && (string) $creator->lastName !== '') {
+                        $temp_first = (string) $creator->firstName;
+                        $result->creators[$i]->firstName = $creator->lastName;
+                        $result->creators[$i]->lastName = $temp_first;
+                    }
+                }
+            }
+            if (isset($result->author) && is_array($result->author)) {
+                foreach ($result->author as $i => $auth) {
+                    if (is_array($auth) && isset($auth[0]) && isset($auth[1]) &&
+                        (string) $auth[0] !== '' && (string) $auth[1] !== '') {
+                        $result->author[$i][0] = (string) $auth[1];
+                        $result->author[$i][1] = (string) $auth[0];
+                    }
+                }
+            }
+        }
         if (mb_stripos((string) @$result->publicationTitle, 'Extended Abstracts') !== false) { // https://research.vu.nl/en/publications/5a946ccf-5f5b-4cab-b47e-824508c4d709
             unset($result->publicationTitle);
         }

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -453,8 +453,7 @@ final class Zotero {
             unset($result->author); // EATCS Joomla CMS records the posting admin as "author", not a content creator
         }
         if (mb_stripos($url, 'digital.library.unt.edu') !== false) {
-            // UNT Digital Library metadata lists names in "Family, Given" order but Zotero
-            // misparses them, placing the family name in firstName and the given name in lastName
+            // UNT Digital Library: Zotero swaps firstName/lastName due to "Family, Given" catalog format
             if (isset($result->creators) && is_array($result->creators)) {
                 foreach ($result->creators as $i => $creator) {
                     if (isset($creator->firstName) && isset($creator->lastName) &&

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1478,18 +1478,13 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryAuthorNameSwap(): void {
-        // UNT Digital Library metadata provides names in "Family, Given" order but Zotero
-        // misparses them, placing the family name in firstName and the given name in lastName.
-        // See https://digital.library.unt.edu/ark:/67531/metadc19815/m1/ (John Gilliland)
-        // The bot must swap them so first1=John and last1=Gilliland, not first1=Gilliland and last1=John.
-
-        // Test via the author array path (webpage/document itemType)
+        // UNT Digital Library: Zotero swaps firstName/lastName; bot must correct it (author array path)
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|id=}}';
         $template = $this->make_citation($text);
         $access_date = 0;
         $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
         $author = [];
-        $author[0] = [0 => 'Gilliland', 1 => 'John']; // Simulating Zotero's misparsed output: family name in [0] (should be in [1]), given name in [1] (should be in [0])
+        $author[0] = [0 => 'Gilliland', 1 => 'John']; // Zotero misparsed: family name in [0], given in [1]
         $zotero_data = [];
         $zotero_data[0] = (object) ['title' => 'History of Rock', 'itemType' => 'webpage', 'author' => $author];
         $zotero_response = json_encode($zotero_data);
@@ -1499,15 +1494,13 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryAuthorNameSwapViaCreators(): void {
-        // UNT Digital Library metadata provides names in "Family, Given" order but Zotero
-        // misparses them, placing the family name in firstName and the given name in lastName.
-        // Test via the creators array path (report/thesis itemType)
+        // UNT Digital Library: Zotero swaps firstName/lastName; bot must correct it (creators path)
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|id=}}';
         $template = $this->make_citation($text);
         $access_date = 0;
         $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
         $creators = [];
-        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland', 'lastName' => 'John']; // Simulating Zotero's misparsed output: family name in firstName (should be lastName), given name in lastName (should be firstName)
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland', 'lastName' => 'John']; // Zotero misparsed: family name in firstName, given in lastName
         $zotero_data = [];
         $zotero_data[0] = (object) ['title' => 'History of Rock', 'itemType' => 'report', 'creators' => $creators];
         $zotero_response = json_encode($zotero_data);

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1476,4 +1476,43 @@ final class zoteroTest extends testBaseClass {
         Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
         $this->assertNull($template->get2('work'));
     }
+
+    public function testUntDigitalLibraryAuthorNameSwap(): void {
+        // UNT Digital Library metadata provides names in "Family, Given" order but Zotero
+        // misparses them, placing the family name in firstName and the given name in lastName.
+        // See https://digital.library.unt.edu/ark:/67531/metadc19815/m1/ (John Gilliland)
+        // The bot must swap them so first1=John and last1=Gilliland, not first1=Gilliland and last1=John.
+
+        // Test via the author array path (webpage/document itemType)
+        $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|id=}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
+        $author = [];
+        $author[0] = [0 => 'Gilliland', 1 => 'John']; // Simulating Zotero's misparsed output: family name in [0] (should be in [1]), given name in [1] (should be in [0])
+        $zotero_data = [];
+        $zotero_data[0] = (object) ['title' => 'History of Rock', 'itemType' => 'webpage', 'author' => $author];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertSame('Gilliland', $template->get2('last1'));
+        $this->assertSame('John', $template->get2('first1'));
+    }
+
+    public function testUntDigitalLibraryAuthorNameSwapViaCreators(): void {
+        // UNT Digital Library metadata provides names in "Family, Given" order but Zotero
+        // misparses them, placing the family name in firstName and the given name in lastName.
+        // Test via the creators array path (report/thesis itemType)
+        $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|id=}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
+        $creators = [];
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland', 'lastName' => 'John']; // Simulating Zotero's misparsed output: family name in firstName (should be lastName), given name in lastName (should be firstName)
+        $zotero_data = [];
+        $zotero_data[0] = (object) ['title' => 'History of Rock', 'itemType' => 'report', 'creators' => $creators];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertSame('Gilliland', $template->get2('last1'));
+        $this->assertSame('John', $template->get2('first1'));
+    }
 }


### PR DESCRIPTION
This pull request improves handling of author name parsing for citations imported from the UNT Digital Library, addressing a specific issue where Zotero misassigns first and last names due to the library's catalog format.

Bug fix for author name parsing:

* Updated `process_zotero_response` in `APIzotero.php` to detect UNT Digital Library URLs and swap `firstName` and `lastName` fields in both the `creators` and `author` arrays, correcting misparsed names from Zotero imports.

Test coverage improvements:

* Added `testUntDigitalLibraryAuthorNameSwap` and `testUntDigitalLibraryAuthorNameSwapViaCreators` to `zoteroTest.php` to verify that author names are correctly parsed and swapped for UNT Digital Library citations, covering both the `author` array and `creators` object paths.