### PR TITLE
Replace assertFaker with markTestSkipped in arxivTest.php

### DIFF
--- a/tests/phpunit/includes/api/arxivTest.php
+++ b/tests/phpunit/includes/api/arxivTest.php
@@ -16,7 +16,7 @@ final class arxivTest extends testBaseClass {
         $text = '{{citation |arxiv=astro-ph/9708005 |last1=Steeghs |first1=D. |last2=Harlaftis |first2=E. T. |last3=Horne |first3=Keith |title=Spiral structure in the accretion disc of the binary IP Pegasi |year=1997  |doi= |doi-broken-date= }}';
         $prepared = $this->process_citation($text);
         if ($prepared->get2('doi') === null || $prepared->get2('doi') === '') {
-            $this->assertFaker(); // arXiv API did not respond
+            $this->markTestSkipped('arXiv API did not respond (rate limit or outage)');
         } else {
             $this->assertSame('10.1093/mnras/290.2.L28', $prepared->get2('doi'));
             $this->assertNotNull($prepared->get2('doi-broken-date')); // The DOI has to not work for this test to cover the code where a title and arxiv exist and a doi is found, but the doi does not add a title


### PR DESCRIPTION
Replace the single `assertFaker()` call in `arxivTest.php` with `markTestSkipped(...)`, matching the pattern already used in `pubmedTest`, `S2apiTest`, and `unpaywallApiTest`:

```php
// Before
$this->assertFaker(); // arXiv API did not respond

// After
$this->markTestSkipped('arXiv API did not respond (rate limit or outage)');
```

The test now surfaces as ⚠ skipped rather than ✓ passed when arXiv is unreachable.