### PR TITLE
Add 190 tests for various functions 

### DIFF
--- a/tests/phpunit/includes/BotCurlTest.php
+++ b/tests/phpunit/includes/BotCurlTest.php
@@ -9,10 +9,8 @@ require_once __DIR__ . '/../../testBaseClass.php';
 
 final class BotCurlTest extends testBaseClass {
 
-    // ======================== curl_limit_page_size() ========================
-
     public function testCurlLimitPageSizeZeroBytes(): void {
-        new TestPage();
+        new TestPage(); // Fill page name with test name for debugging
         $ch = curl_init();
         $this->assertNotFalse($ch);
         $this->assertSame(0, curl_limit_page_size($ch, 0, 0, 0, 0));
@@ -20,7 +18,6 @@ final class BotCurlTest extends testBaseClass {
     }
 
     public function testCurlLimitPageSizeSmallPayload(): void {
-        new TestPage();
         $ch = curl_init();
         $this->assertNotFalse($ch);
         $this->assertSame(0, curl_limit_page_size($ch, 0, 1000, 0, 0));
@@ -28,7 +25,6 @@ final class BotCurlTest extends testBaseClass {
     }
 
     public function testCurlLimitPageSizeAtExactLimit(): void {
-        new TestPage();
         // Limit is 128 MB = 134217728 bytes; at exactly the limit it should still return 0
         $ch = curl_init();
         $this->assertNotFalse($ch);
@@ -37,7 +33,6 @@ final class BotCurlTest extends testBaseClass {
     }
 
     public function testCurlLimitPageSizeOneByteOverLimit(): void {
-        new TestPage();
         $ch = curl_init();
         $this->assertNotFalse($ch);
         $this->assertSame(1, curl_limit_page_size($ch, 0, 134217729, 0, 0));
@@ -45,38 +40,31 @@ final class BotCurlTest extends testBaseClass {
     }
 
     public function testCurlLimitPageSizeLargePayload(): void {
-        new TestPage();
         $ch = curl_init();
         $this->assertNotFalse($ch);
         $this->assertSame(1, curl_limit_page_size($ch, 0, 500000000, 0, 0));
         curl_close($ch);
     }
 
-    // ======================== bot_curl_init() ========================
-
     public function testBotCurlInitReturnsCurlHandle(): void {
-        new TestPage();
         $ch = bot_curl_init(1.0, []);
         $this->assertInstanceOf(CurlHandle::class, $ch);
         curl_close($ch);
     }
 
     public function testBotCurlInitWithUrl(): void {
-        new TestPage();
         $ch = bot_curl_init(1.0, [CURLOPT_URL => 'http://example.com']);
         $this->assertInstanceOf(CurlHandle::class, $ch);
         curl_close($ch);
     }
 
     public function testBotCurlInitWithHalfTimeScale(): void {
-        new TestPage();
         $ch = bot_curl_init(0.5, []);
         $this->assertInstanceOf(CurlHandle::class, $ch);
         curl_close($ch);
     }
 
     public function testBotCurlInitWithZeroTimeScale(): void {
-        new TestPage();
         $ch = bot_curl_init(0.0, []);
         $this->assertInstanceOf(CurlHandle::class, $ch);
         curl_close($ch);

--- a/tests/phpunit/includes/BotCurlTest.php
+++ b/tests/phpunit/includes/BotCurlTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Tests for bot_curl.php
+ */
+
+require_once __DIR__ . '/../../testBaseClass.php';
+
+final class BotCurlTest extends testBaseClass {
+
+    // ======================== curl_limit_page_size() ========================
+
+    public function testCurlLimitPageSizeZeroBytes(): void {
+        new TestPage();
+        $ch = curl_init();
+        $this->assertNotFalse($ch);
+        $this->assertSame(0, curl_limit_page_size($ch, 0, 0, 0, 0));
+        curl_close($ch);
+    }
+
+    public function testCurlLimitPageSizeSmallPayload(): void {
+        new TestPage();
+        $ch = curl_init();
+        $this->assertNotFalse($ch);
+        $this->assertSame(0, curl_limit_page_size($ch, 0, 1000, 0, 0));
+        curl_close($ch);
+    }
+
+    public function testCurlLimitPageSizeAtExactLimit(): void {
+        new TestPage();
+        // Limit is 128 MB = 134217728 bytes; at exactly the limit it should still return 0
+        $ch = curl_init();
+        $this->assertNotFalse($ch);
+        $this->assertSame(0, curl_limit_page_size($ch, 0, 134217728, 0, 0));
+        curl_close($ch);
+    }
+
+    public function testCurlLimitPageSizeOneByteOverLimit(): void {
+        new TestPage();
+        $ch = curl_init();
+        $this->assertNotFalse($ch);
+        $this->assertSame(1, curl_limit_page_size($ch, 0, 134217729, 0, 0));
+        curl_close($ch);
+    }
+
+    public function testCurlLimitPageSizeLargePayload(): void {
+        new TestPage();
+        $ch = curl_init();
+        $this->assertNotFalse($ch);
+        $this->assertSame(1, curl_limit_page_size($ch, 0, 500000000, 0, 0));
+        curl_close($ch);
+    }
+
+    // ======================== bot_curl_init() ========================
+
+    public function testBotCurlInitReturnsCurlHandle(): void {
+        new TestPage();
+        $ch = bot_curl_init(1.0, []);
+        $this->assertInstanceOf(CurlHandle::class, $ch);
+        curl_close($ch);
+    }
+
+    public function testBotCurlInitWithUrl(): void {
+        new TestPage();
+        $ch = bot_curl_init(1.0, [CURLOPT_URL => 'http://example.com']);
+        $this->assertInstanceOf(CurlHandle::class, $ch);
+        curl_close($ch);
+    }
+
+    public function testBotCurlInitWithHalfTimeScale(): void {
+        new TestPage();
+        $ch = bot_curl_init(0.5, []);
+        $this->assertInstanceOf(CurlHandle::class, $ch);
+        curl_close($ch);
+    }
+
+    public function testBotCurlInitWithZeroTimeScale(): void {
+        new TestPage();
+        $ch = bot_curl_init(0.0, []);
+        $this->assertInstanceOf(CurlHandle::class, $ch);
+        curl_close($ch);
+    }
+}

--- a/tests/phpunit/includes/MiscToolsTest.php
+++ b/tests/phpunit/includes/MiscToolsTest.php
@@ -280,40 +280,31 @@ final class MiscToolsTest extends testBaseClass {
         $this->assertEmpty($bad);
     }
 
-    // ======================== equivalent_parameters() ========================
-
     public function testEquivalentParametersAuthor(): void {
-        new TestPage();
         $this->assertSame(FLATTENED_AUTHOR_PARAMETERS, equivalent_parameters('author'));
     }
 
     public function testEquivalentParametersAuthors(): void {
-        new TestPage();
         $this->assertSame(FLATTENED_AUTHOR_PARAMETERS, equivalent_parameters('authors'));
     }
 
     public function testEquivalentParametersAuthor1(): void {
-        new TestPage();
         $this->assertSame(FLATTENED_AUTHOR_PARAMETERS, equivalent_parameters('author1'));
     }
 
     public function testEquivalentParametersLast1(): void {
-        new TestPage();
         $this->assertSame(FLATTENED_AUTHOR_PARAMETERS, equivalent_parameters('last1'));
     }
 
     public function testEquivalentParametersPmid(): void {
-        new TestPage();
         $this->assertSame(['pmc', 'pmid'], equivalent_parameters('pmid'));
     }
 
     public function testEquivalentParametersPmc(): void {
-        new TestPage();
         $this->assertSame(['pmc', 'pmid'], equivalent_parameters('pmc'));
     }
 
     public function testEquivalentParametersPagesGroup(): void {
-        new TestPage();
         $result = equivalent_parameters('pages');
         $this->assertContains('pages', $result);
         $this->assertContains('page', $result);
@@ -321,127 +312,101 @@ final class MiscToolsTest extends testBaseClass {
     }
 
     public function testEquivalentParametersPageGroup(): void {
-        new TestPage();
         $result = equivalent_parameters('page');
         $this->assertContains('page', $result);
         $this->assertContains('pages', $result);
     }
 
     public function testEquivalentParametersStartPage(): void {
-        new TestPage();
         $result = equivalent_parameters('start_page');
         $this->assertContains('start_page', $result);
         $this->assertContains('end_page', $result);
     }
 
     public function testEquivalentParametersEndPage(): void {
-        new TestPage();
         $result = equivalent_parameters('end_page');
         $this->assertContains('end_page', $result);
         $this->assertContains('pages', $result);
     }
 
     public function testEquivalentParametersPageRange(): void {
-        new TestPage();
         $result = equivalent_parameters('page_range');
         $this->assertContains('page_range', $result);
         $this->assertContains('pages', $result);
     }
 
     public function testEquivalentParametersDefaultReturnsSelf(): void {
-        new TestPage();
         $this->assertSame(['title'], equivalent_parameters('title'));
     }
 
     public function testEquivalentParametersDoiReturnsSelf(): void {
-        new TestPage();
         $this->assertSame(['doi'], equivalent_parameters('doi'));
     }
 
-    // ======================== string_is_book_series() ========================
-
     public function testStringIsBookSeriesJournalName(): void {
-        new TestPage();
         $this->assertFalse(string_is_book_series('Nature'));
     }
 
     public function testStringIsBookSeriesEmpty(): void {
-        new TestPage();
         $this->assertFalse(string_is_book_series(''));
     }
 
-    // ======================== should_url2chapter() ========================
-
     public function testShouldUrl2ChapterHasChapterUrl(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://example.com |chapter=Test |chapter-url=http://example.com/ch1}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterHasChapterurlOld(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://example.com |chapter=Test |chapterurl=http://example.com/ch1}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterHasTransChapter(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://example.com |chapter=Test |trans-chapter=Test Trans}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterNoChapter(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://example.com}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterChapterHasBracket(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://example.com |chapter=[Test]}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterGoogleWithoutPg(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://books.google.com/books?id=abc |chapter=Test}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterArchiveIsbn(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://archive.org/details/isbn_123 |chapter=Test}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterPageIdZero(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://example.com?page_id=0 |chapter=Test}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterPA0(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://example.com/PA0test |chapter=Test}}');
         $this->assertFalse(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterSpringerChapterUrl(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://link.springer.com/chapter/10.1007/test |chapter=Test}}');
         $this->assertTrue(should_url2chapter($template, false));
     }
 
     public function testShouldUrl2ChapterForcedTrue(): void {
-        new TestPage();
         $template = $this->make_citation('{{cite book |url=http://example.com/page |chapter=Test}}');
         $this->assertTrue(should_url2chapter($template, true));
     }
 
-    // ======================== run_type_mods() ========================
-
     public function testRunTypeModsReturnsInt(): void {
-        new TestPage();
         $result = run_type_mods(-1, 10, 20, 30, 40);
         $this->assertIsInt($result);
     }

--- a/tests/phpunit/includes/MiscToolsTest.php
+++ b/tests/phpunit/includes/MiscToolsTest.php
@@ -280,4 +280,170 @@ final class MiscToolsTest extends testBaseClass {
         $this->assertEmpty($bad);
     }
 
+    // ======================== equivalent_parameters() ========================
+
+    public function testEquivalentParametersAuthor(): void {
+        new TestPage();
+        $this->assertSame(FLATTENED_AUTHOR_PARAMETERS, equivalent_parameters('author'));
+    }
+
+    public function testEquivalentParametersAuthors(): void {
+        new TestPage();
+        $this->assertSame(FLATTENED_AUTHOR_PARAMETERS, equivalent_parameters('authors'));
+    }
+
+    public function testEquivalentParametersAuthor1(): void {
+        new TestPage();
+        $this->assertSame(FLATTENED_AUTHOR_PARAMETERS, equivalent_parameters('author1'));
+    }
+
+    public function testEquivalentParametersLast1(): void {
+        new TestPage();
+        $this->assertSame(FLATTENED_AUTHOR_PARAMETERS, equivalent_parameters('last1'));
+    }
+
+    public function testEquivalentParametersPmid(): void {
+        new TestPage();
+        $this->assertSame(['pmc', 'pmid'], equivalent_parameters('pmid'));
+    }
+
+    public function testEquivalentParametersPmc(): void {
+        new TestPage();
+        $this->assertSame(['pmc', 'pmid'], equivalent_parameters('pmc'));
+    }
+
+    public function testEquivalentParametersPagesGroup(): void {
+        new TestPage();
+        $result = equivalent_parameters('pages');
+        $this->assertContains('pages', $result);
+        $this->assertContains('page', $result);
+        $this->assertContains('page_range', $result);
+    }
+
+    public function testEquivalentParametersPageGroup(): void {
+        new TestPage();
+        $result = equivalent_parameters('page');
+        $this->assertContains('page', $result);
+        $this->assertContains('pages', $result);
+    }
+
+    public function testEquivalentParametersStartPage(): void {
+        new TestPage();
+        $result = equivalent_parameters('start_page');
+        $this->assertContains('start_page', $result);
+        $this->assertContains('end_page', $result);
+    }
+
+    public function testEquivalentParametersEndPage(): void {
+        new TestPage();
+        $result = equivalent_parameters('end_page');
+        $this->assertContains('end_page', $result);
+        $this->assertContains('pages', $result);
+    }
+
+    public function testEquivalentParametersPageRange(): void {
+        new TestPage();
+        $result = equivalent_parameters('page_range');
+        $this->assertContains('page_range', $result);
+        $this->assertContains('pages', $result);
+    }
+
+    public function testEquivalentParametersDefaultReturnsSelf(): void {
+        new TestPage();
+        $this->assertSame(['title'], equivalent_parameters('title'));
+    }
+
+    public function testEquivalentParametersDoiReturnsSelf(): void {
+        new TestPage();
+        $this->assertSame(['doi'], equivalent_parameters('doi'));
+    }
+
+    // ======================== string_is_book_series() ========================
+
+    public function testStringIsBookSeriesJournalName(): void {
+        new TestPage();
+        $this->assertFalse(string_is_book_series('Nature'));
+    }
+
+    public function testStringIsBookSeriesEmpty(): void {
+        new TestPage();
+        $this->assertFalse(string_is_book_series(''));
+    }
+
+    // ======================== should_url2chapter() ========================
+
+    public function testShouldUrl2ChapterHasChapterUrl(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://example.com |chapter=Test |chapter-url=http://example.com/ch1}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterHasChapterurlOld(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://example.com |chapter=Test |chapterurl=http://example.com/ch1}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterHasTransChapter(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://example.com |chapter=Test |trans-chapter=Test Trans}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterNoChapter(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://example.com}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterChapterHasBracket(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://example.com |chapter=[Test]}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterGoogleWithoutPg(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://books.google.com/books?id=abc |chapter=Test}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterArchiveIsbn(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://archive.org/details/isbn_123 |chapter=Test}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterPageIdZero(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://example.com?page_id=0 |chapter=Test}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterPA0(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://example.com/PA0test |chapter=Test}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterSpringerChapterUrl(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://link.springer.com/chapter/10.1007/test |chapter=Test}}');
+        $this->assertTrue(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterForcedTrue(): void {
+        new TestPage();
+        $template = $this->make_citation('{{cite book |url=http://example.com/page |chapter=Test}}');
+        $this->assertTrue(should_url2chapter($template, true));
+    }
+
+    // ======================== run_type_mods() ========================
+
+    public function testRunTypeModsReturnsInt(): void {
+        new TestPage();
+        $result = run_type_mods(-1, 10, 20, 30, 40);
+        $this->assertIsInt($result);
+    }
+
 }

--- a/tests/phpunit/includes/UserMessagesTest.php
+++ b/tests/phpunit/includes/UserMessagesTest.php
@@ -9,142 +9,106 @@ require_once __DIR__ . '/../../testBaseClass.php';
 
 final class UserMessagesTest extends testBaseClass {
 
-    // ======================== echoable() ========================
-
     public function testEchoablePlainText(): void {
-        new TestPage();
+        new TestPage(); // Fill page name with test name for debugging
         $this->assertSame('hello world', echoable('hello world'));
     }
 
     public function testEchoableNull(): void {
-        new TestPage();
         $this->assertSame('', echoable(null));
     }
 
     public function testEchoableEmptyString(): void {
-        new TestPage();
         $this->assertSame('', echoable(''));
     }
 
     // In CI mode HTML_OUTPUT is false, so echoable() returns the string unchanged
     public function testEchoableAngleBracketsNotEscapedInCi(): void {
-        new TestPage();
         $this->assertSame('<test>', echoable('<test>'));
     }
 
-    // ======================== pubmed_link() ========================
-
     public function testPubmedLinkPmidContainsId(): void {
-        new TestPage();
         $result = pubmed_link('pmid', '12345678');
         $this->assertStringContainsString('12345678', $result);
     }
 
     public function testPubmedLinkPmcContainsId(): void {
-        new TestPage();
         $result = pubmed_link('pmc', '12345');
         $this->assertStringContainsString('12345', $result);
     }
 
     public function testPubmedLinkPmidUppercasesIdentifierLabel(): void {
-        new TestPage();
         // In non-HTML (CI) mode the result is "PMID 12345678"
         $result = pubmed_link('pmid', '12345678');
         $this->assertStringContainsString('PMID', $result);
     }
 
-    // ======================== bibcode_link() ========================
-
     public function testBibcodeLinkContainsBibcode(): void {
-        new TestPage();
         $result = bibcode_link('2020Natur.123..456A');
         $this->assertStringContainsString('2020Natur.123..456A', $result);
     }
 
-    // ======================== doi_link() ========================
-
     public function testDoiLinkContainsDoi(): void {
-        new TestPage();
         $result = doi_link('10.1000/test');
         $this->assertStringContainsString('10.1000/test', $result);
     }
 
-    // ======================== jstor_link() ========================
-
     public function testJstorLinkContainsId(): void {
-        new TestPage();
         $result = jstor_link('12345');
         $this->assertStringContainsString('12345', $result);
     }
 
     public function testJstorLinkContainsJstorPrefix(): void {
-        new TestPage();
         $result = jstor_link('12345');
         $this->assertStringContainsString('JSTOR', $result);
     }
 
-    // ======================== wiki_link() ========================
-
     public function testWikiLinkContainsArticleName(): void {
-        new TestPage();
         $result = wiki_link('Test Article');
         $this->assertStringContainsString('Test Article', $result);
     }
 
-    // ======================== report_* functions — no-crash in CI ========================
-
     public function testReportPhaseRunsWithoutError(): void {
-        new TestPage();
         report_phase('test phase');
         $this->assertFaker();
     }
 
     public function testReportActionRunsWithoutError(): void {
-        new TestPage();
         report_action('test action');
         $this->assertFaker();
     }
 
     public function testReportInfoRunsWithoutError(): void {
-        new TestPage();
         report_info('test info');
         $this->assertFaker();
     }
 
     public function testReportInactionRunsWithoutError(): void {
-        new TestPage();
         report_inaction('test inaction');
         $this->assertFaker();
     }
 
     public function testReportWarningRunsWithoutError(): void {
-        new TestPage();
         report_warning('test warning');
         $this->assertFaker();
     }
 
     public function testReportModificationRunsWithoutError(): void {
-        new TestPage();
         report_modification('test modification');
         $this->assertFaker();
     }
 
     public function testReportAddRunsWithoutError(): void {
-        new TestPage();
         report_add('test add');
         $this->assertFaker();
     }
 
     public function testReportForgetRunsWithoutError(): void {
-        new TestPage();
         report_forget('test forget');
         $this->assertFaker();
     }
 
-    // ======================== html_echo() ========================
-
     public function testHtmlEchoCiProducesNoOutput(): void {
-        new TestPage();
         ob_start();
         html_echo('html text', 'alt text');
         $output = (string) ob_get_clean();

--- a/tests/phpunit/includes/UserMessagesTest.php
+++ b/tests/phpunit/includes/UserMessagesTest.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Tests for user_messages.php
+ */
+
+require_once __DIR__ . '/../../testBaseClass.php';
+
+final class UserMessagesTest extends testBaseClass {
+
+    // ======================== echoable() ========================
+
+    public function testEchoablePlainText(): void {
+        new TestPage();
+        $this->assertSame('hello world', echoable('hello world'));
+    }
+
+    public function testEchoableNull(): void {
+        new TestPage();
+        $this->assertSame('', echoable(null));
+    }
+
+    public function testEchoableEmptyString(): void {
+        new TestPage();
+        $this->assertSame('', echoable(''));
+    }
+
+    // In CI mode HTML_OUTPUT is false, so echoable() returns the string unchanged
+    public function testEchoableAngleBracketsNotEscapedInCi(): void {
+        new TestPage();
+        $this->assertSame('<test>', echoable('<test>'));
+    }
+
+    // ======================== pubmed_link() ========================
+
+    public function testPubmedLinkPmidContainsId(): void {
+        new TestPage();
+        $result = pubmed_link('pmid', '12345678');
+        $this->assertStringContainsString('12345678', $result);
+    }
+
+    public function testPubmedLinkPmcContainsId(): void {
+        new TestPage();
+        $result = pubmed_link('pmc', '12345');
+        $this->assertStringContainsString('12345', $result);
+    }
+
+    public function testPubmedLinkPmidUppercasesIdentifierLabel(): void {
+        new TestPage();
+        // In non-HTML (CI) mode the result is "PMID 12345678"
+        $result = pubmed_link('pmid', '12345678');
+        $this->assertStringContainsString('PMID', $result);
+    }
+
+    // ======================== bibcode_link() ========================
+
+    public function testBibcodeLinkContainsBibcode(): void {
+        new TestPage();
+        $result = bibcode_link('2020Natur.123..456A');
+        $this->assertStringContainsString('2020Natur.123..456A', $result);
+    }
+
+    // ======================== doi_link() ========================
+
+    public function testDoiLinkContainsDoi(): void {
+        new TestPage();
+        $result = doi_link('10.1000/test');
+        $this->assertStringContainsString('10.1000/test', $result);
+    }
+
+    // ======================== jstor_link() ========================
+
+    public function testJstorLinkContainsId(): void {
+        new TestPage();
+        $result = jstor_link('12345');
+        $this->assertStringContainsString('12345', $result);
+    }
+
+    public function testJstorLinkContainsJstorPrefix(): void {
+        new TestPage();
+        $result = jstor_link('12345');
+        $this->assertStringContainsString('JSTOR', $result);
+    }
+
+    // ======================== wiki_link() ========================
+
+    public function testWikiLinkContainsArticleName(): void {
+        new TestPage();
+        $result = wiki_link('Test Article');
+        $this->assertStringContainsString('Test Article', $result);
+    }
+
+    // ======================== report_* functions — no-crash in CI ========================
+
+    public function testReportPhaseRunsWithoutError(): void {
+        new TestPage();
+        report_phase('test phase');
+        $this->assertFaker();
+    }
+
+    public function testReportActionRunsWithoutError(): void {
+        new TestPage();
+        report_action('test action');
+        $this->assertFaker();
+    }
+
+    public function testReportInfoRunsWithoutError(): void {
+        new TestPage();
+        report_info('test info');
+        $this->assertFaker();
+    }
+
+    public function testReportInactionRunsWithoutError(): void {
+        new TestPage();
+        report_inaction('test inaction');
+        $this->assertFaker();
+    }
+
+    public function testReportWarningRunsWithoutError(): void {
+        new TestPage();
+        report_warning('test warning');
+        $this->assertFaker();
+    }
+
+    public function testReportModificationRunsWithoutError(): void {
+        new TestPage();
+        report_modification('test modification');
+        $this->assertFaker();
+    }
+
+    public function testReportAddRunsWithoutError(): void {
+        new TestPage();
+        report_add('test add');
+        $this->assertFaker();
+    }
+
+    public function testReportForgetRunsWithoutError(): void {
+        new TestPage();
+        report_forget('test forget');
+        $this->assertFaker();
+    }
+
+    // ======================== html_echo() ========================
+
+    public function testHtmlEchoCiProducesNoOutput(): void {
+        new TestPage();
+        ob_start();
+        html_echo('html text', 'alt text');
+        $output = (string) ob_get_clean();
+        // In CI mode HTML is suppressed completely
+        $this->assertSame('', $output);
+    }
+}

--- a/tests/phpunit/includes/WikiThingsTest.php
+++ b/tests/phpunit/includes/WikiThingsTest.php
@@ -9,190 +9,153 @@ require_once __DIR__ . '/../../testBaseClass.php';
 
 final class WikiThingsTest extends testBaseClass {
 
-    // ======================== WikiThings::parse_text / parsed_text ========================
-
     public function testCommentParseAndReturn(): void {
-        new TestPage();
+        new TestPage(); // Fill page name with test name for debugging
         $comment = new Comment();
         $comment->parse_text('<!-- This is a comment -->');
         $this->assertSame('<!-- This is a comment -->', $comment->parsed_text());
     }
 
     public function testNowikiParseAndReturn(): void {
-        new TestPage();
         $nowiki = new Nowiki();
         $nowiki->parse_text('<nowiki>some [[markup]]</nowiki>');
         $this->assertSame('<nowiki>some [[markup]]</nowiki>', $nowiki->parsed_text());
     }
 
     public function testChemistryParseAndReturn(): void {
-        new TestPage();
         $chem = new Chemistry();
         $chem->parse_text('<chem>H2O</chem>');
         $this->assertSame('<chem>H2O</chem>', $chem->parsed_text());
     }
 
     public function testMathematicsParseAndReturn(): void {
-        new TestPage();
         $math = new Mathematics();
         $math->parse_text('<math>E = mc^2</math>');
         $this->assertSame('<math>E = mc^2</math>', $math->parsed_text());
     }
 
     public function testMusicscoresParseAndReturn(): void {
-        new TestPage();
         $music = new Musicscores();
         $music->parse_text('<score>notes here</score>');
         $this->assertSame('<score>notes here</score>', $music->parsed_text());
     }
 
     public function testPreformatedParseAndReturn(): void {
-        new TestPage();
         $pre = new Preformated();
         $pre->parse_text('<pre>preformatted text</pre>');
         $this->assertSame('<pre>preformatted text</pre>', $pre->parsed_text());
     }
 
     public function testSingleBracketParseAndReturn(): void {
-        new TestPage();
         $bracket = new SingleBracket();
         $bracket->parse_text('{single}');
         $this->assertSame('{single}', $bracket->parsed_text());
     }
 
     public function testTripleBracketParseAndReturn(): void {
-        new TestPage();
         $bracket = new TripleBracket();
         $bracket->parse_text('{{{triple}}}');
         $this->assertSame('{{{triple}}}', $bracket->parsed_text());
     }
 
-    // ======================== PLACEHOLDER_TEXT constants ========================
-
     public function testCommentPlaceholderContainsKey(): void {
-        new TestPage();
         $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_COMMENT', Comment::PLACEHOLDER_TEXT);
     }
 
     public function testNowikiPlaceholderContainsKey(): void {
-        new TestPage();
         $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_NOWIKI', Nowiki::PLACEHOLDER_TEXT);
     }
 
     public function testChemistryPlaceholderContainsKey(): void {
-        new TestPage();
         $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_CHEMISTRY', Chemistry::PLACEHOLDER_TEXT);
     }
 
     public function testMathematicsPlaceholderContainsKey(): void {
-        new TestPage();
         $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_MATHEMATICS', Mathematics::PLACEHOLDER_TEXT);
     }
 
     public function testMusicscoresPlaceholderContainsKey(): void {
-        new TestPage();
         $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_MUSIC', Musicscores::PLACEHOLDER_TEXT);
     }
 
     public function testPreformatedPlaceholderContainsKey(): void {
-        new TestPage();
         $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_PREFORMAT', Preformated::PLACEHOLDER_TEXT);
     }
 
     public function testSingleBracketPlaceholderContainsKey(): void {
-        new TestPage();
         $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_SINGLE_BRACKET', SingleBracket::PLACEHOLDER_TEXT);
     }
 
     public function testTripleBracketPlaceholderContainsKey(): void {
-        new TestPage();
         $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_TRIPLE_BRACKET', TripleBracket::PLACEHOLDER_TEXT);
     }
 
-    // ======================== REGEXP patterns ========================
-
     public function testCommentRegexpMatchesSimple(): void {
-        new TestPage();
         $text = '<!-- simple comment -->';
         $this->assertMatchesRegularExpression(Comment::REGEXP[0], $text);
     }
 
     public function testCommentRegexpMatchesMultiline(): void {
-        new TestPage();
         $text = "<!-- multi\nline\ncomment -->";
         $this->assertMatchesRegularExpression(Comment::REGEXP[1], $text);
     }
 
     public function testNowikiRegexpMatchesBasic(): void {
-        new TestPage();
         $text = '<nowiki>test content</nowiki>';
         $this->assertMatchesRegularExpression(Nowiki::REGEXP[0], $text);
     }
 
     public function testNowikiRegexpMatchesMultiline(): void {
-        new TestPage();
         $text = "<nowiki>multi\nline</nowiki>";
         $this->assertMatchesRegularExpression(Nowiki::REGEXP[1], $text);
     }
 
     public function testChemistryRegexpMatches(): void {
-        new TestPage();
         $text = '<chem>CO2 + H2O</chem>';
         $this->assertMatchesRegularExpression(Chemistry::REGEXP[0], $text);
     }
 
     public function testMathematicsRegexpMatchesPlain(): void {
-        new TestPage();
         $text = '<math>x^2 + y^2 = z^2</math>';
         $this->assertMatchesRegularExpression(Mathematics::REGEXP[0], $text);
     }
 
     public function testMathematicsRegexpMatchesInlineDisplay(): void {
-        new TestPage();
         $text = '<math display="inline">x^2</math>';
         $this->assertMatchesRegularExpression(Mathematics::REGEXP[0], $text);
     }
 
     public function testMathematicsRegexpMatchesChem(): void {
-        new TestPage();
         $text = '<math chem>H_2O</math>';
         $this->assertMatchesRegularExpression(Mathematics::REGEXP[0], $text);
     }
 
     public function testMusicscoresRegexpMatches(): void {
-        new TestPage();
         $text = '<score>some music</score>';
         $this->assertMatchesRegularExpression(Musicscores::REGEXP[0], $text);
     }
 
     public function testPreformatedRegexpMatches(): void {
-        new TestPage();
         $text = '<pre>formatted code</pre>';
         $this->assertMatchesRegularExpression(Preformated::REGEXP[0], $text);
     }
 
     public function testSingleBracketRegexpMatchesSingle(): void {
-        new TestPage();
         $text = '{test content}';
         $this->assertMatchesRegularExpression(SingleBracket::REGEXP[0], $text);
     }
 
     public function testSingleBracketRegexpDoesNotMatchDouble(): void {
-        new TestPage();
         $text = '{{double brackets}}';
         $this->assertDoesNotMatchRegularExpression(SingleBracket::REGEXP[0], $text);
     }
 
     public function testTripleBracketRegexpMatches(): void {
-        new TestPage();
         $text = '{{{parameter}}}';
         $this->assertMatchesRegularExpression(TripleBracket::REGEXP[0], $text);
     }
 
-    // ======================== TREAT_IDENTICAL_SEPARATELY constant ========================
-
     public function testTreatIdenticalSeparatelyIsFalseForAll(): void {
-        new TestPage();
         $this->assertFalse(Comment::TREAT_IDENTICAL_SEPARATELY);
         $this->assertFalse(Nowiki::TREAT_IDENTICAL_SEPARATELY);
         $this->assertFalse(Chemistry::TREAT_IDENTICAL_SEPARATELY);
@@ -203,10 +166,7 @@ final class WikiThingsTest extends testBaseClass {
         $this->assertFalse(TripleBracket::TREAT_IDENTICAL_SEPARATELY);
     }
 
-    // ======================== Overwrite / empty string ========================
-
     public function testCommentOverwrite(): void {
-        new TestPage();
         $comment = new Comment();
         $comment->parse_text('<!-- first -->');
         $comment->parse_text('<!-- second -->');
@@ -214,7 +174,6 @@ final class WikiThingsTest extends testBaseClass {
     }
 
     public function testParseTextEmptyString(): void {
-        new TestPage();
         $comment = new Comment();
         $comment->parse_text('');
         $this->assertSame('', $comment->parsed_text());

--- a/tests/phpunit/includes/WikiThingsTest.php
+++ b/tests/phpunit/includes/WikiThingsTest.php
@@ -1,0 +1,222 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Tests for WikiThings.php
+ */
+
+require_once __DIR__ . '/../../testBaseClass.php';
+
+final class WikiThingsTest extends testBaseClass {
+
+    // ======================== WikiThings::parse_text / parsed_text ========================
+
+    public function testCommentParseAndReturn(): void {
+        new TestPage();
+        $comment = new Comment();
+        $comment->parse_text('<!-- This is a comment -->');
+        $this->assertSame('<!-- This is a comment -->', $comment->parsed_text());
+    }
+
+    public function testNowikiParseAndReturn(): void {
+        new TestPage();
+        $nowiki = new Nowiki();
+        $nowiki->parse_text('<nowiki>some [[markup]]</nowiki>');
+        $this->assertSame('<nowiki>some [[markup]]</nowiki>', $nowiki->parsed_text());
+    }
+
+    public function testChemistryParseAndReturn(): void {
+        new TestPage();
+        $chem = new Chemistry();
+        $chem->parse_text('<chem>H2O</chem>');
+        $this->assertSame('<chem>H2O</chem>', $chem->parsed_text());
+    }
+
+    public function testMathematicsParseAndReturn(): void {
+        new TestPage();
+        $math = new Mathematics();
+        $math->parse_text('<math>E = mc^2</math>');
+        $this->assertSame('<math>E = mc^2</math>', $math->parsed_text());
+    }
+
+    public function testMusicscoresParseAndReturn(): void {
+        new TestPage();
+        $music = new Musicscores();
+        $music->parse_text('<score>notes here</score>');
+        $this->assertSame('<score>notes here</score>', $music->parsed_text());
+    }
+
+    public function testPreformatedParseAndReturn(): void {
+        new TestPage();
+        $pre = new Preformated();
+        $pre->parse_text('<pre>preformatted text</pre>');
+        $this->assertSame('<pre>preformatted text</pre>', $pre->parsed_text());
+    }
+
+    public function testSingleBracketParseAndReturn(): void {
+        new TestPage();
+        $bracket = new SingleBracket();
+        $bracket->parse_text('{single}');
+        $this->assertSame('{single}', $bracket->parsed_text());
+    }
+
+    public function testTripleBracketParseAndReturn(): void {
+        new TestPage();
+        $bracket = new TripleBracket();
+        $bracket->parse_text('{{{triple}}}');
+        $this->assertSame('{{{triple}}}', $bracket->parsed_text());
+    }
+
+    // ======================== PLACEHOLDER_TEXT constants ========================
+
+    public function testCommentPlaceholderContainsKey(): void {
+        new TestPage();
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_COMMENT', Comment::PLACEHOLDER_TEXT);
+    }
+
+    public function testNowikiPlaceholderContainsKey(): void {
+        new TestPage();
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_NOWIKI', Nowiki::PLACEHOLDER_TEXT);
+    }
+
+    public function testChemistryPlaceholderContainsKey(): void {
+        new TestPage();
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_CHEMISTRY', Chemistry::PLACEHOLDER_TEXT);
+    }
+
+    public function testMathematicsPlaceholderContainsKey(): void {
+        new TestPage();
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_MATHEMATICS', Mathematics::PLACEHOLDER_TEXT);
+    }
+
+    public function testMusicscoresPlaceholderContainsKey(): void {
+        new TestPage();
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_MUSIC', Musicscores::PLACEHOLDER_TEXT);
+    }
+
+    public function testPreformatedPlaceholderContainsKey(): void {
+        new TestPage();
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_PREFORMAT', Preformated::PLACEHOLDER_TEXT);
+    }
+
+    public function testSingleBracketPlaceholderContainsKey(): void {
+        new TestPage();
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_SINGLE_BRACKET', SingleBracket::PLACEHOLDER_TEXT);
+    }
+
+    public function testTripleBracketPlaceholderContainsKey(): void {
+        new TestPage();
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_TRIPLE_BRACKET', TripleBracket::PLACEHOLDER_TEXT);
+    }
+
+    // ======================== REGEXP patterns ========================
+
+    public function testCommentRegexpMatchesSimple(): void {
+        new TestPage();
+        $text = '<!-- simple comment -->';
+        $this->assertMatchesRegularExpression(Comment::REGEXP[0], $text);
+    }
+
+    public function testCommentRegexpMatchesMultiline(): void {
+        new TestPage();
+        $text = "<!-- multi\nline\ncomment -->";
+        $this->assertMatchesRegularExpression(Comment::REGEXP[1], $text);
+    }
+
+    public function testNowikiRegexpMatchesBasic(): void {
+        new TestPage();
+        $text = '<nowiki>test content</nowiki>';
+        $this->assertMatchesRegularExpression(Nowiki::REGEXP[0], $text);
+    }
+
+    public function testNowikiRegexpMatchesMultiline(): void {
+        new TestPage();
+        $text = "<nowiki>multi\nline</nowiki>";
+        $this->assertMatchesRegularExpression(Nowiki::REGEXP[1], $text);
+    }
+
+    public function testChemistryRegexpMatches(): void {
+        new TestPage();
+        $text = '<chem>CO2 + H2O</chem>';
+        $this->assertMatchesRegularExpression(Chemistry::REGEXP[0], $text);
+    }
+
+    public function testMathematicsRegexpMatchesPlain(): void {
+        new TestPage();
+        $text = '<math>x^2 + y^2 = z^2</math>';
+        $this->assertMatchesRegularExpression(Mathematics::REGEXP[0], $text);
+    }
+
+    public function testMathematicsRegexpMatchesInlineDisplay(): void {
+        new TestPage();
+        $text = '<math display="inline">x^2</math>';
+        $this->assertMatchesRegularExpression(Mathematics::REGEXP[0], $text);
+    }
+
+    public function testMathematicsRegexpMatchesChem(): void {
+        new TestPage();
+        $text = '<math chem>H_2O</math>';
+        $this->assertMatchesRegularExpression(Mathematics::REGEXP[0], $text);
+    }
+
+    public function testMusicscoresRegexpMatches(): void {
+        new TestPage();
+        $text = '<score>some music</score>';
+        $this->assertMatchesRegularExpression(Musicscores::REGEXP[0], $text);
+    }
+
+    public function testPreformatedRegexpMatches(): void {
+        new TestPage();
+        $text = '<pre>formatted code</pre>';
+        $this->assertMatchesRegularExpression(Preformated::REGEXP[0], $text);
+    }
+
+    public function testSingleBracketRegexpMatchesSingle(): void {
+        new TestPage();
+        $text = '{test content}';
+        $this->assertMatchesRegularExpression(SingleBracket::REGEXP[0], $text);
+    }
+
+    public function testSingleBracketRegexpDoesNotMatchDouble(): void {
+        new TestPage();
+        $text = '{{double brackets}}';
+        $this->assertDoesNotMatchRegularExpression(SingleBracket::REGEXP[0], $text);
+    }
+
+    public function testTripleBracketRegexpMatches(): void {
+        new TestPage();
+        $text = '{{{parameter}}}';
+        $this->assertMatchesRegularExpression(TripleBracket::REGEXP[0], $text);
+    }
+
+    // ======================== TREAT_IDENTICAL_SEPARATELY constant ========================
+
+    public function testTreatIdenticalSeparatelyIsFalseForAll(): void {
+        new TestPage();
+        $this->assertFalse(Comment::TREAT_IDENTICAL_SEPARATELY);
+        $this->assertFalse(Nowiki::TREAT_IDENTICAL_SEPARATELY);
+        $this->assertFalse(Chemistry::TREAT_IDENTICAL_SEPARATELY);
+        $this->assertFalse(Mathematics::TREAT_IDENTICAL_SEPARATELY);
+        $this->assertFalse(Musicscores::TREAT_IDENTICAL_SEPARATELY);
+        $this->assertFalse(Preformated::TREAT_IDENTICAL_SEPARATELY);
+        $this->assertFalse(SingleBracket::TREAT_IDENTICAL_SEPARATELY);
+        $this->assertFalse(TripleBracket::TREAT_IDENTICAL_SEPARATELY);
+    }
+
+    // ======================== Overwrite / empty string ========================
+
+    public function testCommentOverwrite(): void {
+        new TestPage();
+        $comment = new Comment();
+        $comment->parse_text('<!-- first -->');
+        $comment->parse_text('<!-- second -->');
+        $this->assertSame('<!-- second -->', $comment->parsed_text());
+    }
+
+    public function testParseTextEmptyString(): void {
+        new TestPage();
+        $comment = new Comment();
+        $comment->parse_text('');
+        $this->assertSame('', $comment->parsed_text());
+    }
+}

--- a/tests/phpunit/includes/nameToolsTest.php
+++ b/tests/phpunit/includes/nameToolsTest.php
@@ -303,4 +303,212 @@ final class nameToolsTest extends testBaseClass {
         $template = $this->process_citation($text);
         $this->assertSame('{{cite document |last1=Howlett |first1=Felicity|last2=Fred}}', $template->parsed_text());
     }
+
+    // ======================== author_is_human() ========================
+
+    public function testAuthorIsHumanNormalName(): void {
+        new TestPage();
+        $this->assertTrue(author_is_human('John Smith'));
+    }
+
+    public function testAuthorIsHumanSingleWord(): void {
+        new TestPage();
+        $this->assertTrue(author_is_human('Smith'));
+    }
+
+    public function testAuthorIsHumanWithColon(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('Reuters: News Agency'));
+    }
+
+    public function testAuthorIsHumanTooManySpaces(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('A B C D E'));
+    }
+
+    public function testAuthorIsHumanTooLong(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('Abcdefghijklmnopqrstuvwxyz12345678'));
+    }
+
+    public function testAuthorIsHumanStartsWithThe(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('The Associated Press'));
+    }
+
+    public function testAuthorIsHumanThreeUppercaseChars(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('ABC News'));
+    }
+
+    public function testAuthorIsHumanInc(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('Company Inc'));
+    }
+
+    public function testAuthorIsHumanIncDot(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('Company Inc.'));
+    }
+
+    public function testAuthorIsHumanLLC(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('Company LLC'));
+    }
+
+    public function testAuthorIsHumanLLCDot(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('Company LLC.'));
+    }
+
+    public function testAuthorIsHumanBooks(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('Some Books'));
+    }
+
+    public function testAuthorIsHumanNyheter(): void {
+        new TestPage();
+        $this->assertFalse(author_is_human('Dagbladet Nyheter'));
+    }
+
+    // ======================== under_two_authors() ========================
+
+    public function testUnderTwoAuthorsSingleWord(): void {
+        new TestPage();
+        $this->assertTrue(under_two_authors('Smith'));
+    }
+
+    public function testUnderTwoAuthorsLastFirstFormat(): void {
+        new TestPage();
+        $this->assertTrue(under_two_authors('Smith, John'));
+    }
+
+    public function testUnderTwoAuthorsSemicolon(): void {
+        new TestPage();
+        $this->assertFalse(under_two_authors('Smith, John; Doe, Jane'));
+    }
+
+    public function testUnderTwoAuthorsMoreThanOneComma(): void {
+        new TestPage();
+        $this->assertFalse(under_two_authors('Smith, John, Doe'));
+    }
+
+    public function testUnderTwoAuthorsSpacesExceedCommas(): void {
+        new TestPage();
+        // "John Smith" has 1 space and 0 commas → spaces > commas → multiple authors
+        $this->assertFalse(under_two_authors('John Smith'));
+    }
+
+    // ======================== is_bad_author() ========================
+
+    public function testIsBadAuthorPipe(): void {
+        new TestPage();
+        $this->assertTrue(is_bad_author('|'));
+    }
+
+    public function testIsBadAuthorPublished(): void {
+        new TestPage();
+        $this->assertTrue(is_bad_author('Published'));
+    }
+
+    public function testIsBadAuthorNormalName(): void {
+        new TestPage();
+        $this->assertFalse(is_bad_author('John Smith'));
+    }
+
+    public function testIsBadAuthorEmpty(): void {
+        new TestPage();
+        $this->assertFalse(is_bad_author(''));
+    }
+
+    // ======================== split_author() ========================
+
+    public function testSplitAuthorOneComma(): void {
+        new TestPage();
+        $result = split_author('Smith, John');
+        $this->assertSame(['Smith', ' John'], $result);
+    }
+
+    public function testSplitAuthorNoComma(): void {
+        new TestPage();
+        $result = split_author('John Smith');
+        $this->assertSame([], $result);
+    }
+
+    public function testSplitAuthorMultipleCommas(): void {
+        new TestPage();
+        $result = split_author('Smith, John, Jr');
+        $this->assertSame([], $result);
+    }
+
+    // ======================== clean_up_full_names() ========================
+
+    public function testCleanUpFullNamesAndSemicolon(): void {
+        new TestPage();
+        $this->assertSame('name1; name2', clean_up_full_names('name1 and; name2'));
+    }
+
+    public function testCleanUpFullNamesDoubleSpace(): void {
+        new TestPage();
+        $this->assertSame('name1 name2', clean_up_full_names('name1  name2'));
+    }
+
+    public function testCleanUpFullNamesPlusRemoved(): void {
+        new TestPage();
+        $this->assertSame('name1name2', clean_up_full_names('name1+name2'));
+    }
+
+    public function testCleanUpFullNamesStarRemoved(): void {
+        new TestPage();
+        $this->assertSame('name1name2', clean_up_full_names('name1*name2'));
+    }
+
+    // ======================== clean_up_first_names() ========================
+
+    public function testCleanUpFirstNamesSingleCharGetsDot(): void {
+        new TestPage();
+        $this->assertSame('J.', clean_up_first_names('J'));
+    }
+
+    public function testCleanUpFirstNamesTwoInitialsGetDots(): void {
+        new TestPage();
+        $this->assertSame('F. M.', clean_up_first_names('F M'));
+    }
+
+    public function testCleanUpFirstNamesWordEndingInInitial(): void {
+        new TestPage();
+        $this->assertSame('Fred M.', clean_up_first_names('Fred M'));
+    }
+
+    public function testCleanUpFirstNamesDoubleSpaceCollapsed(): void {
+        new TestPage();
+        $this->assertSame('Fred Smith', clean_up_first_names('Fred  Smith'));
+    }
+
+    // ======================== format_surname_2() ========================
+
+    public function testFormatSurname2UpperToTitleCase(): void {
+        new TestPage();
+        $this->assertSame('Smith', format_surname_2('SMITH'));
+    }
+
+    public function testFormatSurname2VonLowercased(): void {
+        new TestPage();
+        $this->assertSame('von Neumann', format_surname_2('VON NEUMANN'));
+    }
+
+    public function testFormatSurname2DeLaLowercased(): void {
+        new TestPage();
+        $this->assertSame('de la Cruz', format_surname_2('DE LA CRUZ'));
+    }
+
+    public function testFormatSurname2HyphenWithSpaces(): void {
+        new TestPage();
+        $this->assertSame('Smith-Jones', format_surname_2('SMITH - JONES'));
+    }
+
+    public function testFormatSurname2UndLowercased(): void {
+        new TestPage();
+        $this->assertSame('Strauss und Torney', format_surname_2('STRAUSS UND TORNEY'));
+    }
 }

--- a/tests/phpunit/includes/nameToolsTest.php
+++ b/tests/phpunit/includes/nameToolsTest.php
@@ -304,211 +304,159 @@ final class nameToolsTest extends testBaseClass {
         $this->assertSame('{{cite document |last1=Howlett |first1=Felicity|last2=Fred}}', $template->parsed_text());
     }
 
-    // ======================== author_is_human() ========================
-
     public function testAuthorIsHumanNormalName(): void {
-        new TestPage();
         $this->assertTrue(author_is_human('John Smith'));
     }
 
     public function testAuthorIsHumanSingleWord(): void {
-        new TestPage();
         $this->assertTrue(author_is_human('Smith'));
     }
 
     public function testAuthorIsHumanWithColon(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('Reuters: News Agency'));
     }
 
     public function testAuthorIsHumanTooManySpaces(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('A B C D E'));
     }
 
     public function testAuthorIsHumanTooLong(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('Abcdefghijklmnopqrstuvwxyz12345678'));
     }
 
     public function testAuthorIsHumanStartsWithThe(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('The Associated Press'));
     }
 
     public function testAuthorIsHumanThreeUppercaseChars(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('ABC News'));
     }
 
     public function testAuthorIsHumanInc(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('Company Inc'));
     }
 
     public function testAuthorIsHumanIncDot(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('Company Inc.'));
     }
 
     public function testAuthorIsHumanLLC(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('Company LLC'));
     }
 
     public function testAuthorIsHumanLLCDot(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('Company LLC.'));
     }
 
     public function testAuthorIsHumanBooks(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('Some Books'));
     }
 
     public function testAuthorIsHumanNyheter(): void {
-        new TestPage();
         $this->assertFalse(author_is_human('Dagbladet Nyheter'));
     }
 
