### PR TITLE
Skip testLatexMathInTitle on arXiv API null response (rate limiting)

### DIFF
--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -708,8 +708,7 @@ EP - 999 }}';
         $expanded = $this->process_citation($text);
         $title = $expanded->get2('title');
         if ($title === null) {
-            $this->assertFaker(); // arXiv API did not respond
-            return;
+            $this->markTestSkipped('arXiv API did not respond (rate limit or outage)');
         }
         // For some reason we sometimes get the first one - probably just ARXIV
         $title1 = 'A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc';

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -707,6 +707,10 @@ EP - 999 }}';
         $text = "{{Cite arxiv|eprint=1801.03103}}";
         $expanded = $this->process_citation($text);
         $title = $expanded->get2('title');
+        if ($title === null) {
+            $this->assertFaker(); // arXiv API did not respond
+            return;
+        }
         // For some reason we sometimes get the first one - probably just ARXIV
         $title1 = 'A Candidate $z\sim10$ Galaxy Strongly Lensed into a Spatially Resolved Arc';
         $title2 = "RELICS: A Candidate ''z'' ∼ 10 Galaxy Strongly Lensed into a Spatially Resolved Arc";


### PR DESCRIPTION
`testLatexMathInTitle` was failing with `null` title when the arXiv API returned nothing (rate limiting), since only the three known title strings were handled — `null` fell through to the failing `assertSame` branch.

## Change

Added an early `null` guard using `markTestSkipped()`, consistent with the pattern used throughout the test suite for API rate limit/outage scenarios (e.g. in `S2apiTest.php`, `pubmedTest.php`, `pageTest.php`):

```php
if ($title === null) {
    $this->markTestSkipped('arXiv API did not respond (rate limit or outage)');
}
```