### PR TITLE
Fix UNT Digital Library author silently dropped by date-change early return

### DIFF
--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -777,8 +777,14 @@ final class Zotero {
         if (isset($result->ISBN)) {
             $template->add_if_new('isbn', $result->ISBN);
         }
-        if ($access_date && isset($result->date) && mb_stripos($url, 'digital.library.unt.edu') === false) {
-            // UNT is a permanent archive; its date reflects the original document, not a content change.
+        $is_permanent_archive = false;
+        foreach (PERMANENT_ARCHIVE_DOMAINS as $permanent_archive) {
+            if (mb_stripos($url, $permanent_archive) !== false) {
+                $is_permanent_archive = true;
+                break;
+            }
+        }
+        if ($access_date && isset($result->date) && !$is_permanent_archive) {
             $new_date = strtotime(tidy_date((string) $result->date)); // One time got an integer
             if ($new_date) { // can compare
                 if ($new_date > $access_date) {

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -778,8 +778,7 @@ final class Zotero {
             $template->add_if_new('isbn', $result->ISBN);
         }
         if ($access_date && isset($result->date) && mb_stripos($url, 'digital.library.unt.edu') === false) {
-            // UNT Digital Library is a permanent archive; its metadata date reflects the original document date,
-            // not a page-content change, so the date-change gate must not block author extraction there.
+            // UNT is a permanent archive; its date reflects the original document, not a content change.
             $new_date = strtotime(tidy_date((string) $result->date)); // One time got an integer
             if ($new_date) { // can compare
                 if ($new_date > $access_date) {

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -777,7 +777,9 @@ final class Zotero {
         if (isset($result->ISBN)) {
             $template->add_if_new('isbn', $result->ISBN);
         }
-        if ($access_date && isset($result->date)) {
+        if ($access_date && isset($result->date) && mb_stripos($url, 'digital.library.unt.edu') === false) {
+            // UNT Digital Library is a permanent archive; its metadata date reflects the original document date,
+            // not a page-content change, so the date-change gate must not block author extraction there.
             $new_date = strtotime(tidy_date((string) $result->date)); // One time got an integer
             if ($new_date) { // can compare
                 if ($new_date > $access_date) {

--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -1195,6 +1195,12 @@ const NO_DATE_WEBSITES = [
     'thepracticalleader.com',
 ];
 
+// Permanent archives whose Zotero-returned date reflects the original document, not a page-content
+// change, so the date-change guard must not apply to them.
+const PERMANENT_ARCHIVE_DOMAINS = [
+    'digital.library.unt.edu',
+];
+
 const ZOTERO_AVOID_REGEX = [
     'ftp\.unicode\.org', // Zotero goes insane on titles
     'arkive\.org',

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1575,4 +1575,29 @@ final class zoteroTest extends testBaseClass {
         $this->assertSame('Jones', $template->get2('last2'));
         $this->assertSame('Bob', $template->get2('first2'));
     }
+
+    public function testUntDigitalLibraryAuthorNotBlockedByDateChangeEarlyReturn(): void {
+        // Regression: when $access_date is non-zero (real bot usage) and the Zotero response
+        // contains a 'date' field newer than the citation's access-date, the generic date-change
+        // guard returned early BEFORE the author processing loop, silently dropping the author.
+        // UNT Digital Library is a permanent archive; its date reflects the original document,
+        // not a page-content change, so the guard must not apply.
+        $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|title=Show 47 - Sergeant Pepper at the Summit|publisher=Digital.library.unt.edu|access-date=2014-02-02}}';
+        $template = $this->make_citation($text);
+        $access_date = (int) strtotime('2014-02-02'); // Non-zero: real bot sets this from the citation
+        $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
+        $creators = [];
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland,', 'lastName' => 'John']; // UNT catalog "Family, Given": family in firstName, trailing comma; the swap corrects this
+        $zotero_data = [];
+        $zotero_data[0] = (object) [
+            'title' => 'Show 47 - Sergeant Pepper at the Summit',
+            'itemType' => 'webpage',
+            'creators' => $creators,
+            'date' => '2024-01-01', // Newer than access-date: would trigger early return without the fix
+        ];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertSame('Gilliland', $template->get2('last1'));
+        $this->assertSame('John', $template->get2('first1'));
+    }
 }

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1577,23 +1577,20 @@ final class zoteroTest extends testBaseClass {
     }
 
     public function testUntDigitalLibraryAuthorNotBlockedByDateChangeEarlyReturn(): void {
-        // Regression: when $access_date is non-zero (real bot usage) and the Zotero response
-        // contains a 'date' field newer than the citation's access-date, the generic date-change
-        // guard returned early BEFORE the author processing loop, silently dropping the author.
-        // UNT Digital Library is a permanent archive; its date reflects the original document,
-        // not a page-content change, so the guard must not apply.
+        // Regression: non-zero $access_date + Zotero date newer than access-date triggered an early
+        // return before the author loop. UNT is a permanent archive; the guard must not apply there.
         $text = '{{cite web|url=https://digital.library.unt.edu/ark:/67531/metadc19815/m1/|title=Show 47 - Sergeant Pepper at the Summit|publisher=Digital.library.unt.edu|access-date=2014-02-02}}';
         $template = $this->make_citation($text);
-        $access_date = (int) strtotime('2014-02-02'); // Non-zero: real bot sets this from the citation
+        $access_date = (int) strtotime('2014-02-02'); // Non-zero: real bot usage
         $url = 'https://digital.library.unt.edu/ark:/67531/metadc19815/m1/';
         $creators = [];
-        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland,', 'lastName' => 'John']; // UNT catalog "Family, Given": family in firstName, trailing comma; the swap corrects this
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => 'Gilliland,', 'lastName' => 'John']; // UNT "Family, Given" format; swap corrects firstName/lastName
         $zotero_data = [];
         $zotero_data[0] = (object) [
             'title' => 'Show 47 - Sergeant Pepper at the Summit',
             'itemType' => 'webpage',
             'creators' => $creators,
-            'date' => '2024-01-01', // Newer than access-date: would trigger early return without the fix
+            'date' => '2024-01-01', // Newer than access-date: triggers early return without the fix
         ];
         $zotero_response = json_encode($zotero_data);
         Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);


### PR DESCRIPTION
All three prior fix PRs (#5516, #5517, #5520) correctly handled the UNT name-swap and creator-to-author copy logic, but every test used `$access_date = 0`, which bypasses a critical guard in `process_zotero_response`:

```php
// APIzotero.php:780
if ($access_date && isset($result->date)) {
    if ($new_date > $access_date) {
        return;  // fires BEFORE author processing loop at line 957
    }
}
```

In production, `expand_by_zotero` sets `$access_date` from the citation's `access-date=` field. If the Citoid response includes a `date` newer than that (e.g. a metadata-refresh timestamp on the UNT archive page), the function returns early and silently discards everything #5520 correctly placed into `$result->author`. Tests passed; real bot produced no author.

So hopefully this should be the final fix for this very specific " UNT Digital Library"