-    // ======================== under_two_authors() ========================
-
     public function testUnderTwoAuthorsSingleWord(): void {
-        new TestPage();
         $this->assertTrue(under_two_authors('Smith'));
     }
 
     public function testUnderTwoAuthorsLastFirstFormat(): void {
-        new TestPage();
         $this->assertTrue(under_two_authors('Smith, John'));
     }
 
     public function testUnderTwoAuthorsSemicolon(): void {
-        new TestPage();
         $this->assertFalse(under_two_authors('Smith, John; Doe, Jane'));
     }
 
     public function testUnderTwoAuthorsMoreThanOneComma(): void {
-        new TestPage();
         $this->assertFalse(under_two_authors('Smith, John, Doe'));
     }
 
     public function testUnderTwoAuthorsSpacesExceedCommas(): void {
-        new TestPage();
         // "John Smith" has 1 space and 0 commas → spaces > commas → multiple authors
         $this->assertFalse(under_two_authors('John Smith'));
     }
 
-    // ======================== is_bad_author() ========================
-
     public function testIsBadAuthorPipe(): void {
-        new TestPage();
         $this->assertTrue(is_bad_author('|'));
     }
 
     public function testIsBadAuthorPublished(): void {
-        new TestPage();
         $this->assertTrue(is_bad_author('Published'));
     }
 
     public function testIsBadAuthorNormalName(): void {
-        new TestPage();
         $this->assertFalse(is_bad_author('John Smith'));
     }
 
     public function testIsBadAuthorEmpty(): void {
-        new TestPage();
         $this->assertFalse(is_bad_author(''));
     }
 
