### PR TITLE
Fix numeric ordinal suffix handling in firstN params and Vancouver conversion

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3313,6 +3313,22 @@ final class Template
         if ($this->has('veditors')) {
             $this->had_initial_eds = true;
         }
+        // Wrap numeric ordinal suffixes (2nd, 3rd, 4th, etc.) in firstN / editor-firstN
+        // parameters with accept-as-written markup to suppress the CS1 maint: numeric names
+        // maintenance category.  Jr and Jr. are text suffixes and do not need wrapping.
+        // This runs after any first/last → vauthors conversion, so only params that remain
+        // in first/last format (i.e. non-Vancouver citations) are affected.
+        foreach ($this->param as $p) {
+            if (preg_match('~^(?:first|editor-first)\d*$~', $p->param) && $p->val !== '') {
+                if (mb_substr($p->val, 0, 2) !== '((') {
+                    $suffix_test = junior_test($p->val);
+                    $suffix = $suffix_test[1];
+                    if ($suffix !== '' && preg_match('~^ \d~', $suffix)) {
+                        $p->val = '((' . mb_trim($p->val) . '))';
+                    }
+                }
+            }
+        }
     }
 
     public function change_name_to(string $new_name, bool $rename_cite_book = true, bool $rename_anything = false): void {

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3313,11 +3313,7 @@ final class Template
         if ($this->has('veditors')) {
             $this->had_initial_eds = true;
         }
-        // Wrap numeric ordinal suffixes (2nd, 3rd, 4th, etc.) in firstN / editor-firstN
-        // parameters with accept-as-written markup to suppress the CS1 maint: numeric names
-        // maintenance category.  Jr and Jr. are text suffixes and do not need wrapping.
-        // This runs after any first/last → vauthors conversion, so only params that remain
-        // in first/last format (i.e. non-Vancouver citations) are affected.
+        // Wrap numeric ordinal suffixes in firstN/editor-firstN with ((...)) to suppress CS1 maint: numeric names.
         foreach ($this->param as $p) {
             if (preg_match('~^(?:first|editor-first)\d*$~', $p->param) && $p->val !== '') {
                 if (mb_substr($p->val, 0, 2) !== '((') {

--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -104,7 +104,7 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                         $junior = $suffix_test[1];
                                         if (preg_match("~(.*) (\w+)$~", $subItem, $names)) {
                                             $first = mb_trim(preg_replace('~(?<=[A-Z])([A-Z])~', ". $1", $names[2]));
-                                            if (mb_strpos($first, '.') && mb_substr($first, -1) !== '.') {
+                                            if ($first !== '' && mb_substr($first, -1) !== '.' && (mb_strpos($first, '.') !== false || $junior !== '')) {
                                                 $first .= '.';
                                             }
                                             $i++;

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1926,9 +1926,7 @@ EP - 999 }}';
     }
 
     public function testOrdinalSuffixWrappedInFirstNameNonVanc(): void {
-        // When NOT using Vancouver style, a numeric ordinal suffix in firstN must be
-        // wrapped in ((...)) accept-as-written markup to suppress the CS1 maint:
-        // numeric names maintenance message.  Jr (text suffix) must NOT be wrapped.
+        // Non-Vancouver: numeric ordinal suffix in firstN must be wrapped in ((...)).
         $text = '{{cite journal |title=Test Title |last1=Jacob |first1=P. 3rd }}';
         Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
         $template = $this->make_citation($text);
@@ -1937,7 +1935,7 @@ EP - 999 }}';
     }
 
     public function testJrSuffixNotWrappedInFirstName(): void {
-        // Jr is a text suffix, not a numeric ordinal; it must never be wrapped.
+        // Text suffix Jr must not be wrapped.
         $text = '{{cite journal |title=Test Title |last1=Smith |first1=P. Jr }}';
         Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
         $template = $this->make_citation($text);

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1924,4 +1924,24 @@ EP - 999 }}';
             $this->assertStringContainsString($expected, $result);
         }
     }
+
+    public function testOrdinalSuffixWrappedInFirstNameNonVanc(): void {
+        // When NOT using Vancouver style, a numeric ordinal suffix in firstN must be
+        // wrapped in ((...)) accept-as-written markup to suppress the CS1 maint:
+        // numeric names maintenance message.  Jr (text suffix) must NOT be wrapped.
+        $text = '{{cite journal |title=Test Title |last1=Jacob |first1=P. 3rd }}';
+        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+        $template = $this->make_citation($text);
+        $result = $template->parsed_text();
+        $this->assertStringContainsString('((P. 3rd))', $result);
+    }
+
+    public function testJrSuffixNotWrappedInFirstName(): void {
+        // Jr is a text suffix, not a numeric ordinal; it must never be wrapped.
+        $text = '{{cite journal |title=Test Title |last1=Smith |first1=P. Jr }}';
+        Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+        $template = $this->make_citation($text);
+        $result = $template->parsed_text();
+        $this->assertStringNotContainsString('((', $result);
+    }
 }

--- a/tests/phpunit/includes/api/pubmedTest.php
+++ b/tests/phpunit/includes/api/pubmedTest.php
@@ -128,4 +128,13 @@ final class pubmedTest extends testBaseClass {
         $this->assertSame('Jacob', $template->get2('last1'));
         $this->assertSame('P 3rd', $template->get2('first1'));
     }
+
+    public function testAuthorOrdinalSuffixWithPeriodOnInitial(): void {
+        // entrez_api now stores a period on the initial before appending the suffix,
+        // so the split yields first = "P. 3rd" (not "P 3rd" or "3rd").
+        $template = $this->make_citation('{{cite journal}}');
+        $template->add_if_new('author1', 'Jacob,P. 3rd', 'entrez');
+        $this->assertSame('Jacob', $template->get2('last1'));
+        $this->assertSame('P. 3rd', $template->get2('first1'));
+    }
 }

--- a/tests/phpunit/includes/api/pubmedTest.php
+++ b/tests/phpunit/includes/api/pubmedTest.php
@@ -130,8 +130,7 @@ final class pubmedTest extends testBaseClass {
     }
 
     public function testAuthorOrdinalSuffixWithPeriodOnInitial(): void {
-        // entrez_api now stores a period on the initial before appending the suffix,
-        // so the split yields first = "P. 3rd" (not "P 3rd" or "3rd").
+        // Period is appended to initial when suffix is present: "P. 3rd" not "P 3rd".
         $template = $this->make_citation('{{cite journal}}');
         $template->add_if_new('author1', 'Jacob,P. 3rd', 'entrez');
         $this->assertSame('Jacob', $template->get2('last1'));


### PR DESCRIPTION
This pull request adds logic to handle numeric ordinal suffixes in author/editor first names for citations, ensuring they are properly wrapped to suppress a specific maintenance warning.

**Handling of numeric ordinal suffixes in citation parameters:**

* Updated `convert_to_vanc()` in `Template.php` to wrap numeric ordinal suffixes in `firstN` and `editor-firstN` parameters with `((...))`, preventing "CS1 maint: numeric names" warnings. This only applies when the suffix is numeric (e.g., "3rd") and not for text suffixes like "Jr".

**Testing improvements:**

* Added `testOrdinalSuffixWrappedInFirstNameNonVanc` to verify that numeric suffixes in `firstN` are wrapped in `((...))` for non-Vancouver citation styles.
* Added `testJrSuffixNotWrappedInFirstName` to ensure that text suffixes like "Jr" are not wrapped.

**Documentation and clarity:**

* Clarified the comment in `testAuthorOrdinalSuffixWithPeriodOnInitial` to better explain the expected formatting of initials and suffixes.