### PR TITLE
Fix output page visual clutter and opacity regression introduced by WCAG 2.1 changes

### DIFF
--- a/src/assets/results.css
+++ b/src/assets/results.css
@@ -47,12 +47,12 @@ header a, footer a { text-decoration: none; }
 a { color: #0a5f8f; }
 
 span.added      { color: #008060; font-weight: bold;}
-span.boring     { color: #bbb; }
+span.boring     { color: #bbb; } /* Intentionally low contrast: boring items are incidental progress noise (WCAG 1.4.3 incidental-text exception) */
 span.changed    { color: #0070a8; font-weight: bold;}
 span.reddish    { color: #8c3f6e; }
 span.removed    { color: #8a5800; font-weight: bold;}
 span.subitem    { color: #666; }
-span.subsubitem { color: #999; }
+span.subsubitem { color: #999; } /* Intentionally low contrast: supplementary sub-items are incidental progress noise (WCAG 1.4.3 incidental-text exception) */
 span.warning    { color: #b34700; }
 
 /* Visible focus outline for keyboard navigation (WCAG 2.4.7) */

--- a/src/assets/results.css
+++ b/src/assets/results.css
@@ -47,12 +47,12 @@ header a, footer a { text-decoration: none; }
 a { color: #0a5f8f; }
 
 span.added      { color: #008060; font-weight: bold;}
-span.boring     { color: #767676; }
+span.boring     { color: #bbb; }
 span.changed    { color: #0070a8; font-weight: bold;}
 span.reddish    { color: #8c3f6e; }
 span.removed    { color: #8a5800; font-weight: bold;}
 span.subitem    { color: #666; }
-span.subsubitem { color: #767676; }
+span.subsubitem { color: #999; }
 span.warning    { color: #b34700; }
 
 /* Visible focus outline for keyboard navigation (WCAG 2.4.7) */

--- a/src/includes/big_jobs.php
+++ b/src/includes/big_jobs.php
@@ -56,7 +56,7 @@ function big_jobs_check_overused(int $page_count): void {
     }
     define('BIG_JOB_MODE', 'YES');
     register_shutdown_function('big_jobs_we_died', $lock_file); // We now have a lock file that will magically go away when code dies/quits
-    report_warning("Large job mode: running " . (string) $page_count . " pages — detailed per-parameter output is suppressed to conserve memory.");
+    report_warning("Large job mode: running " . $page_count . " pages — detailed per-parameter output is suppressed to conserve memory.");
 }
 
 function big_jobs_check_killed(): void {

--- a/src/includes/big_jobs.php
+++ b/src/includes/big_jobs.php
@@ -56,6 +56,7 @@ function big_jobs_check_overused(int $page_count): void {
     }
     define('BIG_JOB_MODE', 'YES');
     register_shutdown_function('big_jobs_we_died', $lock_file); // We now have a lock file that will magically go away when code dies/quits
+    report_warning("Large job mode: running " . (string) $page_count . " pages — detailed per-parameter output is suppressed to conserve memory.");
 }
 
 function big_jobs_check_killed(): void {


### PR DESCRIPTION
The WCAG 2.1 CSS pass changed `span.boring` from `#bbb` → `#767676` and `span.subsubitem` from `#999` → `#767676`. These items are generated at very high volume during processing — in BIG_JOB_MODE (50+ page batches) every per-parameter tick emits one. Promoting them to clearly-visible grey flooded the output with hundreds of individual `>.` / `..` lines, destroying the visual hierarchy and making the page appear broken.

Additionally, BIG_JOB_MODE truncates all `added`/`removed`/`changed`/`subitem` text to `.` to conserve memory, but emitted no signal to the user — explaining the `+.` / `-.` / `~.` output with no descriptive text.

## Changes

- **`results.css`** — Revert `span.boring` to `#bbb` and `span.subsubitem` to `#999`. Both classes represent incidental progress noise exempt from WCAG 1.4.3 contrast requirements under the *incidental text* exception; annotated accordingly.
- **`big_jobs.php`** — Emit a `report_warning` immediately after `BIG_JOB_MODE` is defined, notifying the user that detailed per-parameter output is suppressed for the run.