-    // ======================== split_author() ========================
-
     public function testSplitAuthorOneComma(): void {
-        new TestPage();
         $result = split_author('Smith, John');
         $this->assertSame(['Smith', ' John'], $result);
     }
 
     public function testSplitAuthorNoComma(): void {
-        new TestPage();
         $result = split_author('John Smith');
         $this->assertSame([], $result);
     }
 
     public function testSplitAuthorMultipleCommas(): void {
-        new TestPage();
         $result = split_author('Smith, John, Jr');
         $this->assertSame([], $result);
     }
 
-    // ======================== clean_up_full_names() ========================
-
     public function testCleanUpFullNamesAndSemicolon(): void {
-        new TestPage();
         $this->assertSame('name1; name2', clean_up_full_names('name1 and; name2'));
     }
 
     public function testCleanUpFullNamesDoubleSpace(): void {
-        new TestPage();
         $this->assertSame('name1 name2', clean_up_full_names('name1  name2'));
     }
 
     public function testCleanUpFullNamesPlusRemoved(): void {
-        new TestPage();
         $this->assertSame('name1name2', clean_up_full_names('name1+name2'));
     }
 
     public function testCleanUpFullNamesStarRemoved(): void {
-        new TestPage();
         $this->assertSame('name1name2', clean_up_full_names('name1*name2'));
     }
 
