### PR TITLE
Fix UNT Digital Library authors silently dropped for non-journal itemTypes

### DIFF
--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -473,7 +473,7 @@ final class Zotero {
                     }
                 }
             }
-            // Copy swapped creators to author array so the general loop picks them up for all itemTypes.
+            // UNT only: copy swapped creators to author array for non-journal itemTypes (e.g. webpage) where $result->author is not populated.
             if (isset($result->creators) && is_array($result->creators) && empty($result->author)) {
                 foreach ($result->creators as $creator) {
                     if (isset($creator->creatorType) && (string) $creator->creatorType === 'author' &&

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -473,6 +473,22 @@ final class Zotero {
                     }
                 }
             }
+            // Creators are only processed for specific itemTypes (journalArticle, report, etc.).
+            // For 'webpage', 'audioRecording', 'radioBroadcast', and other types, they are skipped.
+            // Copy swapped creators to the author array (after the author-swap block above) so the
+            // general author loop (which runs for all itemTypes) picks them up in the correct order.
+            if (isset($result->creators) && is_array($result->creators) && empty($result->author)) {
+                $result->author = [];
+                foreach ($result->creators as $creator) {
+                    if (isset($creator->creatorType) && (string) $creator->creatorType === 'author' &&
+                        isset($creator->firstName) && isset($creator->lastName)) {
+                        $result->author[] = [(string) $creator->firstName, (string) $creator->lastName];
+                    }
+                }
+                if (empty($result->author)) {
+                    unset($result->author);
+                }
+            }
         }
         if (mb_stripos((string) @$result->publicationTitle, 'Extended Abstracts') !== false) { // https://research.vu.nl/en/publications/5a946ccf-5f5b-4cab-b47e-824508c4d709
             unset($result->publicationTitle);

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -478,7 +478,6 @@ final class Zotero {
             // Copy swapped creators to the author array (after the author-swap block above) so the
             // general author loop (which runs for all itemTypes) picks them up in the correct order.
             if (isset($result->creators) && is_array($result->creators) && empty($result->author)) {
-                $result->author = [];
                 foreach ($result->creators as $creator) {
                     if (isset($creator->creatorType) && (string) $creator->creatorType === 'author' &&
                         isset($creator->firstName) && isset($creator->lastName)) {

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -473,10 +473,7 @@ final class Zotero {
                     }
                 }
             }
-            // Creators are only processed for specific itemTypes (journalArticle, report, etc.).
-            // For 'webpage', 'audioRecording', 'radioBroadcast', and other types, they are skipped.
-            // Copy swapped creators to the author array (after the author-swap block above) so the
-            // general author loop (which runs for all itemTypes) picks them up in the correct order.
+            // Copy swapped creators to author array so the general loop picks them up for all itemTypes.
             if (isset($result->creators) && is_array($result->creators) && empty($result->author)) {
                 foreach ($result->creators as $creator) {
                     if (isset($creator->creatorType) && (string) $creator->creatorType === 'author' &&

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1478,13 +1478,13 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryAuthorNameSwap(): void {
-        // UNT: bot swaps Zotero's reversed firstName/lastName (author array path)
+        // UNT reversed firstName/lastName is swapped back (author array path)
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|id=}}';
         $template = $this->make_citation($text);
         $access_date = 0;
         $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
         $author = [];
-        $author[0] = [0 => 'Gilliland', 1 => 'John']; // family in [0], given in [1]
+        $author[0] = [0 => 'Gilliland', 1 => 'John']; // reversed: family in [0]
         $zotero_data = [];
         $zotero_data[0] = (object) ['title' => 'History of Rock', 'itemType' => 'webpage', 'author' => $author];
         $zotero_response = json_encode($zotero_data);
@@ -1494,13 +1494,13 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryAuthorNameSwapWithTrailingComma(): void {
-        // UNT: trailing comma from "Family, Given" catalog format is stripped after swap (author array path)
+        // UNT trailing comma in the family-name slot is stripped after swap (author array path)
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|id=}}';
         $template = $this->make_citation($text);
         $access_date = 0;
         $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
         $author = [];
-        $author[0] = [0 => 'Gilliland,', 1 => 'John']; // trailing comma in family-name slot
+        $author[0] = [0 => 'Gilliland,', 1 => 'John']; // trailing comma
         $zotero_data = [];
         $zotero_data[0] = (object) ['title' => 'History of Rock', 'itemType' => 'webpage', 'author' => $author];
         $zotero_response = json_encode($zotero_data);
@@ -1510,13 +1510,13 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryAuthorNameSwapViaCreators(): void {
-        // UNT: bot swaps Zotero's reversed firstName/lastName (creators path)
+        // UNT reversed firstName/lastName is swapped back (creators path)
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|id=}}';
         $template = $this->make_citation($text);
         $access_date = 0;
         $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
         $creators = [];
-        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland', 'lastName' => 'John']; // family in firstName, given in lastName
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland', 'lastName' => 'John']; // reversed: family in firstName
         $zotero_data = [];
         $zotero_data[0] = (object) ['title' => 'History of Rock', 'itemType' => 'report', 'creators' => $creators];
         $zotero_response = json_encode($zotero_data);
@@ -1526,13 +1526,13 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryAuthorNameSwapViaCreatorsWithTrailingComma(): void {
-        // UNT: trailing comma from "Family, Given" catalog format is stripped after swap (creators path)
+        // UNT trailing comma in firstName is stripped after swap (creators path)
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|publisher=Digital.library.unt.edu|id=}}';
         $template = $this->make_citation($text);
         $access_date = 0;
         $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
         $creators = [];
-        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland,', 'lastName' => 'John']; // actual Zotero output
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland,', 'lastName' => 'John']; // trailing comma
         $zotero_data = [];
         $zotero_data[0] = (object) ['title' => 'History of Rock', 'itemType' => 'journalArticle', 'creators' => $creators];
         $zotero_response = json_encode($zotero_data);
@@ -1542,14 +1542,13 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryAuthorAddedForWebpageItemType(): void {
-        // UNT: Citoid returns itemType='webpage' with creators; creators must still be added as authors.
-        // Regression test for bug where creators were silently ignored for non-journal itemTypes.
+        // UNT creators must be added even when itemType='webpage'
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|title=Show 47 - Sergeant Pepper at the Summit|publisher=Digital.library.unt.edu|access-date=2014-02-02}}';
         $template = $this->make_citation($text);
         $access_date = 0;
         $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
         $creators = [];
-        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland,', 'lastName' => 'John']; // actual Zotero output
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland,', 'lastName' => 'John']; // trailing comma
         $zotero_data = [];
         $zotero_data[0] = (object) ['title' => 'Show 47 - Sergeant Pepper at the Summit', 'itemType' => 'webpage', 'creators' => $creators];
         $zotero_response = json_encode($zotero_data);
@@ -1559,7 +1558,7 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryMultipleAuthorsForWebpageItemType(): void {
-        // UNT: multiple creators of type 'author' are all added in order for itemType='webpage'.
+        // UNT multiple creators are all added in order for itemType='webpage'
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|publisher=Digital.library.unt.edu|id=}}';
         $template = $this->make_citation($text);
         $access_date = 0;

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1540,4 +1540,21 @@ final class zoteroTest extends testBaseClass {
         $this->assertSame('Gilliland', $template->get2('last1'));
         $this->assertSame('John', $template->get2('first1'));
     }
