### PR TITLE
Add data-driven conditional free-DOI tagging based on publication date

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -4212,27 +4212,9 @@ final class Template
                             $this->add_if_new('doi-access', 'free');
                         }
                     }
-                    // Weird ones that are time dependent
-                    $year = $this->year_int(); // Will be zero if not set
-                    if (mb_strpos($doi, '10.1155/') === 0 && $year > 2006) {
-                        $this->add_if_new('doi-access', 'free');
-                    }
-                    unset($year);
+                    // Time-dependent access rules (see DOI_FREE_CONDITIONAL in free_doi.php)
+                    $this->doi_free_check_conditional($doi);
                     /** } */
-                    if (/** doi_works($doi) && */ mb_strpos($doi, '10.1073/pnas') === 0) {
-                        $template_year = $this->year();
-                        if ($template_year === '') {
-                            $template_year = $this->get('publication-date');
-                        }
-                        if ($template_year !== '') {
-                            $template_year = (int) $template_year;
-                            $year = (int) date("Y");
-                            if ($template_year + 1 < $year) {
-                                // At least one year old, up to three
-                                $this->add_if_new('doi-access', 'free');
-                            }
-                        }
-                    }
                     if (preg_match('~^10\.48550/arXiv\.(\S{4}\.\S{5})$~i', $doi, $matches)) {
                         if ($this->blank(ARXIV_ALIASES)) {
                             $this->rename('doi', 'eprint', $matches[1]);
@@ -6768,6 +6750,101 @@ final class Template
 
     private function year_int(): int {
         return intval($this->year());
+    }
+
+    /**
+     * Returns the publication year from date / year / publication-date fields, or 0 if unavailable.
+     * Extends year_int() by also consulting the publication-date field as a fallback.
+     */
+    private function pub_year_extended(): int {
+        $year = $this->year_int();
+        if ($year > 0) {
+            return $year;
+        }
+        if ($this->has('publication-date')) {
+            if (preg_match('~(\d{4})~', $this->get('publication-date'), $matches)) {
+                return (int) $matches[1];
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Returns a Unix timestamp for the publication date only when month-level information is
+     * available in the date or publication-date fields.
+     * Returns null when only a year is known or when no date can be determined at all.
+     * Pure year strings (e.g. "2023") are explicitly skipped so callers can apply their own
+     * conservative year-level fallback if needed.
+     */
+    private function pub_exact_ts(): ?int {
+        foreach (['date', 'publication-date'] as $field) {
+            if ($this->has($field)) {
+                $date_val = $this->get($field);
+                if (preg_match('~^\d{4}$~', $date_val)) {
+                    continue; // Year-only string; no month available
+                }
+                $time = strtotime($date_val);
+                if ($time !== false && $time > 0) {
+                    return $time;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Evaluates all DOI_FREE_CONDITIONAL rules for the given DOI and calls add_if_new('doi-access', 'free')
+     * when the publication date satisfies the rule's condition.
+     * Called from tidy_parameter('doi') immediately after the unconditional DOI_FREE_PREFIX loop.
+     *
+     * Supported types (see free_doi.php for full documentation):
+     *   AFTER_YEAR    - free if pub year >  (int) value
+     *   FROM_YEAR     - free if pub year >= (int) value
+     *   EMBARGO_YEARS - free if pub year + (int) value < current year
+     *   EMBARGO_MONTHS - free if pub date + (int) value months <= now
+     *                   (uses end-of-year as conservative fallback when only year is known)
+     */
+    private function doi_free_check_conditional(string $doi): void {
+        foreach (DOI_FREE_CONDITIONAL as $rule) {
+            if (mb_stripos($doi, $rule['prefix']) !== 0) {
+                continue;
+            }
+            $rule_type  = $rule['type'];
+            $rule_value = $rule['value'];
+            if ($rule_type === 'AFTER_YEAR') {
+                $pub_year = $this->pub_year_extended();
+                if ($pub_year > 0 && $pub_year > (int) $rule_value) {
+                    $this->add_if_new('doi-access', 'free');
+                }
+            } elseif ($rule_type === 'FROM_YEAR') {
+                $pub_year = $this->pub_year_extended();
+                if ($pub_year > 0 && $pub_year >= (int) $rule_value) {
+                    $this->add_if_new('doi-access', 'free');
+                }
+            } elseif ($rule_type === 'EMBARGO_YEARS') {
+                $pub_year = $this->pub_year_extended();
+                if ($pub_year > 0 && ($pub_year + (int) $rule_value) < (int) date('Y')) {
+                    $this->add_if_new('doi-access', 'free');
+                }
+            } elseif ($rule_type === 'EMBARGO_MONTHS') {
+                $pub_ts = $this->pub_exact_ts();
+                if ($pub_ts === null) {
+                    // No month available: fall back to end-of-year (conservative — the article
+                    // could have been published as late as 31 Dec of the known year, so the embargo
+                    // is assumed to expire no earlier than 31 Dec + N months).
+                    $pub_year = $this->pub_year_extended();
+                    if ($pub_year > 1000) {
+                        $pub_ts = mktime(0, 0, 0, 12, 31, $pub_year);
+                    }
+                }
+                if ($pub_ts !== null) {
+                    $free_after_ts = strtotime('+' . (int) $rule_value . ' months', $pub_ts);
+                    if ($free_after_ts !== false && time() >= $free_after_ts) {
+                        $this->add_if_new('doi-access', 'free');
+                    }
+                }
+            }
+        }
     }
 
     /** @return array<string> */

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -6752,10 +6752,7 @@ final class Template
         return intval($this->year());
     }
 
-    /**
-     * Returns the publication year from date / year / publication-date fields, or 0 if unavailable.
-     * Extends year_int() by also consulting the publication-date field as a fallback.
-     */
+    /** Returns pub year from year/date/publication-date fields, or 0. */
     private function pub_year_extended(): int {
         $year = $this->year_int();
         if ($year > 0) {
@@ -6769,19 +6766,13 @@ final class Template
         return 0;
     }
 
-    /**
-     * Returns a Unix timestamp for the publication date only when month-level information is
-     * available in the date or publication-date fields.
-     * Returns null when only a year is known or when no date can be determined at all.
-     * Pure year strings (e.g. "2023") are explicitly skipped so callers can apply their own
-     * conservative year-level fallback if needed.
-     */
+    /** Returns Unix timestamp when month-level date info is available; null for year-only or missing dates. */
     private function pub_exact_ts(): ?int {
         foreach (['date', 'publication-date'] as $field) {
             if ($this->has($field)) {
                 $date_val = $this->get($field);
                 if (preg_match('~^\d{4}$~', $date_val)) {
-                    continue; // Year-only string; no month available
+                    continue; // Year-only; no month available
                 }
                 $time = strtotime($date_val);
                 if ($time !== false && $time > 0) {
@@ -6792,18 +6783,7 @@ final class Template
         return null;
     }
 
-    /**
-     * Evaluates all DOI_FREE_CONDITIONAL rules for the given DOI and calls add_if_new('doi-access', 'free')
-     * when the publication date satisfies the rule's condition.
-     * Called from tidy_parameter('doi') immediately after the unconditional DOI_FREE_PREFIX loop.
-     *
-     * Supported types (see free_doi.php for full documentation):
-     *   AFTER_YEAR    - free if pub year >  (int) value
-     *   FROM_YEAR     - free if pub year >= (int) value
-     *   EMBARGO_YEARS - free if pub year + (int) value < current year
-     *   EMBARGO_MONTHS - free if pub date + (int) value months <= now
-     *                   (uses end-of-year as conservative fallback when only year is known)
-     */
+    /** Applies DOI_FREE_CONDITIONAL rules; tags doi-access=free when pub date satisfies the rule. */
     private function doi_free_check_conditional(string $doi): void {
         foreach (DOI_FREE_CONDITIONAL as $rule) {
             if (mb_stripos($doi, $rule['prefix']) !== 0) { // Case-insensitive, consistent with DOI_FREE_PREFIX loop above
@@ -6829,11 +6809,9 @@ final class Template
             } elseif ($rule_type === 'EMBARGO_MONTHS') {
                 $pub_ts = $this->pub_exact_ts();
                 if ($pub_ts === null) {
-                    // No month available: fall back to end-of-year (conservative — the article
-                    // could have been published as late as 31 Dec of the known year, so the embargo
-                    // is assumed to expire no earlier than 31 Dec + N months).
+                    // Fall back to Dec 31 of the known year (conservative: embargo expires latest possible)
                     $pub_year = $this->pub_year_extended();
-                    if ($pub_year > 1000) { // Sanity-check: publication year must be plausible (> year 1000)
+                    if ($pub_year > 1000) { // Sanity-check: must be a plausible year
                         $pub_ts = mktime(0, 0, 0, 12, 31, $pub_year);
                     }
                 }

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -6786,7 +6786,7 @@ final class Template
     /** Applies DOI_FREE_CONDITIONAL rules; tags doi-access=free when pub date satisfies the rule. */
     private function doi_free_check_conditional(string $doi): void {
         foreach (DOI_FREE_CONDITIONAL as $rule) {
-            if (mb_stripos($doi, $rule['prefix']) !== 0) { // Case-insensitive, consistent with DOI_FREE_PREFIX loop above
+            if (mb_stripos($doi, $rule['prefix']) !== 0) {
                 continue;
             }
             $rule_type  = $rule['type'];
@@ -6799,14 +6799,14 @@ final class Template
             } elseif ($rule_type === 'EMBARGO_MONTHS') {
                 $pub_ts = $this->pub_exact_ts();
                 if ($pub_ts === null) {
-                    // Fall back to Dec 31 of the known year (conservative: embargo expires latest possible)
+                    // Dec 31: conservative year-only fallback
                     $pub_year = $this->pub_year_extended();
                     if ($pub_year > 1000) { // Sanity-check: must be a plausible year
                         $pub_ts = mktime(0, 0, 0, 12, 31, $pub_year);
                     }
                 }
                 if ($pub_ts !== null) {
-                    // Advance to end of the publication month for safety (e.g. "January 2010" → Jan 31)
+                    // end of month for safety
                     $pub_ts = mktime(0, 0, 0, (int) date('n', $pub_ts), (int) date('t', $pub_ts), (int) date('Y', $pub_ts));
                     $free_after_ts = strtotime('+' . (int) $rule_value . ' months', $pub_ts);
                     if (time() >= $free_after_ts) {

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -6817,7 +6817,7 @@ final class Template
                 }
                 if ($pub_ts !== null) {
                     $free_after_ts = strtotime('+' . (int) $rule_value . ' months', $pub_ts);
-                    if ($free_after_ts !== false && time() >= $free_after_ts) {
+                    if (time() >= $free_after_ts) {
                         $this->add_if_new('doi-access', 'free');
                     }
                 }

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -6806,7 +6806,7 @@ final class Template
      */
     private function doi_free_check_conditional(string $doi): void {
         foreach (DOI_FREE_CONDITIONAL as $rule) {
-            if (mb_stripos($doi, $rule['prefix']) !== 0) {
+            if (mb_stripos($doi, $rule['prefix']) !== 0) { // Case-insensitive, consistent with DOI_FREE_PREFIX loop above
                 continue;
             }
             $rule_type  = $rule['type'];
@@ -6833,7 +6833,7 @@ final class Template
                     // could have been published as late as 31 Dec of the known year, so the embargo
                     // is assumed to expire no earlier than 31 Dec + N months).
                     $pub_year = $this->pub_year_extended();
-                    if ($pub_year > 1000) {
+                    if ($pub_year > 1000) { // Sanity-check: publication year must be plausible (> year 1000)
                         $pub_ts = mktime(0, 0, 0, 12, 31, $pub_year);
                     }
                 }

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -6816,6 +6816,8 @@ final class Template
                     }
                 }
                 if ($pub_ts !== null) {
+                    // Advance to end of the publication month for safety (e.g. "January 2010" → Jan 31)
+                    $pub_ts = mktime(0, 0, 0, (int) date('n', $pub_ts), (int) date('t', $pub_ts), (int) date('Y', $pub_ts));
                     $free_after_ts = strtotime('+' . (int) $rule_value . ' months', $pub_ts);
                     if (time() >= $free_after_ts) {
                         $this->add_if_new('doi-access', 'free');

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -6796,16 +6796,6 @@ final class Template
                 if ($pub_year > 0 && $pub_year > (int) $rule_value) {
                     $this->add_if_new('doi-access', 'free');
                 }
-            } elseif ($rule_type === 'FROM_YEAR') {
-                $pub_year = $this->pub_year_extended();
-                if ($pub_year > 0 && $pub_year >= (int) $rule_value) {
-                    $this->add_if_new('doi-access', 'free');
-                }
-            } elseif ($rule_type === 'EMBARGO_YEARS') {
-                $pub_year = $this->pub_year_extended();
-                if ($pub_year > 0 && ($pub_year + (int) $rule_value) < (int) date('Y')) {
-                    $this->add_if_new('doi-access', 'free');
-                }
             } elseif ($rule_type === 'EMBARGO_MONTHS') {
                 $pub_ts = $this->pub_exact_ts();
                 if ($pub_ts === null) {

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -321,7 +321,7 @@ const DOI_FREE_CONDITIONAL = [
         'type'   => 'EMBARGO_MONTHS',
         'value'  => '36',
     ],
-    [   // EPJC: open-access after 2014 
+    [   // EPJC: open-access after 2014
         'prefix' => '10.1140/epjc',
         'type'   => 'AFTER_YEAR',
         'value'  => '2014',

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -291,42 +291,29 @@ const DOI_FREE_PREFIX = [
 
 /**
  * Conditional free DOI rules: DOIs that are free only under certain publication-date conditions.
- *
- * Supported rule types and their semantics:
- *   AFTER_YEAR    - free if pub year >  value  (strictly after, e.g. Hindawi content after 2006)
- *   FROM_YEAR     - free if pub year >= value  (from a given year onwards, e.g. EPJC from 2015)
- *   EMBARGO_YEARS - free if (pub year + value) < current year  (whole-year rolling embargo)
- *   EMBARGO_MONTHS - free if (pub date + value months) <= now  (month-precise rolling embargo;
- *                    when only a year is known the end of that year is used as a conservative estimate)
- *
- * The 'value' field is always a string.
- *   - For AFTER_YEAR / FROM_YEAR it is a four-digit year, e.g. '2015'.
- *   - For EMBARGO_YEARS / EMBARGO_MONTHS it is the number of years/months as a string, e.g. '1' or '36'.
- *
- * When no parseable publication date or year is present in the citation, no free tag is added.
- *
- * Existing unconditional entries in DOI_FREE_PREFIX take precedence; this list is evaluated afterwards.
- * To add a new rule, append a new array entry here — no Template.php changes required.
- *
+ * Rule types: AFTER_YEAR (year > value), FROM_YEAR (year >= value),
+ *   EMBARGO_YEARS (year + value < current year), EMBARGO_MONTHS (pub date + value months <= now;
+ *   falls back to end of year when only year is known).
+ * If no parseable date is present, no free tag is added.
  * @var array<array{prefix: string, type: string, value: string}>
  */
 const DOI_FREE_CONDITIONAL = [
-    [   // Hindawi journals became fully open-access; older Hindawi content is free for years after 2006
+    [   // Hindawi: free for years after 2006
         'prefix' => '10.1155/',
         'type'   => 'AFTER_YEAR',
         'value'  => '2006',
     ],
-    [   // PNAS: rolling embargo — free once at least 1 full year old (year-level precision)
+    [   // PNAS: 1-year rolling embargo
         'prefix' => '10.1073/pnas',
         'type'   => 'EMBARGO_YEARS',
         'value'  => '1',
     ],
-    [   // Limnology and Oceanography (Wiley): 3-year (36-month) rolling embargo, month-precise
+    [   // Limnology and Oceanography: 36-month rolling embargo, month-precise
         'prefix' => '10.1002/lno.',
         'type'   => 'EMBARGO_MONTHS',
         'value'  => '36',
     ],
-    [   // European Physical Journal C: open-access from 2015 onwards (published after 31 Dec 2014)
+    [   // EPJC: open-access from 2015 onwards
         'prefix' => '10.1140/epjc',
         'type'   => 'FROM_YEAR',
         'value'  => '2015',

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -323,9 +323,9 @@ const DOI_FREE_CONDITIONAL = [
         'type'   => 'EMBARGO_MONTHS',
         'value'  => '36',
     ],
-    [   // EPJC: open-access from 2015 onwards
+    [   // EPJC: open-access after 2014 (i.e. 2015 onwards)
         'prefix' => '10.1140/epjc',
-        'type'   => 'FROM_YEAR',
-        'value'  => '2015',
+        'type'   => 'AFTER_YEAR',
+        'value'  => '2014',
     ],
 ];

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -288,3 +288,47 @@ const DOI_FREE_PREFIX = [
     '10.7766/',
     '10.9778/',
 ];
+
+/**
+ * Conditional free DOI rules: DOIs that are free only under certain publication-date conditions.
+ *
+ * Supported rule types and their semantics:
+ *   AFTER_YEAR    - free if pub year >  value  (strictly after, e.g. Hindawi content after 2006)
+ *   FROM_YEAR     - free if pub year >= value  (from a given year onwards, e.g. EPJC from 2015)
+ *   EMBARGO_YEARS - free if (pub year + value) < current year  (whole-year rolling embargo)
+ *   EMBARGO_MONTHS - free if (pub date + value months) <= now  (month-precise rolling embargo;
+ *                    when only a year is known the end of that year is used as a conservative estimate)
+ *
+ * The 'value' field is always a string.
+ *   - For AFTER_YEAR / FROM_YEAR it is a four-digit year, e.g. '2015'.
+ *   - For EMBARGO_YEARS / EMBARGO_MONTHS it is the number of years/months as a string, e.g. '1' or '36'.
+ *
+ * When no parseable publication date or year is present in the citation, no free tag is added.
+ *
+ * Existing unconditional entries in DOI_FREE_PREFIX take precedence; this list is evaluated afterwards.
+ * To add a new rule, append a new array entry here — no Template.php changes required.
+ *
+ * @var array<array{prefix: string, type: string, value: string}>
+ */
+const DOI_FREE_CONDITIONAL = [
+    [   // Hindawi journals became fully open-access; older Hindawi content is free for years after 2006
+        'prefix' => '10.1155/',
+        'type'   => 'AFTER_YEAR',
+        'value'  => '2006',
+    ],
+    [   // PNAS: rolling embargo — free once at least 1 full year old (year-level precision)
+        'prefix' => '10.1073/pnas',
+        'type'   => 'EMBARGO_YEARS',
+        'value'  => '1',
+    ],
+    [   // Limnology and Oceanography (Wiley): 3-year (36-month) rolling embargo, month-precise
+        'prefix' => '10.1002/lno.',
+        'type'   => 'EMBARGO_MONTHS',
+        'value'  => '36',
+    ],
+    [   // European Physical Journal C: open-access from 2015 onwards (published after 31 Dec 2014)
+        'prefix' => '10.1140/epjc',
+        'type'   => 'FROM_YEAR',
+        'value'  => '2015',
+    ],
+];

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -313,6 +313,16 @@ const DOI_FREE_CONDITIONAL = [
         'type'   => 'EMBARGO_MONTHS',
         'value'  => '36',
     ],
+    [   // L&O Bulletin: 36-month rolling embargo
+        'prefix' => '10.1002/lob.',
+        'type'   => 'EMBARGO_MONTHS',
+        'value'  => '36',
+    ],
+    [   // L&O Methods: 36-month rolling embargo
+        'prefix' => '10.1002/lom3.',
+        'type'   => 'EMBARGO_MONTHS',
+        'value'  => '36',
+    ],
     [   // EPJC: open-access from 2015 onwards
         'prefix' => '10.1140/epjc',
         'type'   => 'FROM_YEAR',

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -291,8 +291,7 @@ const DOI_FREE_PREFIX = [
 
 /**
  * Conditional free DOI rules: DOIs that are free only under certain publication-date conditions.
- * Rule types: AFTER_YEAR (year > value), FROM_YEAR (year >= value),
- *   EMBARGO_YEARS (year + value < current year), EMBARGO_MONTHS (pub date + value months <= now;
+ * Rule types: AFTER_YEAR (year > value), EMBARGO_MONTHS (pub date + value months <= now;
  *   falls back to end of year when only year is known).
  * If no parseable date is present, no free tag is added.
  * @var array<array{prefix: string, type: string, value: string}>

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -291,8 +291,7 @@ const DOI_FREE_PREFIX = [
 
 /**
  * Conditional free DOI rules: DOIs that are free only under certain publication-date conditions.
- * Rule types: AFTER_YEAR (year > value), EMBARGO_MONTHS (pub date + value months <= now;
- *   falls back to end of year when only year is known).
+ * Rule types: AFTER_YEAR (year > value), EMBARGO_MONTHS (pub date + value months <= now; falls back to end of year when only year is known).
  * If no parseable date is present, no free tag is added.
  * @var array<array{prefix: string, type: string, value: string}>
  */
@@ -302,12 +301,12 @@ const DOI_FREE_CONDITIONAL = [
         'type'   => 'AFTER_YEAR',
         'value'  => '2006',
     ],
-    [   // PNAS: 12-month rolling embargo, month-precise
+    [   // PNAS: 12-month rolling embargo
         'prefix' => '10.1073/pnas',
         'type'   => 'EMBARGO_MONTHS',
         'value'  => '12',
     ],
-    [   // Limnology and Oceanography: 36-month rolling embargo, month-precise
+    [   // Limnology and Oceanography: 36-month rolling embargo
         'prefix' => '10.1002/lno.',
         'type'   => 'EMBARGO_MONTHS',
         'value'  => '36',
@@ -322,7 +321,7 @@ const DOI_FREE_CONDITIONAL = [
         'type'   => 'EMBARGO_MONTHS',
         'value'  => '36',
     ],
-    [   // EPJC: open-access after 2014 (i.e. 2015 onwards)
+    [   // EPJC: open-access after 2014 
         'prefix' => '10.1140/epjc',
         'type'   => 'AFTER_YEAR',
         'value'  => '2014',

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -303,10 +303,10 @@ const DOI_FREE_CONDITIONAL = [
         'type'   => 'AFTER_YEAR',
         'value'  => '2006',
     ],
-    [   // PNAS: 1-year rolling embargo
+    [   // PNAS: 12-month rolling embargo, month-precise
         'prefix' => '10.1073/pnas',
-        'type'   => 'EMBARGO_YEARS',
-        'value'  => '1',
+        'type'   => 'EMBARGO_MONTHS',
+        'value'  => '12',
     ],
     [   // Limnology and Oceanography: 36-month rolling embargo, month-precise
         'prefix' => '10.1002/lno.',

--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -746,4 +746,30 @@ final class ConstantsTest extends testBaseClass {
         }
     }
 
+    public function testDoiConditionalStructure(): void {
+        new TestPage(); // Fill page name with test name for debugging
+        $valid_types = ['AFTER_YEAR', 'FROM_YEAR', 'EMBARGO_YEARS', 'EMBARGO_MONTHS'];
+        foreach (DOI_FREE_CONDITIONAL as $idx => $rule) {
+            $label = 'DOI_FREE_CONDITIONAL[' . $idx . ']';
+            $this->assertTrue(is_array($rule), $label . ' must be an array');
+            $this->assertArrayHasKey('prefix', $rule, $label . ' missing prefix');
+            $this->assertArrayHasKey('type', $rule, $label . ' missing type');
+            $this->assertArrayHasKey('value', $rule, $label . ' missing value');
+            $this->assertTrue(is_string($rule['prefix']), $label . ' prefix must be string');
+            $this->assertTrue(is_string($rule['type']), $label . ' type must be string');
+            $this->assertTrue(is_string($rule['value']), $label . ' value must be string');
+            $this->assertContains($rule['type'], $valid_types, $label . ' type must be one of: ' . implode(', ', $valid_types));
+            if (mb_strpos($rule['prefix'], '/') === false) {
+                $this->assertSame('This prefix needs a slash', $rule['prefix']);
+            }
+            if ($rule['type'] === 'AFTER_YEAR' || $rule['type'] === 'FROM_YEAR') {
+                $this->assertMatchesRegularExpression('~^\d{4}$~', $rule['value'], $label . ' value must be a 4-digit year for ' . $rule['type']);
+            }
+            if ($rule['type'] === 'EMBARGO_YEARS' || $rule['type'] === 'EMBARGO_MONTHS') {
+                $this->assertMatchesRegularExpression('~^\d+$~', $rule['value'], $label . ' value must be a positive integer string for ' . $rule['type']);
+                $this->assertGreaterThan(0, (int) $rule['value'], $label . ' value must be > 0 for ' . $rule['type']);
+            }
+        }
+    }
+
 }

--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -748,7 +748,7 @@ final class ConstantsTest extends testBaseClass {
 
     public function testDoiConditionalStructure(): void {
         new TestPage();
-        $valid_types = ['AFTER_YEAR', 'FROM_YEAR', 'EMBARGO_YEARS', 'EMBARGO_MONTHS'];
+        $valid_types = ['AFTER_YEAR', 'EMBARGO_MONTHS'];
         foreach (DOI_FREE_CONDITIONAL as $idx => $rule) {
             $label = 'DOI_FREE_CONDITIONAL[' . $idx . ']';
             $this->assertIsArray($rule, $label);
@@ -760,7 +760,7 @@ final class ConstantsTest extends testBaseClass {
             $this->assertIsString($rule['value'], $label . ' value');
             $this->assertContains($rule['type'], $valid_types, $label . ' type');
             $this->assertStringContainsString('/', $rule['prefix'], $label . ' prefix');
-            if ($rule['type'] === 'AFTER_YEAR' || $rule['type'] === 'FROM_YEAR') {
+            if ($rule['type'] === 'AFTER_YEAR') {
                 $this->assertMatchesRegularExpression('~^\d{4}$~', $rule['value'], $label . ' value');
             } else {
                 $this->assertGreaterThan(0, (int) $rule['value'], $label . ' value');

--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -759,9 +759,7 @@ final class ConstantsTest extends testBaseClass {
             $this->assertTrue(is_string($rule['type']), $label . ' type must be string');
             $this->assertTrue(is_string($rule['value']), $label . ' value must be string');
             $this->assertContains($rule['type'], $valid_types, $label . ' type must be one of: ' . implode(', ', $valid_types));
-            if (mb_strpos($rule['prefix'], '/') === false) {
-                $this->assertSame('This prefix needs a slash', $rule['prefix']);
-            }
+            $this->assertStringContainsString('/', $rule['prefix'], $label . ' prefix must contain a slash');
             if ($rule['type'] === 'AFTER_YEAR' || $rule['type'] === 'FROM_YEAR') {
                 $this->assertMatchesRegularExpression('~^\d{4}$~', $rule['value'], $label . ' value must be a 4-digit year for ' . $rule['type']);
             }

--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -747,25 +747,23 @@ final class ConstantsTest extends testBaseClass {
     }
 
     public function testDoiConditionalStructure(): void {
-        new TestPage(); // Fill page name with test name for debugging
+        new TestPage();
         $valid_types = ['AFTER_YEAR', 'FROM_YEAR', 'EMBARGO_YEARS', 'EMBARGO_MONTHS'];
         foreach (DOI_FREE_CONDITIONAL as $idx => $rule) {
             $label = 'DOI_FREE_CONDITIONAL[' . $idx . ']';
-            $this->assertTrue(is_array($rule), $label . ' must be an array');
-            $this->assertArrayHasKey('prefix', $rule, $label . ' missing prefix');
-            $this->assertArrayHasKey('type', $rule, $label . ' missing type');
-            $this->assertArrayHasKey('value', $rule, $label . ' missing value');
-            $this->assertTrue(is_string($rule['prefix']), $label . ' prefix must be string');
-            $this->assertTrue(is_string($rule['type']), $label . ' type must be string');
-            $this->assertTrue(is_string($rule['value']), $label . ' value must be string');
-            $this->assertContains($rule['type'], $valid_types, $label . ' type must be one of: ' . implode(', ', $valid_types));
-            $this->assertStringContainsString('/', $rule['prefix'], $label . ' prefix must contain a slash');
+            $this->assertIsArray($rule, $label);
+            $this->assertArrayHasKey('prefix', $rule, $label);
+            $this->assertArrayHasKey('type', $rule, $label);
+            $this->assertArrayHasKey('value', $rule, $label);
+            $this->assertIsString($rule['prefix'], $label . ' prefix');
+            $this->assertIsString($rule['type'], $label . ' type');
+            $this->assertIsString($rule['value'], $label . ' value');
+            $this->assertContains($rule['type'], $valid_types, $label . ' type');
+            $this->assertStringContainsString('/', $rule['prefix'], $label . ' prefix');
             if ($rule['type'] === 'AFTER_YEAR' || $rule['type'] === 'FROM_YEAR') {
-                $this->assertMatchesRegularExpression('~^\d{4}$~', $rule['value'], $label . ' value must be a 4-digit year for ' . $rule['type']);
-            }
-            if ($rule['type'] === 'EMBARGO_YEARS' || $rule['type'] === 'EMBARGO_MONTHS') {
-                $this->assertMatchesRegularExpression('~^\d+$~', $rule['value'], $label . ' value must be a positive integer string for ' . $rule['type']);
-                $this->assertGreaterThan(0, (int) $rule['value'], $label . ' value must be > 0 for ' . $rule['type']);
+                $this->assertMatchesRegularExpression('~^\d{4}$~', $rule['value'], $label . ' value');
+            } else {
+                $this->assertGreaterThan(0, (int) $rule['value'], $label . ' value');
             }
         }
     }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1916,15 +1916,15 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
-    public function testDoiConditionalEmbargoYears_OldArticle_Free(): void {
-        $text = '{{cite journal|doi=10.1073/pnas.0000000|year=2010}}';
+    public function testDoiConditionalEmbargoMonths_PnasOldArticle_Free(): void {
+        $text = '{{cite journal|doi=10.1073/pnas.0000000|date=January 2010}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertSame('free', $template->get2('doi-access'));
     }
 
-    public function testDoiConditionalEmbargoYears_CurrentYear_NotFree(): void {
-        $text = '{{cite journal|doi=10.1073/pnas.0000000|year=' . date('Y') . '}}';
+    public function testDoiConditionalEmbargoMonths_PnasCurrentMonth_NotFree(): void {
+        $text = '{{cite journal|doi=10.1073/pnas.0000000|date=' . date('F Y') . '}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertNull($template->get2('doi-access'));

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1964,4 +1964,11 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $template->tidy_parameter('doi');
         $this->assertSame('free', $template->get2('doi-access'));
     }
+
+    public function testDoiConditionalEmbargoMonths_UnresolvableDate_NotFree(): void {
+        $text = '{{cite journal|doi=10.1002/lno.example|date=forthcoming}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
 }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1902,20 +1902,6 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
-    public function testDoiConditionalAfterYear_EpjcFree(): void {
-        $text = '{{cite journal|doi=10.1140/epjc/example|year=2015}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
-    }
-
-    public function testDoiConditionalAfterYear_EpjcAtThreshold_NotFree(): void {
-        $text = '{{cite journal|doi=10.1140/epjc/example|year=2014}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertNull($template->get2('doi-access'));
-    }
-
     public function testDoiConditionalEmbargoMonths_PnasOldArticle_Free(): void {
         $text = '{{cite journal|doi=10.1073/pnas.0000000|date=January 2010}}';
         $template = $this->make_citation($text);
@@ -1928,13 +1914,6 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertNull($template->get2('doi-access'));
-    }
-
-    public function testDoiConditionalEmbargoMonths_OldDate_Free(): void {
-        $text = '{{cite journal|doi=10.1002/lno.example|date=January 2010}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
     }
 
     public function testDoiConditionalEmbargoMonths_YearOnlyOld_Free(): void {
@@ -1956,13 +1935,6 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertSame('limited', $template->get2('doi-access'));
-    }
-
-    public function testDoiUnconditionalFreePrefixUnchanged(): void {
-        $text = '{{cite journal|doi=10.1371/journal.pone.0000001}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
     }
 
     public function testDoiConditionalEmbargoMonths_UnresolvableDate_NotFree(): void {

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1958,6 +1958,20 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertSame('limited', $template->get2('doi-access'));
     }
 
+    public function testDoiConditionalEmbargoMonths_LobOldDate_Free(): void {
+        $text = '{{cite journal|doi=10.1002/lob.example|date=January 2010}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalEmbargoMonths_Lom3OldDate_Free(): void {
+        $text = '{{cite journal|doi=10.1002/lom3.example|date=January 2010}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
     public function testDoiUnconditionalFreePrefixUnchanged(): void {
         $text = '{{cite journal|doi=10.1371/journal.pone.0000001}}';
         $template = $this->make_citation($text);

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1902,14 +1902,14 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
-    public function testDoiConditionalFromYear_Free(): void {
+    public function testDoiConditionalAfterYear_EpjcFree(): void {
         $text = '{{cite journal|doi=10.1140/epjc/example|year=2015}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertSame('free', $template->get2('doi-access'));
     }
 
-    public function testDoiConditionalFromYear_BelowThreshold_NotFree(): void {
+    public function testDoiConditionalAfterYear_EpjcAtThreshold_NotFree(): void {
         $text = '{{cite journal|doi=10.1140/epjc/example|year=2014}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1887,4 +1887,191 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $template->final_tidy();
         $this->assertNull($template->get2('title'));
     }
+
+    // -----------------------------------------------------------------------
+    // Tests for DOI_FREE_CONDITIONAL: time-dependent doi-access tagging
+    // -----------------------------------------------------------------------
+
+    // --- AFTER_YEAR (10.1155/) ---
+
+    public function testDoiConditionalAfterYear_Free(): void {
+        // Year strictly after threshold (2006): must be tagged free
+        $text = '{{cite journal|doi=10.1155/2007/example|year=2007}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterYear_AtThreshold_NotFree(): void {
+        // Year equal to threshold: must NOT be tagged free (rule is strictly "after")
+        $text = '{{cite journal|doi=10.1155/2006/example|year=2006}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterYear_BelowThreshold_NotFree(): void {
+        // Year below threshold: must NOT be tagged free
+        $text = '{{cite journal|doi=10.1155/2005/example|year=2005}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterYear_NoYear_NotFree(): void {
+        // No year present: must NOT be tagged (safe default)
+        $text = '{{cite journal|doi=10.1155/example}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    // --- FROM_YEAR (10.1140/epjc) ---
+
+    public function testDoiConditionalFromYear_Free(): void {
+        // Year at or after threshold (2015): must be tagged free
+        $text = '{{cite journal|doi=10.1140/epjc/example|year=2015}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalFromYear_AfterThreshold_Free(): void {
+        // Year well after threshold: must be tagged free
+        $text = '{{cite journal|doi=10.1140/epjc/example|year=2020}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalFromYear_BelowThreshold_NotFree(): void {
+        // Year strictly before threshold: must NOT be tagged free
+        $text = '{{cite journal|doi=10.1140/epjc/example|year=2014}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalFromYear_NoYear_NotFree(): void {
+        // No year present: must NOT be tagged (safe default)
+        $text = '{{cite journal|doi=10.1140/epjc/example}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalFromYear_DateField_Free(): void {
+        // Year extracted from full date field: must be tagged free
+        $text = '{{cite journal|doi=10.1140/epjc/example|date=March 2017}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    // --- EMBARGO_YEARS (10.1073/pnas) ---
+
+    public function testDoiConditionalEmbargoYears_OldArticle_Free(): void {
+        // Clearly old year: pub_year + 1 < current_year -> free
+        $text = '{{cite journal|doi=10.1073/pnas.0000000|year=2010}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalEmbargoYears_CurrentYear_NotFree(): void {
+        // Current year: embargo not expired
+        $current_year = (string) date('Y');
+        $text = '{{cite journal|doi=10.1073/pnas.0000000|year=' . $current_year . '}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalEmbargoYears_NoYear_NotFree(): void {
+        // No year: must NOT be tagged (safe default)
+        $text = '{{cite journal|doi=10.1073/pnas.0000000}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalEmbargoYears_PublicationDateFallback_Free(): void {
+        // Year extracted from publication-date field as fallback
+        $text = '{{cite journal|doi=10.1073/pnas.0000000|publication-date=2010}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    // --- EMBARGO_MONTHS (10.1002/lno.) ---
+
+    public function testDoiConditionalEmbargoMonths_ClearlyOldFullDate_Free(): void {
+        // Full date clearly more than 36 months ago: must be free
+        $text = '{{cite journal|doi=10.1002/lno.example|date=January 2010}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalEmbargoMonths_ClearlyNewFullDate_NotFree(): void {
+        // Full date clearly less than 36 months ago: must NOT be free
+        $text = '{{cite journal|doi=10.1002/lno.example|date=January 2026}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalEmbargoMonths_YearOnlyOldConservative_Free(): void {
+        // Year-only: uses end-of-year conservative fallback.
+        // Dec 31 2010 + 36 months = Dec 31 2013, which is clearly in the past -> free
+        $text = '{{cite journal|doi=10.1002/lno.example|year=2010}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalEmbargoMonths_YearOnlyTooRecent_NotFree(): void {
+        // Year-only: Dec 31 of current year + 36 months is in the future -> NOT free
+        $current_year = (string) date('Y');
+        $text = '{{cite journal|doi=10.1002/lno.example|year=' . $current_year . '}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalEmbargoMonths_NoDate_NotFree(): void {
+        // No date at all: must NOT be tagged (safe default)
+        $text = '{{cite journal|doi=10.1002/lno.example}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    // --- Existing doi-access preserved ---
+
+    public function testDoiConditionalExistingAccessPreserved(): void {
+        // If doi-access is already set to something, it must not be changed
+        $text = '{{cite journal|doi=10.1002/lno.example|date=January 2010|doi-access=limited}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('limited', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalExistingFreeAccessPreserved(): void {
+        // doi-access=free already set: add_if_new must not duplicate it
+        $text = '{{cite journal|doi=10.1002/lno.example|date=January 2010|doi-access=free}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    // --- Unconditional DOI_FREE_PREFIX still works ---
+
+    public function testDoiUnconditionalFreePrefixUnchanged(): void {
+        // A DOI in DOI_FREE_PREFIX must still be tagged without needing a date
+        $text = '{{cite journal|doi=10.1371/journal.pone.0000001}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
 }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1888,14 +1888,7 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('title'));
     }
 
-    // -----------------------------------------------------------------------
-    // Tests for DOI_FREE_CONDITIONAL: time-dependent doi-access tagging
-    // -----------------------------------------------------------------------
-
-    // --- AFTER_YEAR (10.1155/) ---
-
     public function testDoiConditionalAfterYear_Free(): void {
-        // Year strictly after threshold (2006): must be tagged free
         $text = '{{cite journal|doi=10.1155/2007/example|year=2007}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
@@ -1903,75 +1896,27 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
     }
 
     public function testDoiConditionalAfterYear_AtThreshold_NotFree(): void {
-        // Year equal to threshold: must NOT be tagged free (rule is strictly "after")
         $text = '{{cite journal|doi=10.1155/2006/example|year=2006}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertNull($template->get2('doi-access'));
     }
 
-    public function testDoiConditionalAfterYear_BelowThreshold_NotFree(): void {
-        // Year below threshold: must NOT be tagged free
-        $text = '{{cite journal|doi=10.1155/2005/example|year=2005}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertNull($template->get2('doi-access'));
-    }
-
-    public function testDoiConditionalAfterYear_NoYear_NotFree(): void {
-        // No year present: must NOT be tagged (safe default)
-        $text = '{{cite journal|doi=10.1155/example}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertNull($template->get2('doi-access'));
-    }
-
-    // --- FROM_YEAR (10.1140/epjc) ---
-
     public function testDoiConditionalFromYear_Free(): void {
-        // Year at or after threshold (2015): must be tagged free
         $text = '{{cite journal|doi=10.1140/epjc/example|year=2015}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertSame('free', $template->get2('doi-access'));
     }
 
-    public function testDoiConditionalFromYear_AfterThreshold_Free(): void {
-        // Year well after threshold: must be tagged free
-        $text = '{{cite journal|doi=10.1140/epjc/example|year=2020}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
-    }
-
     public function testDoiConditionalFromYear_BelowThreshold_NotFree(): void {
-        // Year strictly before threshold: must NOT be tagged free
         $text = '{{cite journal|doi=10.1140/epjc/example|year=2014}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertNull($template->get2('doi-access'));
     }
 
-    public function testDoiConditionalFromYear_NoYear_NotFree(): void {
-        // No year present: must NOT be tagged (safe default)
-        $text = '{{cite journal|doi=10.1140/epjc/example}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertNull($template->get2('doi-access'));
-    }
-
-    public function testDoiConditionalFromYear_DateField_Free(): void {
-        // Year extracted from full date field: must be tagged free
-        $text = '{{cite journal|doi=10.1140/epjc/example|date=March 2017}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
-    }
-
-    // --- EMBARGO_YEARS (10.1073/pnas) ---
-
     public function testDoiConditionalEmbargoYears_OldArticle_Free(): void {
-        // Clearly old year: pub_year + 1 < current_year -> free
         $text = '{{cite journal|doi=10.1073/pnas.0000000|year=2010}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
@@ -1979,96 +1924,41 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
     }
 
     public function testDoiConditionalEmbargoYears_CurrentYear_NotFree(): void {
-        // Current year: embargo not expired
-        $current_year = (string) date('Y');
-        $text = '{{cite journal|doi=10.1073/pnas.0000000|year=' . $current_year . '}}';
+        $text = '{{cite journal|doi=10.1073/pnas.0000000|year=' . date('Y') . '}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertNull($template->get2('doi-access'));
     }
 
-    public function testDoiConditionalEmbargoYears_NoYear_NotFree(): void {
-        // No year: must NOT be tagged (safe default)
-        $text = '{{cite journal|doi=10.1073/pnas.0000000}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertNull($template->get2('doi-access'));
-    }
-
-    public function testDoiConditionalEmbargoYears_PublicationDateFallback_Free(): void {
-        // Year extracted from publication-date field as fallback
-        $text = '{{cite journal|doi=10.1073/pnas.0000000|publication-date=2010}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
-    }
-
-    // --- EMBARGO_MONTHS (10.1002/lno.) ---
-
-    public function testDoiConditionalEmbargoMonths_ClearlyOldFullDate_Free(): void {
-        // Full date clearly more than 36 months ago: must be free
+    public function testDoiConditionalEmbargoMonths_OldDate_Free(): void {
         $text = '{{cite journal|doi=10.1002/lno.example|date=January 2010}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertSame('free', $template->get2('doi-access'));
     }
 
-    public function testDoiConditionalEmbargoMonths_ClearlyNewFullDate_NotFree(): void {
-        // Full date clearly less than 36 months ago: must NOT be free
-        $text = '{{cite journal|doi=10.1002/lno.example|date=January 2026}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertNull($template->get2('doi-access'));
-    }
-
-    public function testDoiConditionalEmbargoMonths_YearOnlyOldConservative_Free(): void {
-        // Year-only: uses end-of-year conservative fallback.
-        // Dec 31 2010 + 36 months = Dec 31 2013, which is clearly in the past -> free
+    public function testDoiConditionalEmbargoMonths_YearOnlyOld_Free(): void {
         $text = '{{cite journal|doi=10.1002/lno.example|year=2010}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertSame('free', $template->get2('doi-access'));
     }
 
-    public function testDoiConditionalEmbargoMonths_YearOnlyTooRecent_NotFree(): void {
-        // Year-only: Dec 31 of current year + 36 months is in the future -> NOT free
-        $current_year = (string) date('Y');
-        $text = '{{cite journal|doi=10.1002/lno.example|year=' . $current_year . '}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertNull($template->get2('doi-access'));
-    }
-
-    public function testDoiConditionalEmbargoMonths_NoDate_NotFree(): void {
-        // No date at all: must NOT be tagged (safe default)
+    public function testDoiConditionalNoDate_NotFree(): void {
         $text = '{{cite journal|doi=10.1002/lno.example}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertNull($template->get2('doi-access'));
     }
 
-    // --- Existing doi-access preserved ---
-
     public function testDoiConditionalExistingAccessPreserved(): void {
-        // If doi-access is already set to something, it must not be changed
         $text = '{{cite journal|doi=10.1002/lno.example|date=January 2010|doi-access=limited}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');
         $this->assertSame('limited', $template->get2('doi-access'));
     }
 
-    public function testDoiConditionalExistingFreeAccessPreserved(): void {
-        // doi-access=free already set: add_if_new must not duplicate it
-        $text = '{{cite journal|doi=10.1002/lno.example|date=January 2010|doi-access=free}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
-    }
-
-    // --- Unconditional DOI_FREE_PREFIX still works ---
-
     public function testDoiUnconditionalFreePrefixUnchanged(): void {
-        // A DOI in DOI_FREE_PREFIX must still be tagged without needing a date
         $text = '{{cite journal|doi=10.1371/journal.pone.0000001}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('doi');

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1958,20 +1958,6 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertSame('limited', $template->get2('doi-access'));
     }
 
-    public function testDoiConditionalEmbargoMonths_LobOldDate_Free(): void {
-        $text = '{{cite journal|doi=10.1002/lob.example|date=January 2010}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
-    }
-
-    public function testDoiConditionalEmbargoMonths_Lom3OldDate_Free(): void {
-        $text = '{{cite journal|doi=10.1002/lom3.example|date=January 2010}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('doi');
-        $this->assertSame('free', $template->get2('doi-access'));
-    }
-
     public function testDoiUnconditionalFreePrefixUnchanged(): void {
         $text = '{{cite journal|doi=10.1371/journal.pone.0000001}}';
         $template = $this->make_citation($text);


### PR DESCRIPTION
This pull request introduces a new system for handling DOIs (Digital Object Identifiers) that are free to access only under certain publication-date conditions. It centralises these conditional rules, applies them in a more maintainable way.
This results in more accurate and future-proof tagging of free-access DOIs.

**Conditional DOI free-access rules:**

* Introduced a new constant `DOI_FREE_CONDITIONAL` in `free_doi.php` to define rules for DOIs that are free only after a certain year or after an embargo period has elapsed since publication. The rules cover publishers like Hindawi, PNAS, and several Limnology and Oceanography journals.

* Refactored `Template.php` to use a new method `doi_free_check_conditional`, which checks the DOI against the centralized rules and tags `doi-access=free` if the publication date condition is satisfied. This replaces hardcoded, scattered logic for specific DOIs. 

**Date handling improvements:**

* Added helper methods in `Template.php` to robustly parse publication years and dates (`pub_year_extended`, `pub_exact_ts`), supporting both year-only and more precise date fields for embargo calculations.

**Testing and validation:**

* Added PHPUnit tests to verify the structure of the new `DOI_FREE_CONDITIONAL` constant and to ensure correct behavior for various date and DOI scenarios, including edge cases (e.g., embargo periods, missing dates, existing access tags).