-    // ======================== clean_up_first_names() ========================
-
     public function testCleanUpFirstNamesSingleCharGetsDot(): void {
-        new TestPage();
         $this->assertSame('J.', clean_up_first_names('J'));
     }
 
     public function testCleanUpFirstNamesTwoInitialsGetDots(): void {
-        new TestPage();
         $this->assertSame('F. M.', clean_up_first_names('F M'));
     }
 
     public function testCleanUpFirstNamesWordEndingInInitial(): void {
-        new TestPage();
         $this->assertSame('Fred M.', clean_up_first_names('Fred M'));
     }
 
     public function testCleanUpFirstNamesDoubleSpaceCollapsed(): void {
-        new TestPage();
         $this->assertSame('Fred Smith', clean_up_first_names('Fred  Smith'));
     }
 
-    // ======================== format_surname_2() ========================
-
     public function testFormatSurname2UpperToTitleCase(): void {
-        new TestPage();
         $this->assertSame('Smith', format_surname_2('SMITH'));
     }
 
     public function testFormatSurname2VonLowercased(): void {
-        new TestPage();
         $this->assertSame('von Neumann', format_surname_2('VON NEUMANN'));
     }
 
     public function testFormatSurname2DeLaLowercased(): void {
-        new TestPage();
         $this->assertSame('de la Cruz', format_surname_2('DE LA CRUZ'));
     }
 
     public function testFormatSurname2HyphenWithSpaces(): void {
-        new TestPage();
         $this->assertSame('Smith-Jones', format_surname_2('SMITH - JONES'));
     }
 
     public function testFormatSurname2UndLowercased(): void {
-        new TestPage();
         $this->assertSame('Strauss und Torney', format_surname_2('STRAUSS UND TORNEY'));
     }
 }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -977,249 +977,185 @@ final class textToolsTest extends testBaseClass {
         $this->assertSame('eJournal', $expanded->get2('journal'));
     }
 
