### PR TITLE
Security fixes: Page name limits, sanitize debug log, CORS

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'actions' ]
+        language: [ 'javascript', 'actions', 'php' ]
         # Learn more, lokk at log files and see:
         # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'actions', 'php' ]
+        language: [ 'javascript', 'actions' ]
+        # PHP is intentionally omitted — CodeQL does not support it.
+        # PHP SAST coverage is handled by PHPStan (level 6), Psalm (taint),
+        # Phan, Progpilot, and two dependency security checkers.
         # Learn more, lokk at log files and see:
         # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
 

--- a/progpilot.json
+++ b/progpilot.json
@@ -55,12 +55,12 @@
     {
         "vuln_rule": "MUST_NOT_VERIFY_DEFINITION",
         "vuln_name": "security misconfiguration",
-        "vuln_line": 9,
-        "vuln_column": 129,
+        "vuln_line": 18,
+        "vuln_column": 467,
         "vuln_file": "src\/gadgetapi.php",
         "vuln_description": "CORS should not be allowed on all origins",
         "vuln_cwe": "CWE_346",
-        "vuln_id": "fe08183038499157970fd6a1a65a3585ebfb15be51b29909133c74ece3dc77c1",
+        "vuln_id": "c44cd39099281596281e5587205e9be86fdb11f9e9c307e2d2eff3f5e6470399",
         "vuln_type": "custom"
     }
 ]

--- a/src/gadgetapi.php
+++ b/src/gadgetapi.php
@@ -6,9 +6,6 @@ declare(strict_types=1);
 set_time_limit(120);
 
 try {
-    @header('Access-Control-Allow-Origin: *'); // Needed for gadget to work right
-    @header('Content-Type: application/json');
-
     //Set up tool requirements
     require_once __DIR__ . '/includes/setup.php';
 
@@ -17,6 +14,9 @@ try {
         throw new Exception('not a wiki');    // @codeCoverageIgnore
     }
     unset($origin);
+
+    @header('Access-Control-Allow-Origin: *'); // Needed for gadget to work right
+    @header('Content-Type: application/json');
 
     if (!is_string(@$_POST['text']) || !is_string(@$_POST['summary'])) {
         throw new Exception('not a string');    // @codeCoverageIgnore

--- a/src/includes/setup.php
+++ b/src/includes/setup.php
@@ -27,7 +27,7 @@ function bot_debug_log(string $log_this): void {
         }
         @clearstatcache(); // Deal with multiple writers, but not so paranoid that we get a file lock
         // Do all at once to avoid spreading over lines in file
-        file_put_contents(__DIR__ . '/DebugLog.txt', $base . ' :: ' . echoable(WikipediaBot::GetLastUser()) . " :: " . echoable(Page::$last_title) . " :: " . $log_this . "\n", FILE_APPEND);
+        file_put_contents(__DIR__ . '/DebugLog.txt', $base . ' :: ' . echoable(WikipediaBot::GetLastUser()) . " :: " . echoable(Page::$last_title) . " :: " . echoable($log_this) . "\n", FILE_APPEND);
     }
 }
 

--- a/src/process_page.php
+++ b/src/process_page.php
@@ -89,6 +89,17 @@ if (!empty($_REQUEST["edit"]) && is_string($_REQUEST["edit"])) {
 
 $pages_to_do = array_unique(explode('|', $pages));
 unset($pages);
+
+foreach ($pages_to_do as $a_page) {
+    if (mb_strlen($a_page) > 255) {
+        report_warning(
+            'Page name "' . echoable(mb_substr($a_page, 0, 80)) . '…" is too long.'
+        );
+        bot_html_footer();
+        exit(0);
+    }
+}
+
 unset($_GET, $_POST, $_REQUEST); // Memory minimize
 
 edit_a_list_of_pages($pages_to_do, $api, $edit_summary_end);


### PR DESCRIPTION
## Summary

Three low-risk security fixes for the citation-bot codebase, focused on hardening input validation, access control, and CI coverage.

---

### 1. Page name length limits

`src/process_page.php`

Adds per-page validation after the `explode('|')` split at line 90, checking each page name against Wikipedia's 255-byte max title length. Catches all three input paths (CLI, GET, POST) in a single validation point. Oversized pages produce a warning and clean exit. Uses `echoable()` to safely truncate the page name in the error message (80 char preview) to avoid leaking full input.

### 2. Sanitize debug log output

`src/includes/setup.php`

Wraps the `$log_this` parameter of `bot_debug_log()` with `echoable()` before writing to `DebugLog.txt`. The other two fields (WikipediaBot user and page title) were already sanitized — `$log_this` (which carries user-controlled data like page names, URLs, DOIs) was not. `echoable()` applies `htmlspecialchars()` in HTML mode to prevent XSS if the log file is ever viewed in a browser, and passes through unchanged in CLI mode.

### 3. CORS header after origin validation

`src/gadgetapi.php`

Moves `Access-Control-Allow-Origin: *` and `Content-Type: application/json` from before the `setup.php` include to after the `*.wikipedia.org` / `mdwiki.org` origin validation. Previously the wildcard CORS header was emitted for every request regardless of origin, including rejected ones. Now it is only sent for validated wiki origins. The gadget API contract is unchanged — valid origins receive identical headers as before.