### PR TITLE
Implement skip for testBioRxivToJournalConversionWorks when API is not available + ground work for others

### DIFF
--- a/src/includes/api/APIdoi.php
+++ b/src/includes/api/APIdoi.php
@@ -635,9 +635,16 @@ function get_doi_from_crossref(Template $template): void {
  *
  * @param string $doi DOI (10.1101/* or 10.64898/*)
  * @param string $server Server type: 'biorxiv' or 'medrxiv' (default: 'biorxiv')
+ * @param string|null $api_status API status message (if present)
  * @return string|null Published DOI or null
  */
-function get_biorxiv_published_doi(string $doi, string $server = 'biorxiv'): ?string {
+function get_biorxiv_published_doi(
+    string $doi,
+    string $server = 'biorxiv',
+    ?string &$api_status = null
+): ?string {
+    $api_status = null;
+
     if (mb_strpos($doi, '10.1101/') !== 0 && mb_strpos($doi, '10.64898/') !== 0) {
         return null;
     }
@@ -666,6 +673,17 @@ function get_biorxiv_published_doi(string $doi, string $server = 'biorxiv'): ?st
 
     if (!is_object($data)) {
         return null;
+    }
+    if (isset($data->messages) &&
+        is_array($data->messages) &&
+        count($data->messages) > 0 &&
+        is_object($data->messages[0]) &&
+        isset($data->messages[0]->status)
+    ) {
+        $status = mb_trim((string) $data->messages[0]->status);
+        if ($status !== '') {
+            $api_status = $status;
+        }
     }
 
     if (isset($data->collection) && is_array($data->collection) && count($data->collection) > 0) {

--- a/src/includes/api/APIdoi.php
+++ b/src/includes/api/APIdoi.php
@@ -635,7 +635,7 @@ function get_doi_from_crossref(Template $template): void {
  *
  * @param string $doi DOI (10.1101/* or 10.64898/*)
  * @param string $server Server type: 'biorxiv' or 'medrxiv' (default: 'biorxiv')
- * @param string|null $api_status API status message (if present)
+ * @param string|null &$api_status API status message (if present)
  * @return string|null Published DOI or null
  */
 function get_biorxiv_published_doi(

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1866,29 +1866,13 @@ EP - 999 }}';
         // This is a verified conversion (Kutanan et al. 2016) from bioRxiv API
         $biorxiv_doi = '10.1101/063172';
         $expected_published_doi = '10.1007/s00439-016-1742-y';
+        $api_status = null;
 
-        $published_doi = get_biorxiv_published_doi($biorxiv_doi);
-        if ($published_doi === null) {
-            $url = "https://api.biorxiv.org/details/biorxiv/$biorxiv_doi/na/json";
-            $ch = bot_curl_init(1.0, [CURLOPT_USERAGENT => BOT_CROSSREF_USER_AGENT]);
-            curl_setopt($ch, CURLOPT_URL, $url);
-            $json = bot_curl_exec($ch);
-            $decoded = @json_decode($json);
-            $status = null;
-            if (is_object($decoded) &&
-                isset($decoded->messages) &&
-                is_array($decoded->messages) &&
-                count($decoded->messages) > 0 &&
-                is_object($decoded->messages[0]) &&
-                isset($decoded->messages[0]->status)
-            ) {
-                $status = mb_trim((string) $decoded->messages[0]->status);
-            }
-            if ($status === 'Not available at this time') {
-                $this->markTestSkipped(
-                    "bioRxiv API temporarily unavailable for DOI $biorxiv_doi: $status"
-                );
-            }
+        $published_doi = get_biorxiv_published_doi($biorxiv_doi, 'biorxiv', $api_status);
+        if ($published_doi === null && $api_status === 'Not available at this time') {
+            $this->markTestSkipped(
+                "bioRxiv API temporarily unavailable for DOI $biorxiv_doi: $api_status"
+            );
         }
 
         $this->assertNotNull(

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1868,6 +1868,28 @@ EP - 999 }}';
         $expected_published_doi = '10.1007/s00439-016-1742-y';
 
         $published_doi = get_biorxiv_published_doi($biorxiv_doi);
+        if ($published_doi === null) {
+            $url = "https://api.biorxiv.org/details/biorxiv/$biorxiv_doi/na/json";
+            $ch = bot_curl_init(1.0, [CURLOPT_USERAGENT => BOT_CROSSREF_USER_AGENT]);
+            curl_setopt($ch, CURLOPT_URL, $url);
+            $json = bot_curl_exec($ch);
+            $decoded = @json_decode($json);
+            $status = null;
+            if (is_object($decoded) &&
+                isset($decoded->messages) &&
+                is_array($decoded->messages) &&
+                count($decoded->messages) > 0 &&
+                is_object($decoded->messages[0]) &&
+                isset($decoded->messages[0]->status)
+            ) {
+                $status = mb_trim((string) $decoded->messages[0]->status);
+            }
+            if ($status === 'Not available at this time') {
+                $this->markTestSkipped(
+                    "bioRxiv API temporarily unavailable for DOI $biorxiv_doi: $status"
+                );
+            }
+        }
 
         $this->assertNotNull(
             $published_doi,


### PR DESCRIPTION
This pull request enhances the handling of bioRxiv API responses by allowing the API status message to be captured and acted upon. The most significant changes involve updating the `get_biorxiv_published_doi` function to accept and populate an API status reference, and modifying the related test to skip when the API is temporarily unavailable.

**Improvements to API response handling:**

* The `get_biorxiv_published_doi` function now accepts an optional reference parameter (`$api_status`) to capture API status messages, enabling better error handling and diagnostics.
* The function inspects the API response for a status message and assigns it to `$api_status` if present, allowing calling code to react appropriately to API issues.

**Testing enhancements:**

* The `testBioRxivToJournalConversionWorks` test now passes the `$api_status` reference to `get_biorxiv_published_doi` and skips the test if the API reports it is temporarily unavailable, preventing false negatives due to external service outages.