-    // ======================== de_wikify() ========================
-
     public function testDeWikifyWikilink(): void {
-        new TestPage();
         $this->assertSame('test link', de_wikify('[[test link]]'));
     }
 
     public function testDeWikifyPipedWikilink(): void {
-        new TestPage();
         $this->assertSame('display text', de_wikify('[[target|display text]]'));
     }
 
     public function testDeWikifyBoldMarkup(): void {
-        new TestPage();
         $this->assertSame("'bold'", de_wikify("'''bold'''"));
     }
 
     public function testDeWikifyItalicMarkup(): void {
-        new TestPage();
         $this->assertSame("'italic'", de_wikify("''italic''"));
     }
 
     public function testDeWikifyAmpersandRemoved(): void {
-        new TestPage();
         $this->assertSame('', de_wikify('&'));
     }
 
     public function testDeWikifyPlainText(): void {
-        new TestPage();
         $this->assertSame('plain text', de_wikify('plain text'));
     }
 
-    // ======================== truncate_publisher() ========================
-
     public function testTruncatePublisherGroup(): void {
-        new TestPage();
         $this->assertSame('Penguin', truncate_publisher('Penguin Group'));
     }
 
     public function testTruncatePublisherInc(): void {
-        new TestPage();
         $this->assertSame('Company', truncate_publisher('Company Inc'));
     }
 
     public function testTruncatePublisherIncDot(): void {
-        new TestPage();
         $this->assertSame('Company', truncate_publisher('Company Inc.'));
     }
 
     public function testTruncatePublisherLtd(): void {
-        new TestPage();
         $this->assertSame('Company', truncate_publisher('Company Ltd'));
     }
 
     public function testTruncatePublisherPublishing(): void {
-        new TestPage();
         $this->assertSame('Oxford', truncate_publisher('Oxford Publishing'));
     }
 
     public function testTruncatePublisherNoSuffix(): void {
-        new TestPage();
         $this->assertSame('Random House', truncate_publisher('Random House'));
     }
 
