### PR TITLE
Add 4-part OCLC proxy domain pattern for ccTLD Wikipedia Library URLs

### DIFF
--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -1129,7 +1129,10 @@ function clean_existing_urls_INSIDE(Template $template, string $param): void {
     // idm.oclc.org Proxy
     if (mb_stripos($template->get($param), 'idm.oclc.org') !== false && mb_stripos($template->get($param), 'ancestryinstitution') === false) {
         $oclc_found = false;
-        if (preg_match("~^https://([^\.\-\/]+)-([^\.\-\/]+)-([^\.\-\/]+)\.[^\.\-\/]+\.idm\.oclc\.org/(.+)$~i", $template->get($param), $matches)) {
+        if (preg_match("~^https://([^\.\-\/]+)-([^\.\-\/]+)-([^\.\-\/]+)-([^\.\-\/]+)\.[^\.\-\/]+\.idm\.oclc\.org/(.+)$~i", $template->get($param), $matches)) {
+            $template->set($param, 'https://' . $matches[1] . '.' . $matches[2] . '.' . $matches[3] . '.' . $matches[4] . '/' . $matches[5]);
+            $oclc_found = true;
+        } elseif (preg_match("~^https://([^\.\-\/]+)-([^\.\-\/]+)-([^\.\-\/]+)\.[^\.\-\/]+\.idm\.oclc\.org/(.+)$~i", $template->get($param), $matches)) {
             $template->set($param, 'https://' . $matches[1] . '.' . $matches[2] . '.' . $matches[3] . '/' . $matches[4]);
             $oclc_found = true;
         } elseif (preg_match("~^https://([^\.\-\/]+)\.([^\.\-\/]+)\.com.[^\.\-\/]+\.idm\.oclc\.org/(.+)$~i", $template->get($param), $matches)) {

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -804,6 +804,14 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('isbn'));
     }
 
+    public function testTidy90(): void {
+        $text = "{{cite web|url=https://www-haaretz-co-il.wikipedialibrary.idm.oclc.org/gallery/2010-06-28/ty-article/0000017f-f85f-d47e-a37f-f97fac920000 |via = wiki stuff }}";
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('url');
+        $this->assertSame('https://www.haaretz.co.il/gallery/2010-06-28/ty-article/0000017f-f85f-d47e-a37f-f97fac920000', $template->get2('url'));
+        $this->assertNull($template->get2('via'));
+    }
+
     public function testIncomplete1a(): void {
         $text = "{{cite book|url=http://perma-archives.org/pqd1234|isbn=Xxxx|title=xxx|issue=a|volume=x}}"; // Non-date website
         $template = $this->make_citation($text);


### PR DESCRIPTION
Wikipedia Library OCLC proxy URLs encode the original domain by replacing dots with hyphens in the subdomain (e.g. `www.haaretz.co.il` → `www-haaretz-co-il.wikipedialibrary.idm.oclc.org`). The existing patterns only reversed 2- and 3-segment subdomains, so 4-segment ccTLD domains were never de-proxied — leaving Zotero to scrape the proxy login page and return `title=The Wikipedia Library` instead of the actual article title.

## Changes

- **`src/includes/URLtools.php`** — Adds a new 4-capture-group pattern as the first branch in the OCLC `if/elseif` chain, converting e.g.:
  ```
  https://www-haaretz-co-il.wikipedialibrary.idm.oclc.org/gallery/…
  → https://www.haaretz.co.il/gallery/…
  ```
  Covers all ccTLD variants proxied through Wikipedia Library: `.co.il`, `.co.uk`, `.com.au`, `.org.uk`, `.ac.uk`, etc.

- **`tests/phpunit/includes/templatePart4Test.php`** — Adds `testTidy90` covering the exact Haaretz URL from the bug report, including verification that `via=wiki stuff` is cleared.