### PR TITLE
Fix generational suffix handling in Vancouver System

### DIFF
--- a/src/includes/NameTools.php
+++ b/src/includes/NameTools.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/constants.php';    // @codeCoverageIgnore
 
-/* junior_test - tests a name for a Junior appellation
+/* junior_test - tests a name for a Junior appellation or generational suffix
  * Input: $name - the name to be tested
- * Output: array ($name without Jr, if $name ends in Jr, Jr)
+ * Output: array ($name without suffix, generational suffix if present)
+ * Recognized suffixes: Jr, Jr., and ordinal numbers (2nd, 3rd, 4th, 5th, etc.)
  */
 
 /** @return array<string> */
@@ -18,6 +19,11 @@ function junior_test(string $name): array {
         $junior = mb_substr($name, -4) === " Jr." ? " Jr." : "";
         if ($junior) {
             $name = mb_substr($name, 0, -4);
+        } else {
+            if (preg_match('~ (\d+(?:st|nd|rd|th)\.?)$~i', $name, $matches)) {
+                $junior = ' ' . $matches[1];
+                $name = mb_substr($name, 0, -mb_strlen($junior));
+            }
         }
     }
     if (mb_substr($name, -1) === ",") {

--- a/src/includes/NameTools.php
+++ b/src/includes/NameTools.php
@@ -20,7 +20,7 @@ function junior_test(string $name): array {
         if ($junior) {
             $name = mb_substr($name, 0, -4);
         } else {
-            if (preg_match('~ (\d+(?:st|nd|rd|th)\.?)$~i', $name, $matches)) {
+            if (preg_match('~ (\d{1,2}(?:st|nd|rd|th)\.?)$~i', $name, $matches)) {
                 $junior = ' ' . $matches[1];
                 $name = mb_substr($name, 0, -mb_strlen($junior));
             }

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3283,10 +3283,16 @@ final class Template
                         if ($v !== '') {
                             $v .= ', ';
                         }
-                        $v .= mb_trim($lv . ' ' . mb_substr($fv, 0, 1));
-                        $lve = explode(' ', $fv);
+                        $jr_test = junior_test($fv);
+                        $fv_base = mb_trim($jr_test[0]);
+                        $fv_suffix = $jr_test[1];
+                        $v .= mb_trim($lv . ' ' . mb_substr($fv_base, 0, 1));
+                        $lve = explode(' ', $fv_base);
                         if (array_key_exists(1, $lve)) {
                             $v .= mb_substr($lve[1], 0, 1);
+                        }
+                        if ($fv_suffix !== '') {
+                            $v .= $fv_suffix;
                         }
                         $i++;
                     }

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3283,9 +3283,9 @@ final class Template
                         if ($v !== '') {
                             $v .= ', ';
                         }
-                        $jr_test = junior_test($fv);
-                        $fv_base = mb_trim($jr_test[0]);
-                        $fv_suffix = $jr_test[1];
+                        $suffix_test = junior_test($fv);
+                        $fv_base = mb_trim($suffix_test[0]);
+                        $fv_suffix = $suffix_test[1];
                         $v .= mb_trim($lv . ' ' . mb_substr($fv_base, 0, 1));
                         $lve = explode(' ', $fv_base);
                         if (array_key_exists(1, $lve)) {

--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -108,7 +108,7 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                                 $first .= '.';
                                             }
                                             $i++;
-                                            $this_template->add_if_new("author{$i}", $names[1] . $junior . ',' . $first, 'entrez');
+                                            $this_template->add_if_new("author{$i}", $names[1] . ',' . $first . $junior, 'entrez');
                                         }
                                     } else {
                                         // We probably have a committee or similar.    Just use 'author$i'.

--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -99,9 +99,9 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                     } elseif (mb_strlen($subItem) > 100) {
                                         break;    // @codeCoverageIgnore
                                     } elseif (author_is_human($subItem)) {
-                                        $jr_test = junior_test($subItem);
-                                        $subItem = $jr_test[0];
-                                        $junior = $jr_test[1];
+                                        $suffix_test = junior_test($subItem);
+                                        $subItem = $suffix_test[0];
+                                        $junior = $suffix_test[1];
                                         if (preg_match("~(.*) (\w+)$~", $subItem, $names)) {
                                             $first = mb_trim(preg_replace('~(?<=[A-Z])([A-Z])~', ". $1", $names[2]));
                                             if (mb_strpos($first, '.') && mb_substr($first, -1) !== '.') {

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1904,4 +1904,29 @@ EP - 999 }}';
         $this->assertNotEmpty($expanded->get2('journal'),
             'Journal name should be added from published article metadata');
     }
+
+    public function testVancGenerationalSuffixInVauthors(): void {
+        // Bug fix: bot was writing "Jacob p 3" instead of "Jacob P 3rd"
+        // When first1 contains a generational suffix like "P 3rd", convert_to_vanc
+        // must strip it, extract initials, then re-append the suffix.
+        $text = '{{cite journal |title=Test Title |last1=Jacob |first1=P 3rd }}';
+        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_VANC;
+        $template = $this->make_citation($text);
+        $template->initial_author_params_set([]);
+        $result = $template->parsed_text();
+        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+        $this->assertStringContainsString('Jacob P 3rd', $result);
+    }
+
+    public function testVancJrSuffixInVauthors(): void {
+        // Existing Jr suffix must also be handled correctly in convert_to_vanc
+        // when the suffix has been placed in the first name field (e.g., "P Jr").
+        $text = '{{cite journal |title=Test Title |last1=Smith |first1=P Jr }}';
+        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_VANC;
+        $template = $this->make_citation($text);
+        $template->initial_author_params_set([]);
+        $result = $template->parsed_text();
+        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+        $this->assertStringContainsString('Smith P Jr', $result);
+    }
 }

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1905,28 +1905,16 @@ EP - 999 }}';
             'Journal name should be added from published article metadata');
     }
 