+
+    public function testUntDigitalLibraryAuthorAddedForWebpageItemType(): void {
+        // UNT: Citoid returns itemType='webpage' with creators; creators must still be added as authors.
+        // Regression test for bug where creators were silently ignored for non-journal itemTypes.
+        $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|title=Show 47 - Sergeant Pepper at the Summit|publisher=Digital.library.unt.edu|access-date=2014-02-02}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
+        $creators = [];
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland,', 'lastName' => 'John']; // actual Zotero output
+        $zotero_data = [];
+        $zotero_data[0] = (object) ['title' => 'Show 47 - Sergeant Pepper at the Summit', 'itemType' => 'webpage', 'creators' => $creators];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertSame('Gilliland', $template->get2('last1'));
+        $this->assertSame('John', $template->get2('first1'));
+    }
 }

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1557,4 +1557,23 @@ final class zoteroTest extends testBaseClass {
         $this->assertSame('Gilliland', $template->get2('last1'));
         $this->assertSame('John', $template->get2('first1'));
     }
+
+    public function testUntDigitalLibraryMultipleAuthorsForWebpageItemType(): void {
+        // UNT: multiple creators of type 'author' are all added in order for itemType='webpage'.
+        $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|publisher=Digital.library.unt.edu|id=}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
+        $creators = [];
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Smith,', 'lastName' => 'Alice'];
+        $creators[1] = (object) ['creatorType' => 'author', 'firstName' => 'Jones,', 'lastName' => 'Bob'];
+        $zotero_data = [];
+        $zotero_data[0] = (object) ['title' => 'Test Article', 'itemType' => 'webpage', 'creators' => $creators];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertSame('Smith', $template->get2('last1'));
+        $this->assertSame('Alice', $template->get2('first1'));
+        $this->assertSame('Jones', $template->get2('last2'));
+        $this->assertSame('Bob', $template->get2('first2'));
+    }
 }


### PR DESCRIPTION

**Enhancements to author extraction logic:**

* Updated `process_zotero_response` in `APIzotero.php` to populate the `author` array from the `creators` array for non-journal item types when `author` is missing, ensuring authors are captured correctly for sources like webpages. specific to UNT Digital Library only.

**Expanded and clarified test coverage:**

* Added new tests to `zoteroTest.php` to verify that authors from the UNT Digital Library are correctly extracted and ordered for `webpage` item types, including support for multiple authors.
* Improved test descriptions and comments for clarity regarding the handling of reversed names and trailing commas in both `author` and `creators` paths. 