### PR TITLE
Add retry+skip resilience to testCategoryMembers1 for Wikipedia API 

### DIFF
--- a/tests/phpunit/includes/wikipediaBotTest.php
+++ b/tests/phpunit/includes/wikipediaBotTest.php
@@ -14,9 +14,25 @@ final class wikipediaBotTest extends testBaseClass {
         $this->assertFaker();
     }
 
+    private function category_members_with_retry(string $category): array {
+        $backoff_delays = [2, 5];
+        $members = WikipediaBot::category_members($category);
+        foreach ($backoff_delays as $delay) {
+            if ($members !== []) {
+                return $members;
+            }
+            sleep($delay);
+            $members = WikipediaBot::category_members($category);
+        }
+        if ($members === []) {
+            $this->markTestSkipped('Wikipedia API unavailable after retries (rate limit or outage)');
+        }
+        return $members;
+    }
+
     public function testCategoryMembers1(): void {
         new TestPage(); // Fill page name with test name for debugging
-        $this->assertTrue(count(WikipediaBot::category_members('Indian drama films')) > 10);
+        $this->assertTrue(count($this->category_members_with_retry('Indian drama films')) > 10);
     }
 
     public function testCategoryMembers2(): void {


### PR DESCRIPTION

Follows the same pattern established in ConstantsTest.php (is_redirect_with_retry) for handling transient Wikipedia API failures. Retries with 2s/5s backoff, then marks the test as skipped if the API is persistently unavailable.