### PR TITLE
Skip HDL handle tests on API unavailability instead of failing

### DIFF
--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1167,7 +1167,11 @@ EP - 999 }}';
     public function testHandles1(): void {
         unset(HandleCache::$cache_hdl_null['10125/20269']);
         $template = $this->make_citation('{{Cite web|url=http://hdl.handle.net/10125/20269////;jsessionid=dfasddsa|journal=X}}');
-        $this->assertTrue($template->get_identifiers_from_url());
+        $result = $template->get_identifiers_from_url();
+        if (!$result && isset(HandleCache::$cache_hdl_null['10125/20269'])) {
+            $this->markTestSkipped('HDL API did not respond (rate limit or outage)');
+        }
+        $this->assertTrue($result);
         $this->assertSame('10125/20269', $template->get2('hdl'));
         $this->assertSame('cite web', $template->wikiname());
         $this->assertNotNull($template->get2('url'));
@@ -1187,6 +1191,9 @@ EP - 999 }}';
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
+        if ($template->get2('hdl') !== '10125/20269' && isset(HandleCache::$cache_hdl_null['10125/20269'])) {
+            $this->markTestSkipped('HDL API did not respond (rate limit or outage)');
+        }
         $this->assertSame('cite web', $template->wikiname());
         $this->assertSame('10125/20269', $template->get2('hdl'));
         $this->assertNotNull($template->get2('url'));
@@ -1203,6 +1210,9 @@ EP - 999 }}';
         unset(HandleCache::$cache_hdl_null['10125/20269']);
         $template = $this->make_citation('{{Cite journal|url=https://scholarspace.manoa.hawaii.edu/handle/10125/20269}}');
         $template->get_identifiers_from_url();
+        if ($template->get2('hdl') !== '10125/20269' && isset(HandleCache::$cache_hdl_null['10125/20269'])) {
+            $this->markTestSkipped('HDL API did not respond (rate limit or outage)');
+        }
         $this->assertSame('10125/20269', $template->get2('hdl'));
         $this->assertNotNull($template->get2('url'));
     }

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1164,12 +1164,18 @@ EP - 999 }}';
         $this->assertSame('2', $template->get2('volume'));
     }
 
+    private function skipIfHdlUnavailable(string $handle): void {
+        if (isset(HandleCache::$cache_hdl_null[$handle])) {
+            $this->markTestSkipped('HDL API did not respond (rate limit or outage)');
+        }
+    }
+
     public function testHandles1(): void {
         unset(HandleCache::$cache_hdl_null['10125/20269']);
         $template = $this->make_citation('{{Cite web|url=http://hdl.handle.net/10125/20269////;jsessionid=dfasddsa|journal=X}}');
         $result = $template->get_identifiers_from_url();
-        if (!$result && isset(HandleCache::$cache_hdl_null['10125/20269'])) {
-            $this->markTestSkipped('HDL API did not respond (rate limit or outage)');
+        if (!$result) {
+            $this->skipIfHdlUnavailable('10125/20269');
         }
         $this->assertTrue($result);
         $this->assertSame('10125/20269', $template->get2('hdl'));
@@ -1191,8 +1197,8 @@ EP - 999 }}';
             sleep(run_type_mods(-1, 15, 15, 5, 15));
             $template->get_identifiers_from_url(); // This test is finicky sometimes
         }
-        if ($template->get2('hdl') !== '10125/20269' && isset(HandleCache::$cache_hdl_null['10125/20269'])) {
-            $this->markTestSkipped('HDL API did not respond (rate limit or outage)');
+        if ($template->get2('hdl') !== '10125/20269') {
+            $this->skipIfHdlUnavailable('10125/20269');
         }
         $this->assertSame('cite web', $template->wikiname());
         $this->assertSame('10125/20269', $template->get2('hdl'));
@@ -1210,8 +1216,8 @@ EP - 999 }}';
         unset(HandleCache::$cache_hdl_null['10125/20269']);
         $template = $this->make_citation('{{Cite journal|url=https://scholarspace.manoa.hawaii.edu/handle/10125/20269}}');
         $template->get_identifiers_from_url();
-        if ($template->get2('hdl') !== '10125/20269' && isset(HandleCache::$cache_hdl_null['10125/20269'])) {
-            $this->markTestSkipped('HDL API did not respond (rate limit or outage)');
+        if ($template->get2('hdl') !== '10125/20269') {
+            $this->skipIfHdlUnavailable('10125/20269');
         }
         $this->assertSame('10125/20269', $template->get2('hdl'));
         $this->assertNotNull($template->get2('url'));


### PR DESCRIPTION
`testHandles1`, `testHandles2`, and `testHandles4` make live HTTP requests to `hdl.handle.net` to verify handle `10125/20269` resolves. When the API is unreachable, `hdl_works()` returns `null` and populates `HandleCache::$cache_hdl_null` — causing hard test failures rather than skips.

## Changes

- **`TemplatePart3Test`**: Added private `skipIfHdlUnavailable(string $handle)` helper that calls `markTestSkipped` when the handle is found in `HandleCache::$cache_hdl_null`
- Applied the guard to all three affected tests after a failed attempt, matching the existing skip pattern used in `pubmedTest`, `S2apiTest`, and `unpaywallApiTest`

```php
private function skipIfHdlUnavailable(string $handle): void {
    if (isset(HandleCache::$cache_hdl_null[$handle])) {
        $this->markTestSkipped('HDL API did not respond (rate limit or outage)');
    }
}
```

`testHandles2` already retried twice before asserting — the skip guard is placed after those retries are exhausted.