### PR TITLE
Fix HDL test 

### DIFF
--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1165,24 +1165,16 @@ EP - 999 }}';
     }
 
     public function testHandles1(): void {
+        unset(HandleCache::$cache_hdl_null['10125/20269']);
         $template = $this->make_citation('{{Cite web|url=http://hdl.handle.net/10125/20269////;jsessionid=dfasddsa|journal=X}}');
-        $template->get_identifiers_from_url();
-        if ($template->get2('hdl') !== '10125/20269') {
-            unset(HandleCache::$cache_hdl_null['10125/20269']);
-            sleep(run_type_mods(-1, 15, 15, 5, 15));
-            $template->get_identifiers_from_url(); // This test is finicky sometimes
-        }
-        if ($template->get2('hdl') !== '10125/20269') {
-            unset(HandleCache::$cache_hdl_null['10125/20269']);
-            sleep(run_type_mods(-1, 15, 15, 5, 15));
-            $template->get_identifiers_from_url(); // This test is finicky sometimes
-        }
+        $this->assertTrue($template->get_identifiers_from_url());
         $this->assertSame('10125/20269', $template->get2('hdl'));
         $this->assertSame('cite web', $template->wikiname());
         $this->assertNotNull($template->get2('url'));
     }
 
     public function testHandles2(): void {
+        unset(HandleCache::$cache_hdl_null['10125/20269']);
         $template = $this->make_citation('{{Cite web|url=https://hdl.handle.net/handle////10125/20269}}');
         $template->get_identifiers_from_url();
         if ($template->get2('hdl') !== '10125/20269') {
@@ -1208,36 +1200,18 @@ EP - 999 }}';
     }
 
     public function testHandles4(): void {
+        unset(HandleCache::$cache_hdl_null['10125/20269']);
         $template = $this->make_citation('{{Cite journal|url=https://scholarspace.manoa.hawaii.edu/handle/10125/20269}}');
         $template->get_identifiers_from_url();
-        if ($template->get2('hdl') !== '10125/20269') {
-            unset(HandleCache::$cache_hdl_null['10125/20269']);
-            sleep(run_type_mods(-1, 15, 15, 5, 15));
-            $template->get_identifiers_from_url(); // This test is finicky sometimes
-        }
-        if ($template->get2('hdl') !== '10125/20269') {
-            unset(HandleCache::$cache_hdl_null['10125/20269']);
-            sleep(run_type_mods(-1, 15, 15, 5, 15));
-            $template->get_identifiers_from_url(); // This test is finicky sometimes
-        }
         $this->assertSame('10125/20269', $template->get2('hdl'));
         $this->assertNotNull($template->get2('url'));
     }
 
     public function testHandles5(): void {
         $expected_hdl = '2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672';
+        unset(HandleCache::$cache_hdl_null[$expected_hdl]);
         $template = $this->make_citation('{{Cite journal|url=http://hdl.handle.net/2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672}}');
         $template->get_identifiers_from_url();
-        if ($template->get2('hdl') !== $expected_hdl) {
-            unset(HandleCache::$cache_hdl_null[$expected_hdl]);
-            sleep(run_type_mods(-1, 15, 15, 5, 15));
-            $template->get_identifiers_from_url(); // This test is finicky sometimes
-        }
-        if ($template->get2('hdl') !== $expected_hdl) {
-            unset(HandleCache::$cache_hdl_null[$expected_hdl]);
-            sleep(run_type_mods(-1, 15, 15, 5, 15));
-            $template->get_identifiers_from_url(); // This test is finicky sometimes
-        }
         $this->assertSame($expected_hdl, $template->get2('hdl'));
         $this->assertNotNull($template->get2('url'));
     }

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1225,19 +1225,20 @@ EP - 999 }}';
     }
 
     public function testHandles5(): void {
+        $expected_hdl = '2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672';
         $template = $this->make_citation('{{Cite journal|url=http://hdl.handle.net/2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672}}');
         $template->get_identifiers_from_url();
-        if ($template->get2('hdl') !== '2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672') {
-            unset(HandleCache::$cache_hdl_null['2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672']);
+        if ($template->get2('hdl') !== $expected_hdl) {
+            unset(HandleCache::$cache_hdl_null[$expected_hdl]);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
-        if ($template->get2('hdl') !== '2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672') {
-            unset(HandleCache::$cache_hdl_null['2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672']);
+        if ($template->get2('hdl') !== $expected_hdl) {
+            unset(HandleCache::$cache_hdl_null[$expected_hdl]);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
-        $this->assertSame('2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672', $template->get2('hdl'));
+        $this->assertSame($expected_hdl, $template->get2('hdl'));
         $this->assertNotNull($template->get2('url'));
     }
 

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1166,7 +1166,15 @@ EP - 999 }}';
 
     public function testHandles1(): void {
         $template = $this->make_citation('{{Cite web|url=http://hdl.handle.net/10125/20269////;jsessionid=dfasddsa|journal=X}}');
-        $this->assertTrue($template->get_identifiers_from_url());
+        $template->get_identifiers_from_url();
+        if ($template->get2('hdl') !== '10125/20269') {
+            sleep(run_type_mods(-1, 15, 15, 5, 15));
+            $template->get_identifiers_from_url(); // This test is finicky sometimes
+        }
+        if ($template->get2('hdl') !== '10125/20269') {
+            sleep(run_type_mods(-1, 15, 15, 5, 15));
+            $template->get_identifiers_from_url(); // This test is finicky sometimes
+        }
         $this->assertSame('10125/20269', $template->get2('hdl'));
         $this->assertSame('cite web', $template->wikiname());
         $this->assertNotNull($template->get2('url'));
@@ -1198,6 +1206,14 @@ EP - 999 }}';
     public function testHandles4(): void {
         $template = $this->make_citation('{{Cite journal|url=https://scholarspace.manoa.hawaii.edu/handle/10125/20269}}');
         $template->get_identifiers_from_url();
+        if ($template->get2('hdl') !== '10125/20269') {
+            sleep(run_type_mods(-1, 15, 15, 5, 15));
+            $template->get_identifiers_from_url(); // This test is finicky sometimes
+        }
+        if ($template->get2('hdl') !== '10125/20269') {
+            sleep(run_type_mods(-1, 15, 15, 5, 15));
+            $template->get_identifiers_from_url(); // This test is finicky sometimes
+        }
         $this->assertSame('10125/20269', $template->get2('hdl'));
         $this->assertNotNull($template->get2('url'));
     }
@@ -1205,6 +1221,14 @@ EP - 999 }}';
     public function testHandles5(): void {
         $template = $this->make_citation('{{Cite journal|url=http://hdl.handle.net/2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672}}');
         $template->get_identifiers_from_url();
+        if ($template->get2('hdl') !== '2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672') {
+            sleep(run_type_mods(-1, 15, 15, 5, 15));
+            $template->get_identifiers_from_url(); // This test is finicky sometimes
+        }
+        if ($template->get2('hdl') !== '2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672') {
+            sleep(run_type_mods(-1, 15, 15, 5, 15));
+            $template->get_identifiers_from_url(); // This test is finicky sometimes
+        }
         $this->assertSame('2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672', $template->get2('hdl'));
         $this->assertNotNull($template->get2('url'));
     }

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1168,10 +1168,12 @@ EP - 999 }}';
         $template = $this->make_citation('{{Cite web|url=http://hdl.handle.net/10125/20269////;jsessionid=dfasddsa|journal=X}}');
         $template->get_identifiers_from_url();
         if ($template->get2('hdl') !== '10125/20269') {
+            unset(HandleCache::$cache_hdl_null['10125/20269']);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
         if ($template->get2('hdl') !== '10125/20269') {
+            unset(HandleCache::$cache_hdl_null['10125/20269']);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
@@ -1184,10 +1186,12 @@ EP - 999 }}';
         $template = $this->make_citation('{{Cite web|url=https://hdl.handle.net/handle////10125/20269}}');
         $template->get_identifiers_from_url();
         if ($template->get2('hdl') !== '10125/20269') {
+            unset(HandleCache::$cache_hdl_null['10125/20269']);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
         if ($template->get2('hdl') !== '10125/20269') {
+            unset(HandleCache::$cache_hdl_null['10125/20269']);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
@@ -1207,10 +1211,12 @@ EP - 999 }}';
         $template = $this->make_citation('{{Cite journal|url=https://scholarspace.manoa.hawaii.edu/handle/10125/20269}}');
         $template->get_identifiers_from_url();
         if ($template->get2('hdl') !== '10125/20269') {
+            unset(HandleCache::$cache_hdl_null['10125/20269']);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
         if ($template->get2('hdl') !== '10125/20269') {
+            unset(HandleCache::$cache_hdl_null['10125/20269']);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
@@ -1222,10 +1228,12 @@ EP - 999 }}';
         $template = $this->make_citation('{{Cite journal|url=http://hdl.handle.net/2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672}}');
         $template->get_identifiers_from_url();
         if ($template->get2('hdl') !== '2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672') {
+            unset(HandleCache::$cache_hdl_null['2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672']);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
         if ($template->get2('hdl') !== '2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672') {
+            unset(HandleCache::$cache_hdl_null['2027/loc.ark:/13960/t6349vh5n?urlappend=%3Bseq=672']);
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }

--- a/tests/testBaseClass.php
+++ b/tests/testBaseClass.php
@@ -44,7 +44,7 @@ abstract class testBaseClass extends PHPUnit\Framework\TestCase {
 
     #[\Override]
     protected function setUp(): void {
-        \HandleCache::free_memory();
+        HandleCache::free_memory();
         Zotero::create_ch_zotero();
         $wb = new WikipediaBot();
         unset($wb);

--- a/tests/testBaseClass.php
+++ b/tests/testBaseClass.php
@@ -44,6 +44,7 @@ abstract class testBaseClass extends PHPUnit\Framework\TestCase {
 
     #[\Override]
     protected function setUp(): void {
+        \HandleCache::free_memory();
         Zotero::create_ch_zotero();
         $wb = new WikipediaBot();
         unset($wb);

--- a/tests/testBaseClass.php
+++ b/tests/testBaseClass.php
@@ -44,7 +44,6 @@ abstract class testBaseClass extends PHPUnit\Framework\TestCase {
 
     #[\Override]
     protected function setUp(): void {
-        HandleCache::free_memory();
         Zotero::create_ch_zotero();
         $wb = new WikipediaBot();
         unset($wb);


### PR DESCRIPTION


Test reliability improvements:

* Added `unset(HandleCache::$cache_hdl_null['10125/20269'])` at the start of several handle-related tests (`testHandles1`, `testHandles2`, `testHandles4`) to clear any cached null results for that handle and ensure each test runs independently.
* In `testHandles5`, introduced a variable `$expected_hdl` and cleared its cache entry before running the test, then used the variable in the assertion for clarity and consistency.