### PR TITLE
Remove bogus `|issue=Volume N, YEAR` injected by Visual Editor for Annual Reviews citations

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -5706,7 +5706,7 @@ final class Template
                         $this->forget($param);
                         return;
                     }
-                    if (preg_match('~^Volume\s+(\d+),?\s*\d{4}$~i', $value, $matches)) {
+                    if (preg_match('~^Volume\s+(\d+),?\s*(19|20)\d{2}$~i', $value, $matches)) {
                         if ($this->blank('volume')) {
                             $this->rename($param, 'volume', $matches[1]);
                         } else {

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -5706,6 +5706,14 @@ final class Template
                         $this->forget($param);
                         return;
                     }
+                    if (preg_match('~^Volume\s+(\d+),?\s*\d{4}$~i', $value, $matches)) {
+                        if ($this->blank('volume')) {
+                            $this->rename($param, 'volume', $matches[1]);
+                        } else {
+                            $this->forget($param);
+                        }
+                        return;
+                    }
                     if ($param === 'issue' || $param === 'number') {
                         if (preg_match('~^(?:iss\.|iss|issue|number|num|num\.|no|no:|no\.|№|№\.)\s*(\d+)$~iu', $value, $matches)) {
                             $value = $matches[1];

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1943,4 +1943,40 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $template->tidy_parameter('doi');
         $this->assertNull($template->get2('doi-access'));
     }
+
+    private function tidy_issue(string $text): Template {
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('issue');
+        return $template;
+    }
+
+    public function testAnnualReviewBogusIssueVolumePresent(): void {
+        $t = $this->tidy_issue('{{Cite journal|volume=62|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertNull($t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
+    }
+
+    public function testAnnualReviewBogusIssueVolumeAbsent(): void {
+        $t = $this->tidy_issue('{{Cite journal|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertNull($t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
+    }
+
+    public function testAnnualReviewBogusIssueCaseInsensitive(): void {
+        $t = $this->tidy_issue('{{Cite journal|volume=62|issue=volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertNull($t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
+    }
+
+    public function testAnnualReviewBogusIssueNoComma(): void {
+        $t = $this->tidy_issue('{{Cite journal|volume=62|issue=Volume 62 2024|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertNull($t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
+    }
+
+    public function testAnnualReviewBogusIssueImplausibleYearNotRemoved(): void {
+        $t = $this->tidy_issue('{{Cite journal|volume=62|issue=Volume 62, 0001|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertSame('Volume 62, 0001', $t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
+    }
 }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1927,4 +1927,15 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('issue'));
         $this->assertSame('62', $template->get2('volume'));
     }
+
+    public function testAnnualReviewBogusIssueImplausibleYearNotRemoved(): void {
+        // The year component must look like a plausible publication year (1900-2099).
+        // A four-digit string that is not a valid year (e.g. "0001") must not trigger
+        // the Visual Editor clean-up rule and must be left untouched.
+        $text = '{{Cite journal|volume=62|issue=Volume 62, 0001|journal=Annual Review of Astronomy and Astrophysics}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('issue');
+        $this->assertSame('Volume 62, 0001', $template->get2('issue'));
+        $this->assertSame('62', $template->get2('volume'));
+    }
 }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1888,54 +1888,39 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('title'));
     }
 
-    public function testAnnualReviewBogusIssueVolumePresent(): void {
-        // issue=Volume N, YEAR is a bogus value inserted by Visual Editor for Annual Review journals;
-        // when |volume= is already set the bogus issue should be dropped and volume left untouched
-        $text = '{{Cite journal|volume=62|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
+    private function tidy_issue(string $text): Template {
         $template = $this->make_citation($text);
         $template->tidy_parameter('issue');
-        $this->assertNull($template->get2('issue'));
-        $this->assertSame('62', $template->get2('volume'));
+        return $template;
+    }
+
+    public function testAnnualReviewBogusIssueVolumePresent(): void {
+        $t = $this->tidy_issue('{{Cite journal|volume=62|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertNull($t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
     }
 
     public function testAnnualReviewBogusIssueVolumeAbsent(): void {
-        // When |volume= is absent the volume number embedded in the bogus issue value should be
-        // moved into |volume=
-        $text = '{{Cite journal|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('issue');
-        $this->assertNull($template->get2('issue'));
-        $this->assertSame('62', $template->get2('volume'));
+        $t = $this->tidy_issue('{{Cite journal|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertNull($t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
     }
 
     public function testAnnualReviewBogusIssueCaseInsensitive(): void {
-        // The match must be case-insensitive so that "volume 62, 2024" is treated the same as
-        // "Volume 62, 2024"
-        $text = '{{Cite journal|volume=62|issue=volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('issue');
-        $this->assertNull($template->get2('issue'));
-        $this->assertSame('62', $template->get2('volume'));
+        $t = $this->tidy_issue('{{Cite journal|volume=62|issue=volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertNull($t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
     }
 
     public function testAnnualReviewBogusIssueNoComma(): void {
-        // The comma between volume number and year is optional: "Volume 62 2024" must also be
-        // recognised and cleaned up
-        $text = '{{Cite journal|volume=62|issue=Volume 62 2024|journal=Annual Review of Astronomy and Astrophysics}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('issue');
-        $this->assertNull($template->get2('issue'));
-        $this->assertSame('62', $template->get2('volume'));
+        $t = $this->tidy_issue('{{Cite journal|volume=62|issue=Volume 62 2024|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertNull($t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
     }
 
     public function testAnnualReviewBogusIssueImplausibleYearNotRemoved(): void {
-        // The year component must look like a plausible publication year (1900-2099).
-        // A four-digit string that is not a valid year (e.g. "0001") must not trigger
-        // the Visual Editor clean-up rule and must be left untouched.
-        $text = '{{Cite journal|volume=62|issue=Volume 62, 0001|journal=Annual Review of Astronomy and Astrophysics}}';
-        $template = $this->make_citation($text);
-        $template->tidy_parameter('issue');
-        $this->assertSame('Volume 62, 0001', $template->get2('issue'));
-        $this->assertSame('62', $template->get2('volume'));
+        $t = $this->tidy_issue('{{Cite journal|volume=62|issue=Volume 62, 0001|journal=Annual Review of Astronomy and Astrophysics}}');
+        $this->assertSame('Volume 62, 0001', $t->get2('issue'));
+        $this->assertSame('62', $t->get2('volume'));
     }
 }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1888,31 +1888,43 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('title'));
     }
 
-    public function testAnnualReviewBogusIssue(): void {
-        // issue=Volume N, YEAR is a bogus value inserted by Visual Editor for Annual Review journals
+    public function testAnnualReviewBogusIssueVolumePresent(): void {
+        // issue=Volume N, YEAR is a bogus value inserted by Visual Editor for Annual Review journals;
+        // when |volume= is already set the bogus issue should be dropped and volume left untouched
         $text = '{{Cite journal|volume=62|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('issue');
         $this->assertNull($template->get2('issue'));
-        $this->assertSame('62', $template->get2('volume')); // volume preserved
+        $this->assertSame('62', $template->get2('volume'));
+    }
 
-        // When volume is absent, the number should be moved into volume
+    public function testAnnualReviewBogusIssueVolumeAbsent(): void {
+        // When |volume= is absent the volume number embedded in the bogus issue value should be
+        // moved into |volume=
         $text = '{{Cite journal|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('issue');
         $this->assertNull($template->get2('issue'));
         $this->assertSame('62', $template->get2('volume'));
+    }
 
-        // Case-insensitive match
+    public function testAnnualReviewBogusIssueCaseInsensitive(): void {
+        // The match must be case-insensitive so that "volume 62, 2024" is treated the same as
+        // "Volume 62, 2024"
         $text = '{{Cite journal|volume=62|issue=volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('issue');
         $this->assertNull($template->get2('issue'));
+        $this->assertSame('62', $template->get2('volume'));
+    }
 
-        // Without comma: "Volume 62 2024"
+    public function testAnnualReviewBogusIssueNoComma(): void {
+        // The comma between volume number and year is optional: "Volume 62 2024" must also be
+        // recognised and cleaned up
         $text = '{{Cite journal|volume=62|issue=Volume 62 2024|journal=Annual Review of Astronomy and Astrophysics}}';
         $template = $this->make_citation($text);
         $template->tidy_parameter('issue');
         $this->assertNull($template->get2('issue'));
+        $this->assertSame('62', $template->get2('volume'));
     }
 }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1887,4 +1887,32 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $template->final_tidy();
         $this->assertNull($template->get2('title'));
     }
+
+    public function testAnnualReviewBogusIssue(): void {
+        // issue=Volume N, YEAR is a bogus value inserted by Visual Editor for Annual Review journals
+        $text = '{{Cite journal|volume=62|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('issue');
+        $this->assertNull($template->get2('issue'));
+        $this->assertSame('62', $template->get2('volume')); // volume preserved
+
+        // When volume is absent, the number should be moved into volume
+        $text = '{{Cite journal|issue=Volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('issue');
+        $this->assertNull($template->get2('issue'));
+        $this->assertSame('62', $template->get2('volume'));
+
+        // Case-insensitive match
+        $text = '{{Cite journal|volume=62|issue=volume 62, 2024|journal=Annual Review of Astronomy and Astrophysics}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('issue');
+        $this->assertNull($template->get2('issue'));
+
+        // Without comma: "Volume 62 2024"
+        $text = '{{Cite journal|volume=62|issue=Volume 62 2024|journal=Annual Review of Astronomy and Astrophysics}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('issue');
+        $this->assertNull($template->get2('issue'));
+    }
 }


### PR DESCRIPTION
This pull request improves the handling of bogus "issue" parameter values in citations for Annual Review journals, specifically cleaning up cases where Visual Editor inserts values like "Volume N, YEAR" into the `issue` field. The changes ensure that such values are either moved to the `volume` field or removed, depending on whether `volume` is already set, and only when the year appears plausible.
**Bug fix and data cleanup for Annual Review citations:**

* Updated `tidy_parameter` in `Template.php` to detect and handle `issue` values of the form "Volume N, YEAR" (or similar), moving the volume number to the `volume` field if it is not already set, or removing the bogus `issue` if `volume` is present. This only applies if the year is in the 1900s or 2000s, and the match is case-insensitive and allows for an optional comma.

**Testing improvements:**

* Added a suite of PHPUnit tests in `templatePart4Test.php` to verify correct cleanup of Annual Review bogus `issue` values, including tests for case insensitivity, optional comma, and ensuring only plausible years trigger the cleanup.