-    // ======================== str_remove_irrelevant_bits() ========================
-
     public function testStrRemoveIrrelevantBitsEmpty(): void {
-        new TestPage();
         $this->assertSame('', str_remove_irrelevant_bits(''));
     }
 
     public function testStrRemoveIrrelevantBitsStripsLeadingThe(): void {
-        new TestPage();
         $result = str_remove_irrelevant_bits('The New York Times');
         $this->assertStringNotContainsString('The ', $result);
     }
 
     public function testStrRemoveIrrelevantBitsAmpersandToAnd(): void {
-        new TestPage();
         $result = str_remove_irrelevant_bits('Smith & Jones');
         $this->assertStringContainsString('and', $result);
     }
 
     public function testStrRemoveIrrelevantBitsWikilink(): void {
-        new TestPage();
         $result = str_remove_irrelevant_bits('[[Nature (journal)|Nature]]');
         $this->assertStringNotContainsString('[[', $result);
         $this->assertStringContainsString('Nature', $result);
     }
 
-    // ======================== mb_strrev() ========================
-
     public function testMbStrrevBasic(): void {
-        new TestPage();
         $this->assertSame('dcba', mb_strrev('abcd'));
     }
 
     public function testMbStrrevEmpty(): void {
-        new TestPage();
         $this->assertSame('', mb_strrev(''));
     }
 
     public function testMbStrrevSingleChar(): void {
-        new TestPage();
         $this->assertSame('a', mb_strrev('a'));
     }
 
     public function testMbStrrevPalindrome(): void {
-        new TestPage();
         $this->assertSame('racecar', mb_strrev('racecar'));
     }
 
-    // ======================== mb_ucwords() ========================
-
     public function testMbUcwordsLowercase(): void {
-        new TestPage();
         $this->assertSame('Hello World', mb_ucwords('hello world'));
     }
 
     public function testMbUcwordsSingleWord(): void {
-        new TestPage();
         $this->assertSame('Hello', mb_ucwords('hello'));
     }
 
     public function testMbUcwordsAlreadyUppercase(): void {
-        new TestPage();
         $this->assertSame('HELLO', mb_ucwords('HELLO'));
     }
 
