### PR TITLE
Fix intermittent testDoi2PMID test failure and clean up annotations causing PHPStan error

### DIFF
--- a/src/includes/doiTools.php
+++ b/src/includes/doiTools.php
@@ -268,7 +268,6 @@ function is_doi_works(string $doi): ?bool {
     // Got 404 - try again, since we cache this and add doi-broken-date to pages, we should be double sure
     $headers_test = get_headers_array($url);
     /** We trust previous failure, so fail and null are both false */
-    /** @phpstan-ignore identical.alwaysFalse */
     if ($headers_test === false) {
         return false;
     }

--- a/tests/phpunit/includes/api/pubmedTest.php
+++ b/tests/phpunit/includes/api/pubmedTest.php
@@ -79,6 +79,13 @@ final class pubmedTest extends testBaseClass {
         if ($expanded->get2('pmid') === null && $expanded->get2('pmc') === null) {
             $this->markTestSkipped('PubMed API did not respond (rate limit or outage)');
         }
+        if ($expanded->get2('pmc') === null) {
+            sleep(run_type_mods(-1, 5, 3, 2, 2));
+            $expanded = $this->process_citation($text);
+        }
+        if ($expanded->get2('pmc') === null) {
+            $this->markTestSkipped('PubMed PMC API did not respond (rate limit or outage)');
+        }
         $this->assertSame('11573006', $expanded->get2('pmid'));
         $this->assertSame('58796', $expanded->get2('pmc'));
     }


### PR DESCRIPTION
This pull request includes minor improvements to error handling and test reliability for DOI and PubMed API interactions.

Test reliability improvements:

* [`tests/phpunit/includes/api/pubmedTest.php`](diffhunk://#diff-667b159ebc81eaf37497de37e779010131991999f1c17bba41c9328c4e91aa4fR82-R88): Added additional retry logic and conditional skipping for cases where the PubMed Central (PMC) API does not respond, making the test more robust against transient API issues.

Code cleanup:

* [`src/includes/doiTools.php`](diffhunk://#diff-0a1a2606adb2934dba2800cafc2e5082ec1258094125e84659573b0b398b0f9aL271): Removed an unnecessary PHPStan ignore comment related to always-false conditions, improving code clarity.