### PR TITLE
Fix skip-link CSS using clip-path for visibility on focus

### DIFF
--- a/src/assets/results.css
+++ b/src/assets/results.css
@@ -67,18 +67,27 @@ a:focus-visible {
 /* Skip navigation link – visible only on focus (WCAG 2.4.1) */
 .skip-link {
   position: absolute;
-  left: -9999px;
-  top: auto;
+  left: 0;
+  top: 0;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   width: 1px;
   height: 1px;
   overflow: hidden;
+  white-space: nowrap;
 }
 .skip-link:focus {
-  position: static;
+  clip: auto;
+  clip-path: none;
   width: auto;
   height: auto;
   overflow: visible;
-  left: auto;
+  white-space: normal;
+  z-index: 9999;
+  padding: 0.5em 1em;
+  background: #fff;
+  border: 2px solid #0a5f8f;
+  border-radius: 0 0 4px 0;
 }
 
 /* Visually hidden but available to screen readers (WCAG 1.3.1) */


### PR DESCRIPTION
This pull request updates the styling of the `.skip-link` element in `results.css` to improve accessibility and visual presentation when focused. The most important changes are:

Accessibility and visibility improvements:

* The `.skip-link` is now visually hidden using `clip` and `clip-path` instead of positioning it off-screen, which is a more robust method for accessibility.
* On focus, the `.skip-link` becomes clearly visible with added padding, background color, border, and a higher `z-index`, making it easier for keyboard and assistive technology users to see and use.
* Ensured the link's text does not wrap when hidden (`white-space: nowrap`) and wraps normally when visible (`white-space: normal`)