-    // ======================== can_safely_modify_dashes() ========================
-
     public function testCanSafelyModifyDashesSimpleRange(): void {
-        new TestPage();
         $this->assertTrue(can_safely_modify_dashes('1-10'));
     }
 
     public function testCanSafelyModifyDashesWithHttp(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('http://example.com'));
     }
 
     public function testCanSafelyModifyDashesWithProtocolRelative(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('[//example.com]'));
     }
 
     public function testCanSafelyModifyDashesWithHtmlTag(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('<span>text</span>'));
     }
 
     public function testCanSafelyModifyDashesWithPlaceholder(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('CITATION_BOT_PLACEHOLDER'));
     }
 
     public function testCanSafelyModifyDashesWithParenthesis(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('1-(2)'));
     }
 
     public function testCanSafelyModifyDashesSpacesAndLetters(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('some text'));
     }
 
     public function testCanSafelyModifyDashesThreeOrMoreDashes(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('1-2-3-4'));
     }
 
     public function testCanSafelyModifyDashesAlphaNumericPattern(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('A3-5'));
     }
 
     public function testCanSafelyModifyDashesYearAlpha(): void {
-        new TestPage();
         $this->assertFalse(can_safely_modify_dashes('2005-A'));
     }
 
-    // ======================== doi_encode() ========================
-
     public function testDoiEncodePreservesSlash(): void {
-        new TestPage();
         $this->assertSame('10.1000/test', doi_encode('10.1000/test'));
     }
 
     public function testDoiEncodeEncodesSpace(): void {
-        new TestPage();
         $result = doi_encode('10.1000/test value');
         $this->assertStringNotContainsString(' ', $result);
         $this->assertStringContainsString('10.1000', $result);
     }
 
     public function testDoiEncodeMultipleSlashes(): void {
-        new TestPage();
         $this->assertSame('10.1000/path/to/doi', doi_encode('10.1000/path/to/doi'));
     }
 
-    // ======================== hdl_decode() ========================
-
     public function testHdlDecodeBasicHandle(): void {
-        new TestPage();
         $this->assertSame('2027/test', hdl_decode('2027/test'));
     }
 
     public function testHdlDecodeSemicolonEncoded(): void {
-        new TestPage();
         $this->assertSame('2027/test%3Bvalue', hdl_decode('2027/test;value'));
     }
 
     public function testHdlDecodeHashEncoded(): void {
-        new TestPage();
         $this->assertSame('2027/test%23value', hdl_decode('2027/test#value'));
     }
 
     public function testHdlDecodeSpaceEncoded(): void {
-        new TestPage();
         $this->assertSame('2027/test%20value', hdl_decode('2027/test value'));
     }
 
-    // ======================== safe_preg_replace() ========================
-
     public function testSafePregReplaceEmptyInput(): void {
-        new TestPage();
         $this->assertSame('', safe_preg_replace('~a~', 'b', ''));
     }
 
     public function testSafePregReplaceBasicSubstitution(): void {
-        new TestPage();
         $this->assertSame('hello world', safe_preg_replace('~test~', 'world', 'hello test'));
     }
 
     public function testSafePregReplaceNoMatch(): void {
-        new TestPage();
         $this->assertSame('hello', safe_preg_replace('~zzz~', 'x', 'hello'));
     }
 
-    // ======================== safe_preg_replace_callback() ========================
-
     public function testSafePregReplaceCallbackEmptyInput(): void {
-        new TestPage();
         $result = safe_preg_replace_callback('~a~', static function (array $_m): string {
             return 'b';
         }, '');
@@ -1227,88 +1163,67 @@ final class textToolsTest extends testBaseClass {
     }
 
     public function testSafePregReplaceCallbackDoubles(): void {
-        new TestPage();
         $result = safe_preg_replace_callback('~\d+~', static function (array $m): string {
             return (string) ((int) $m[0] * 2);
         }, 'test 5 here');
         $this->assertSame('test 10 here', $result);
     }
 
-    // ======================== wikifyURL() ========================
-
     public function testWikifyURLEncodesSpace(): void {
-        new TestPage();
         $this->assertSame('http://example.com/my%20page', wikifyURL('http://example.com/my page'));
     }
 
     public function testWikifyURLEncodesDoubleQuote(): void {
-        new TestPage();
         $this->assertSame('http://example.com/%22test%22', wikifyURL('http://example.com/"test"'));
     }
 
     public function testWikifyURLEncodesBrackets(): void {
-        new TestPage();
         $this->assertSame('http://example.com/%5Btest%5D', wikifyURL('http://example.com/[test]'));
     }
 
     public function testWikifyURLEncodesPipe(): void {
-        new TestPage();
         $this->assertSame('http://example.com/%7Ctest', wikifyURL('http://example.com/|test'));
     }
 
     public function testWikifyURLNoChangeNeeded(): void {
-        new TestPage();
         $this->assertSame('http://example.com/test', wikifyURL('http://example.com/test'));
     }
 
-    // ======================== echoable_doi() ========================
-
     public function testEchoableDoiPlain(): void {
-        new TestPage();
         $this->assertSame('10.1000/test', echoable_doi('10.1000/test'));
     }
 
     public function testEchoableDoiRestoresAngleBrackets(): void {
-        new TestPage();
         // echoable_doi reverses the &lt;/&gt; escaping so < and > appear in output
         $result = echoable_doi('10.1000/<test>');
         $this->assertStringContainsString('<test>', $result);
     }
 
-    // ======================== clean_volume() ========================
-
     public function testCleanVolumeStripsVolDot(): void {
-        new TestPage();
         $this->assertSame('5', clean_volume('Vol. 5'));
     }
 
     public function testCleanVolumeStripsVolume(): void {
-        new TestPage();
         $this->assertSame('10', clean_volume('Volume 10'));
     }
 
     public function testCleanVolumeStripsIssue(): void {
-        new TestPage();
         $this->assertSame('3', clean_volume('Issue 3'));
     }
 
     public function testCleanVolumeNumericOnly(): void {
-        new TestPage();
         $this->assertSame('42', clean_volume('42'));
     }
 
     public function testCleanVolumeParenthesisReturnsEmpty(): void {
-        new TestPage();
         $this->assertSame('', clean_volume('5(2)'));
     }
 
     public function testCleanVolumeNovemberReturnsEmpty(): void {
-        new TestPage();
         $this->assertSame('', clean_volume('november'));
     }
 
     public function testCleanVolumeNostradamusReturnsEmpty(): void {
-        new TestPage();
         $this->assertSame('', clean_volume('nostradamus'));
     }
 }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -976,4 +976,335 @@ final class textToolsTest extends testBaseClass {
         $expanded = $this->process_citation("{{Cite journal|journal=ejournal}}");
         $this->assertSame('eJournal', $expanded->get2('journal'));
     }