-    public function testVancGenerationalSuffixInVauthors(): void {
-        // Bug fix: bot was writing "Jacob p 3" instead of "Jacob P 3rd"
-        // When first1 contains a generational suffix like "P 3rd", convert_to_vanc
-        // must strip it, extract initials, then re-append the suffix.
-        $text = '{{cite journal |title=Test Title |last1=Jacob |first1=P 3rd }}';
-        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_VANC;
-        $template = $this->make_citation($text);
-        $template->initial_author_params_set([]);
-        $result = $template->parsed_text();
-        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
-        $this->assertStringContainsString('Jacob P 3rd', $result);
-    }
-
-    public function testVancJrSuffixInVauthors(): void {
-        // Existing Jr suffix must also be handled correctly in convert_to_vanc
-        // when the suffix has been placed in the first name field (e.g., "P Jr").
-        $text = '{{cite journal |title=Test Title |last1=Smith |first1=P Jr }}';
-        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_VANC;
-        $template = $this->make_citation($text);
-        $template->initial_author_params_set([]);
-        $result = $template->parsed_text();
-        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
-        $this->assertStringContainsString('Smith P Jr', $result);
+    public function testVancSuffixInVauthors(): void {
+        // Regression: ordinal and Jr suffixes must be preserved in Vancouver output.
+        foreach ([['Jacob', 'P 3rd', 'Jacob P 3rd'], ['Smith', 'P Jr', 'Smith P Jr']] as [$last, $first, $expected]) {
+            $text = "{{cite journal |title=Test Title |last1={$last} |first1={$first} }}";
+            Template::$name_list_style = VancStyle::NAME_LIST_STYLE_VANC;
+            $template = $this->make_citation($text);
+            $template->initial_author_params_set([]);
+            $result = $template->parsed_text();
+            Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+            $this->assertStringContainsString($expected, $result);
+        }
     }
 }

--- a/tests/phpunit/includes/api/pubmedTest.php
+++ b/tests/phpunit/includes/api/pubmedTest.php
@@ -120,4 +120,16 @@ final class pubmedTest extends testBaseClass {
         $this->assertFalse($result);
         $this->assertSame('123–130', $template->get2('pages'));
     }
+
+    public function testAuthorOrdinalSuffixStoredInFirstName(): void {
+        // Regression test for the APIPubMed generational-suffix bug.
+        // Old broken code stored 'Jacob P,3rd' (suffix on last-name side of the comma),
+        // causing convert_to_vanc to produce 'Jacob P 3' instead of 'Jacob P 3rd'.
+        // Fixed code calls junior_test() first and stores 'Jacob,P 3rd' (suffix on
+        // first-name side), so last1/first1 split cleanly and Vancouver output is correct.
+        $template = $this->make_citation('{{cite journal}}');
+        $template->add_if_new('author1', 'Jacob,P 3rd', 'entrez');
+        $this->assertSame('Jacob', $template->get2('last1'));
+        $this->assertSame('P 3rd', $template->get2('first1'));
+    }
 }

