### PR TITLE
Fix skip link not hidden in Chrome 

### DIFF
--- a/src/assets/results.css
+++ b/src/assets/results.css
@@ -69,25 +69,15 @@ a:focus-visible {
   position: absolute;
   left: 0;
   top: 0;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  white-space: nowrap;
-}
-.skip-link:focus {
-  clip: auto;
-  clip-path: none;
-  width: auto;
-  height: auto;
-  overflow: visible;
-  white-space: normal;
   z-index: 9999;
+  transform: translateY(-100%);
   padding: 0.5em 1em;
   background: #fff;
   border: 2px solid #0a5f8f;
   border-radius: 0 0 4px 0;
+}
+.skip-link:focus {
+  transform: translateY(0);
 }
 
 /* Visually hidden but available to screen readers (WCAG 1.3.1) */


### PR DESCRIPTION
This pull request updates the skip link focus styles in `results.css` to improve accessibility and simplify the CSS. The changes replace the previous clipping and size adjustments with a transform-based approach for visually hiding and revealing the skip link.

**Accessibility and style improvements:**

* Replaced the use of `clip`, `clip-path`, and size/overflow properties with a `transform: translateY(-100%)` to visually hide the skip link by default, and `transform: translateY(0)` to reveal it when focused. T