### PR TITLE
Skip testUrlReferencesWithText16 on arXiv API rate limit 

### DIFF
--- a/tests/phpunit/includes/pageTest.php
+++ b/tests/phpunit/includes/pageTest.php
@@ -401,6 +401,9 @@ final class pageTest extends testBaseClass {
     public function testUrlReferencesWithText16(): void {
         $text = "<ref>{{arxiv|0806.0013}}</ref>";
         $page = $this->process_page($text);
+        if (mb_stripos($page->parsed_text(), 'doi') === false) {
+            $this->markTestSkipped('arXiv API did not respond (rate limit or outage)');
+        }
         $this->assertTrue((bool) mb_stripos($page->parsed_text(), 'PhysRevD.78.081701'));
     }
 


### PR DESCRIPTION
`testUrlReferencesWithText16` was failing with `false is not true` because the arXiv API was rate-limited, leaving the template unexpanded and the expected DOI (`PhysRevD.78.081701`) absent from the output.

## Change

Added a `markTestSkipped` guard consistent with the pattern already used in `testGetBadDoiFromArxiv` and `testArxivExpansion`: if no `doi` was added to the parsed text, the API didn't respond and the test is skipped rather than failed.

```php
if (mb_stripos($page->parsed_text(), 'doi') === false) {
    $this->markTestSkipped('arXiv API did not respond (rate limit or outage)');
}
$this->assertTrue((bool) mb_stripos($page->parsed_text(), 'PhysRevD.78.081701'));
```

A wrong DOI in the output (API responded but incorrectly) still causes a hard failure.