--- a/tests/phpunit/includes/api/pubmedTest.php
+++ b/tests/phpunit/includes/api/pubmedTest.php
@@ -122,11 +122,7 @@ final class pubmedTest extends testBaseClass {
     }
 
     public function testAuthorOrdinalSuffixStoredInFirstName(): void {
-        // Regression test for the APIPubMed generational-suffix bug.
-        // Old broken code stored 'Jacob P,3rd' (suffix on last-name side of the comma),
-        // causing convert_to_vanc to produce 'Jacob P 3' instead of 'Jacob P 3rd'.
-        // Fixed code calls junior_test() first and stores 'Jacob,P 3rd' (suffix on
-        // first-name side), so last1/first1 split cleanly and Vancouver output is correct.
+        // Regression: ordinal suffix (e.g. '3rd') must land on the first-name side of the comma.
         $template = $this->make_citation('{{cite journal}}');
         $template->add_if_new('author1', 'Jacob,P 3rd', 'entrez');
         $this->assertSame('Jacob', $template->get2('last1'));

--- a/tests/phpunit/includes/nameToolsTest.php
+++ b/tests/phpunit/includes/nameToolsTest.php
@@ -227,6 +227,41 @@ final class nameToolsTest extends testBaseClass {
         $this->assertSame("", $result[1]);
     }
 
+    public function testJunior8(): void {
+        $text = "Smith 2nd";
+        $result = junior_test($text);
+        $this->assertSame("Smith", $result[0]);
+        $this->assertSame(" 2nd", $result[1]);
+    }
+
+    public function testJunior9(): void {
+        $text = "Smith 3rd";
+        $result = junior_test($text);
+        $this->assertSame("Smith", $result[0]);
+        $this->assertSame(" 3rd", $result[1]);
+    }
+
+    public function testJunior10(): void {
+        $text = "Smith 4th";
+        $result = junior_test($text);
+        $this->assertSame("Smith", $result[0]);
+        $this->assertSame(" 4th", $result[1]);
+    }
+
+    public function testJunior11(): void {
+        $text = "Smith, 3rd";
+        $result = junior_test($text);
+        $this->assertSame("Smith", $result[0]);
+        $this->assertSame(" 3rd", $result[1]);
+    }
+
+    public function testJunior12(): void {
+        $text = "Jacob P 3rd"; // PubMed-style: LastName Initials Suffix
+        $result = junior_test($text);
+        $this->assertSame("Jacob P", $result[0]);
+        $this->assertSame(" 3rd", $result[1]);
+    }
+
     /** Random extra code coverage tests */
     public function testFormat1(): void {
         $this->assertSame('& a. Johnson', format_surname('& A. Johnson'));

--- a/tests/phpunit/includes/nameToolsTest.php
+++ b/tests/phpunit/includes/nameToolsTest.php
@@ -235,28 +235,14 @@ final class nameToolsTest extends testBaseClass {
     }
 
     public function testJunior9(): void {
-        $text = "Smith 3rd";
-        $result = junior_test($text);
-        $this->assertSame("Smith", $result[0]);
-        $this->assertSame(" 3rd", $result[1]);
-    }
-
-    public function testJunior10(): void {
-        $text = "Smith 4th";
-        $result = junior_test($text);
-        $this->assertSame("Smith", $result[0]);
-        $this->assertSame(" 4th", $result[1]);
-    }
-
-    public function testJunior11(): void {
         $text = "Smith, 3rd";
         $result = junior_test($text);
         $this->assertSame("Smith", $result[0]);
         $this->assertSame(" 3rd", $result[1]);
     }
 
-    public function testJunior12(): void {
-        $text = "Jacob P 3rd"; // PubMed-style: LastName Initials Suffix
+    public function testJunior10(): void {
+        $text = "Jacob P 3rd";
         $result = junior_test($text);
         $this->assertSame("Jacob P", $result[0]);
         $this->assertSame(" 3rd", $result[1]);


### PR DESCRIPTION
This pull request enhances the handling of generational suffixes (such as "Jr.", "2nd", "3rd", etc.) in author names throughout the codebase, ensuring these suffixes are correctly recognized, stored, and displayed in various citation formats. I
**Improvements to suffix detection and handling:**

* Expanded the `junior_test` function in `NameTools.php` to recognize not only "Jr" and "Jr." but also ordinal generational suffixes (e.g., "2nd", "3rd", "4th", etc.), and updated its documentation accordingly. [
* Updated `convert_to_vanc` in `Template.php` to use the enhanced `junior_test` function, ensuring that generational suffixes are preserved in Vancouver-style author lists.
* Modified the PubMed API integration in `APIPubMed.php` to correctly store and place generational suffixes on the first-name side of the comma in author fields.

**Testing and regression coverage:**

* Added new PHPUnit tests in `TemplatePart3Test.php`, `pubmedTest.php`, and `nameToolsTest.php` to verify correct behavior for names with generational suffixes, including both Vancouver output and PubMed parsing.