+
+    // ======================== de_wikify() ========================
+
+    public function testDeWikifyWikilink(): void {
+        new TestPage();
+        $this->assertSame('test link', de_wikify('[[test link]]'));
+    }
+
+    public function testDeWikifyPipedWikilink(): void {
+        new TestPage();
+        $this->assertSame('display text', de_wikify('[[target|display text]]'));
+    }
+
+    public function testDeWikifyBoldMarkup(): void {
+        new TestPage();
+        $this->assertSame("'bold'", de_wikify("'''bold'''"));
+    }
+
+    public function testDeWikifyItalicMarkup(): void {
+        new TestPage();
+        $this->assertSame("'italic'", de_wikify("''italic''"));
+    }
+
+    public function testDeWikifyAmpersandRemoved(): void {
+        new TestPage();
+        $this->assertSame('', de_wikify('&'));
+    }
+
+    public function testDeWikifyPlainText(): void {
+        new TestPage();
+        $this->assertSame('plain text', de_wikify('plain text'));
+    }
+
+    // ======================== truncate_publisher() ========================
+
+    public function testTruncatePublisherGroup(): void {
+        new TestPage();
+        $this->assertSame('Penguin', truncate_publisher('Penguin Group'));
+    }
+
+    public function testTruncatePublisherInc(): void {
+        new TestPage();
+        $this->assertSame('Company', truncate_publisher('Company Inc'));
+    }
+
+    public function testTruncatePublisherIncDot(): void {
+        new TestPage();
+        $this->assertSame('Company', truncate_publisher('Company Inc.'));
+    }
+
+    public function testTruncatePublisherLtd(): void {
+        new TestPage();
+        $this->assertSame('Company', truncate_publisher('Company Ltd'));
+    }
+
+    public function testTruncatePublisherPublishing(): void {
+        new TestPage();
+        $this->assertSame('Oxford', truncate_publisher('Oxford Publishing'));
+    }
+
+    public function testTruncatePublisherNoSuffix(): void {
+        new TestPage();
+        $this->assertSame('Random House', truncate_publisher('Random House'));
+    }
+
+    // ======================== str_remove_irrelevant_bits() ========================
+
+    public function testStrRemoveIrrelevantBitsEmpty(): void {
+        new TestPage();
+        $this->assertSame('', str_remove_irrelevant_bits(''));
+    }
+
+    public function testStrRemoveIrrelevantBitsStripsLeadingThe(): void {
+        new TestPage();
+        $result = str_remove_irrelevant_bits('The New York Times');
+        $this->assertStringNotContainsString('The ', $result);
+    }
+
+    public function testStrRemoveIrrelevantBitsAmpersandToAnd(): void {
+        new TestPage();
+        $result = str_remove_irrelevant_bits('Smith & Jones');
+        $this->assertStringContainsString('and', $result);
+    }
+
+    public function testStrRemoveIrrelevantBitsWikilink(): void {
+        new TestPage();
+        $result = str_remove_irrelevant_bits('[[Nature (journal)|Nature]]');
+        $this->assertStringNotContainsString('[[', $result);
+        $this->assertStringContainsString('Nature', $result);
+    }
+
+    // ======================== mb_strrev() ========================
+
+    public function testMbStrrevBasic(): void {
+        new TestPage();
+        $this->assertSame('dcba', mb_strrev('abcd'));
+    }
+
+    public function testMbStrrevEmpty(): void {
+        new TestPage();
+        $this->assertSame('', mb_strrev(''));
+    }
+
+    public function testMbStrrevSingleChar(): void {
+        new TestPage();
+        $this->assertSame('a', mb_strrev('a'));
+    }
+
+    public function testMbStrrevPalindrome(): void {
+        new TestPage();
+        $this->assertSame('racecar', mb_strrev('racecar'));
+    }
+
+    // ======================== mb_ucwords() ========================
+
+    public function testMbUcwordsLowercase(): void {
+        new TestPage();
+        $this->assertSame('Hello World', mb_ucwords('hello world'));
+    }
+
+    public function testMbUcwordsSingleWord(): void {
+        new TestPage();
+        $this->assertSame('Hello', mb_ucwords('hello'));
+    }
+
+    public function testMbUcwordsAlreadyUppercase(): void {
+        new TestPage();
+        $this->assertSame('HELLO', mb_ucwords('HELLO'));
+    }
+
+    // ======================== can_safely_modify_dashes() ========================
+
+    public function testCanSafelyModifyDashesSimpleRange(): void {
+        new TestPage();
+        $this->assertTrue(can_safely_modify_dashes('1-10'));
+    }
+
+    public function testCanSafelyModifyDashesWithHttp(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('http://example.com'));
+    }
+
+    public function testCanSafelyModifyDashesWithProtocolRelative(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('[//example.com]'));
+    }
+
+    public function testCanSafelyModifyDashesWithHtmlTag(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('<span>text</span>'));
+    }
+
+    public function testCanSafelyModifyDashesWithPlaceholder(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('CITATION_BOT_PLACEHOLDER'));
+    }
+
+    public function testCanSafelyModifyDashesWithParenthesis(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('1-(2)'));
+    }
+
+    public function testCanSafelyModifyDashesSpacesAndLetters(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('some text'));
+    }
+
+    public function testCanSafelyModifyDashesThreeOrMoreDashes(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('1-2-3-4'));
+    }
+
+    public function testCanSafelyModifyDashesAlphaNumericPattern(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('A3-5'));
+    }
+
+    public function testCanSafelyModifyDashesYearAlpha(): void {
+        new TestPage();
+        $this->assertFalse(can_safely_modify_dashes('2005-A'));
+    }
+
+    // ======================== doi_encode() ========================
+
+    public function testDoiEncodePreservesSlash(): void {
+        new TestPage();
+        $this->assertSame('10.1000/test', doi_encode('10.1000/test'));
+    }
+
+    public function testDoiEncodeEncodesSpace(): void {
+        new TestPage();
+        $result = doi_encode('10.1000/test value');
+        $this->assertStringNotContainsString(' ', $result);
+        $this->assertStringContainsString('10.1000', $result);
+    }
+
+    public function testDoiEncodeMultipleSlashes(): void {
+        new TestPage();
+        $this->assertSame('10.1000/path/to/doi', doi_encode('10.1000/path/to/doi'));
+    }
+
+    // ======================== hdl_decode() ========================
+
+    public function testHdlDecodeBasicHandle(): void {
+        new TestPage();
+        $this->assertSame('2027/test', hdl_decode('2027/test'));
+    }
+
+    public function testHdlDecodeSemicolonEncoded(): void {
+        new TestPage();
+        $this->assertSame('2027/test%3Bvalue', hdl_decode('2027/test;value'));
+    }
+
+    public function testHdlDecodeHashEncoded(): void {
+        new TestPage();
+        $this->assertSame('2027/test%23value', hdl_decode('2027/test#value'));
+    }
+
+    public function testHdlDecodeSpaceEncoded(): void {
+        new TestPage();
+        $this->assertSame('2027/test%20value', hdl_decode('2027/test value'));
+    }
+
+    // ======================== safe_preg_replace() ========================
+
+    public function testSafePregReplaceEmptyInput(): void {
+        new TestPage();
+        $this->assertSame('', safe_preg_replace('~a~', 'b', ''));
+    }
+
+    public function testSafePregReplaceBasicSubstitution(): void {
+        new TestPage();
+        $this->assertSame('hello world', safe_preg_replace('~test~', 'world', 'hello test'));
+    }
+
+    public function testSafePregReplaceNoMatch(): void {
+        new TestPage();
+        $this->assertSame('hello', safe_preg_replace('~zzz~', 'x', 'hello'));
+    }
+
+    // ======================== safe_preg_replace_callback() ========================
+
+    public function testSafePregReplaceCallbackEmptyInput(): void {
+        new TestPage();
+        $result = safe_preg_replace_callback('~a~', static function (array $m): string { return 'b'; }, '');
+        $this->assertSame('', $result);
+    }
+
+    public function testSafePregReplaceCallbackDoubles(): void {
+        new TestPage();
+        $result = safe_preg_replace_callback('~\d+~', static function (array $m): string { return (string) ((int) $m[0] * 2); }, 'test 5 here');
+        $this->assertSame('test 10 here', $result);
+    }
+
+    // ======================== wikifyURL() ========================
+
+    public function testWikifyURLEncodesSpace(): void {
+        new TestPage();
+        $this->assertSame('http://example.com/my%20page', wikifyURL('http://example.com/my page'));
+    }
+
+    public function testWikifyURLEncodesDoubleQuote(): void {
+        new TestPage();
+        $this->assertSame('http://example.com/%22test%22', wikifyURL('http://example.com/"test"'));
+    }
+
+    public function testWikifyURLEncodesBrackets(): void {
+        new TestPage();
+        $this->assertSame('http://example.com/%5Btest%5D', wikifyURL('http://example.com/[test]'));
+    }
+
+    public function testWikifyURLEncodesPipe(): void {
+        new TestPage();
+        $this->assertSame('http://example.com/%7Ctest', wikifyURL('http://example.com/|test'));
+    }
+
+    public function testWikifyURLNoChangeNeeded(): void {
+        new TestPage();
+        $this->assertSame('http://example.com/test', wikifyURL('http://example.com/test'));
+    }
+
+    // ======================== echoable_doi() ========================
+
+    public function testEchoableDoiPlain(): void {
+        new TestPage();
+        $this->assertSame('10.1000/test', echoable_doi('10.1000/test'));
+    }
+
+    public function testEchoableDoiRestoresAngleBrackets(): void {
+        new TestPage();
+        // echoable_doi reverses the &lt;/&gt; escaping so < and > appear in output
+        $result = echoable_doi('10.1000/<test>');
+        $this->assertStringContainsString('<test>', $result);
+    }
+
+    // ======================== clean_volume() ========================
+
+    public function testCleanVolumeStripsVolDot(): void {
+        new TestPage();
+        $this->assertSame('5', clean_volume('Vol. 5'));
+    }
+
+    public function testCleanVolumeStripsVolume(): void {
+        new TestPage();
+        $this->assertSame('10', clean_volume('Volume 10'));
+    }
+
+    public function testCleanVolumeStripsIssue(): void {
+        new TestPage();
+        $this->assertSame('3', clean_volume('Issue 3'));
+    }
+
+    public function testCleanVolumeNumericOnly(): void {
+        new TestPage();
+        $this->assertSame('42', clean_volume('42'));
+    }
+
+    public function testCleanVolumeParenthesisReturnsEmpty(): void {
+        new TestPage();
+        $this->assertSame('', clean_volume('5(2)'));
+    }
+
+    public function testCleanVolumeNovemberReturnsEmpty(): void {
+        new TestPage();
+        $this->assertSame('', clean_volume('november'));
+    }
+
+    public function testCleanVolumeNostradamusReturnsEmpty(): void {
+        new TestPage();
+        $this->assertSame('', clean_volume('nostradamus'));
+    }
 }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1220,13 +1220,17 @@ final class textToolsTest extends testBaseClass {
 
     public function testSafePregReplaceCallbackEmptyInput(): void {
         new TestPage();
-        $result = safe_preg_replace_callback('~a~', static function (array $m): string { return 'b'; }, '');
+        $result = safe_preg_replace_callback('~a~', static function (array $_m): string {
+            return 'b';
+        }, '');
         $this->assertSame('', $result);
     }
 
     public function testSafePregReplaceCallbackDoubles(): void {
         new TestPage();
-        $result = safe_preg_replace_callback('~\d+~', static function (array $m): string { return (string) ((int) $m[0] * 2); }, 'test 5 here');
+        $result = safe_preg_replace_callback('~\d+~', static function (array $m): string {
+            return (string) ((int) $m[0] * 2);
+        }, 'test 5 here');
         $this->assertSame('test 10 here', $result);
     }
 


### PR DESCRIPTION
This pull request adds comprehensive new PHPUnit test coverage for several utility and helper modules. The primary focus is on verifying correct behavior for functions related to cURL handling, user messaging, wiki markup parsing, parameter equivalence, and author name processing. The new tests are structured to cover a wide range of input scenarios and edge cases, improving the reliability and maintainability of the codebase.

**New test coverage:**

*Bot cURL utilities:*
- Added `BotCurlTest` to test `curl_limit_page_size` and `bot_curl_init`, including edge cases for payload sizes and various initialization parameters.

*User messaging and link generation:*
- Added `UserMessagesTest` to verify correct output from functions like `echoable`, `pubmed_link`, `bibcode_link`, `doi_link`, `jstor_link`, `wiki_link`, and various reporting functions, as well as HTML suppression in CI mode.

*Wiki markup element parsing:*
- Added `WikiThingsTest` to test parsing and placeholder handling for elements such as comments, nowiki, chemistry, mathematics, music scores, preformatted text, and bracketed expressions, including regular expression matching and overwrite behavior.

**Enhancements to existing test suites:**

*Parameter equivalence and citation logic:*
- Expanded `MiscToolsTest` with tests for `equivalent_parameters` (various parameter groups), `string_is_book_series`, `should_url2chapter`, and `run_type_mods`, improving coverage for citation processing logic.

*Author name and formatting utilities:*
- Expanded `nameToolsTest` with tests for `author_is_human`, `under_two_authors`, `is_bad_author`, `split_author`, and various name cleanup and formatting functions, covering both normal and edge-case inputs.