### PR TITLE
suppress Phan warning in Page.php

### DIFF
--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -899,7 +899,7 @@ class Page {
             }
         }
         /** @phpstan-ignore function.alreadyNarrowedType */
-        if ($preg_ok === false && isset($regexp) && is_string($regexp)) {
+        if ($preg_ok === false && is_string($regexp)) {
             // @codeCoverageIgnoreStart
             $regexp = str_replace('~su', '~s', $regexp);
             while ($preg_ok = preg_match($regexp, $text, $match)) { // try last most powerful REGEX without unicode

--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -898,9 +898,8 @@ class Page {
                 $objects[] = $obj;
             }
         }
-        /** @phpstan-ignore function.alreadyNarrowedType */
-        // @phan-suppress-next-line PhanPossiblyUndeclaredVariable
-        if ($preg_ok === false && is_string($regexp)) {
+        /** @phpstan-ignore isset.variable, function.alreadyNarrowedType */
+        if ($preg_ok === false && isset($regexp) && is_string($regexp)) {
             // @codeCoverageIgnoreStart
             $regexp = str_replace('~su', '~s', $regexp);
             while ($preg_ok = preg_match($regexp, $text, $match)) { // try last most powerful REGEX without unicode

--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -899,6 +899,7 @@ class Page {
             }
         }
         /** @phpstan-ignore function.alreadyNarrowedType */
+        // @phan-suppress-next-line PhanPossiblyUndeclaredVariable
         if ($preg_ok === false && is_string($regexp)) {
             // @codeCoverageIgnoreStart
             $regexp = str_replace('~su', '~s', $regexp);


### PR DESCRIPTION
This pull request makes a minor update to the `extract_object` method in `Page.php`, specifically improving static analysis compatibility.

- Static analysis improvement:
  * Added `isset.variable` to the `@phpstan-ignore` annotation to suppress an additional warning related to variable existence checks.