### PR TITLE
Implement end-of-run stats and move auth hint to footer

### DIFF
--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -33,8 +33,8 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
 
     $page = new Page();
     $done = 0;
-    $pages_changed = 0;
-    $pages_unchanged = 0;
+    $pages_changed = 0;   // Pages where expand_text() returned true, meaning text was actually modified
+    $pages_unchanged = 0; // Pages where no edit was made: no changes needed, blank, protected, redirect, etc.
 
     foreach ($pages_in_category as $page_title) {
         flush(); // Only call to flush in normal code, since calling flush breaks headers and sessions

--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -33,12 +33,15 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
 
     $page = new Page();
     $done = 0;
+    $pages_changed = 0;
+    $pages_unchanged = 0;
 
     foreach ($pages_in_category as $page_title) {
         flush(); // Only call to flush in normal code, since calling flush breaks headers and sessions
         big_jobs_check_killed();
         $done++;
         if (mb_strpos($page_title, 'Wikipedia:Requests') === false && $page->get_text_from($page_title) && $page->expand_text()) {
+            $pages_changed++;
             if (SAVETOFILES_MODE) {
                 // Sanitize file name by replacing characters that are not allowed on most file systems to underscores, and also replace path characters
                 // And add .md extension to avoid troubles with devices such as 'con' or 'aux'
@@ -80,6 +83,7 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
                 }
             }
         } else {
+            $pages_unchanged++;
             report_phase($page->parsed_text() ? "No changes required. \n\n      # # # " : "Blank page. \n\n      # # # ");
                 $final_edit_overview .= "\n No changes needed. " . "<a href=" . WIKI_ROOT . "?title=" . urlencode($page_title) . ">" . echoable($page_title) . "</a>";
         }
@@ -93,7 +97,7 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
         if (!HTML_OUTPUT) {
             $final_edit_overview = '';
         }
-        echo "\n Done all " . (string) $total . " pages. \n  # # # \n" . $final_edit_overview;
+        echo "\n Done all " . (string) $total . " pages: " . (string) $pages_changed . " changed, " . (string) $pages_unchanged . " unchanged. \n  # # # \n" . $final_edit_overview;
     } else {
         echo "\n Done with page.";
     }

--- a/src/index.html
+++ b/src/index.html
@@ -60,9 +60,6 @@
         <option value="mdwiki">&nbsp;MDWiki.org</option>
       </select>
     </p>
-    <p>
-      Note: You will be asked to log in to your Wikipedia account if you have not already authorized this tool.
-    </p>
   </form>
   </main>
   <footer>
@@ -80,7 +77,8 @@
       &nbsp;<a href="https://mdwiki.org/wiki/Special:Contributions/Citation_bot" target="_blank" rel="noopener noreferrer" title="Recent mdwiki contributions" aria-label="Recent mdwiki contributions (opens in a new tab)" >mdwiki</a>
     </p>
     <p>
-    Your Wikipedia username will be included in the edit, such as: "Suggested&nbsp;by&nbsp;YourUserID"
+    Your Wikipedia username will be included in the edit, such as: "Suggested&nbsp;by&nbsp;YourUserID".
+    You will be asked to log in to your Wikipedia account if you have not already authorized this tool.
     </p>
   </footer>
  </body>

--- a/src/index.html
+++ b/src/index.html
@@ -60,6 +60,9 @@
         <option value="mdwiki">&nbsp;MDWiki.org</option>
       </select>
     </p>
+    <p>
+      Note: You will be asked to log in to your Wikipedia account if you have not already authorized this tool.
+    </p>
   </form>
   </main>
   <footer>


### PR DESCRIPTION
This pull request adds tracking of how many pages were actually changed versus left unchanged during batch page edits, and improves user messaging about Wikipedia login requirements.

### Batch page edit tracking improvements

* Added counters `pages_changed` and `pages_unchanged` in `edit_a_list_of_pages` (in `WebTools.php`) to track how many pages were modified versus skipped for reasons such as no changes needed, blank, protected, or redirect pages. [[1]](diffhunk://#diff-a5dfc0292478d3d0d3bf87e2a3e533b89341b7e6ee6fcbee76982cdc08a097a1R36-R44) [[2]](diffhunk://#diff-a5dfc0292478d3d0d3bf87e2a3e533b89341b7e6ee6fcbee76982cdc08a097a1R86)
* Updated the completion message to display the total number of pages processed, how many were changed, and how many were unchanged.

### User messaging

* Improved the instructions in `index.html` to clarify that users will be prompted to log in to Wikipedia if they have not already authorized the tool.