### PR TITLE
fix: strip trailing volume suffix from pages parameter

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -5913,6 +5913,8 @@ final class Template
                     } else {
                         $this->set($param, safe_preg_replace("~^[.,;]*\s*(.*?)\s*[,.]*$~", "$1", $this->get($param))); // Not trailing ;
                     }
+                    $value = preg_replace('~\s*,?\s*(?i)vol(?:ume)?\.?\s*\d+\s*$~u', '', $this->get($param));
+                    $this->set($param, $value);
                     if (mb_substr($this->get($param), -4) === ' etc') {
                         $this->set($param, $this->get($param) . '.');
                     }

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -2436,4 +2436,47 @@ final class TemplatePart2Test extends testBaseClass {
         $this->assertNull($template->get2('website'));
     }
 
+    public function testTidyPagesVolSuffix(): void {
+        $text = '{{cite journal |volume=1 |pages=120–129 vol.1}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertSame('120–129', $template->get2('pages'));
+        $this->assertSame('1', $template->get2('volume'));
+    }
+
+    public function testTidyPagesVolSuffixCapitalized(): void {
+        $text = '{{cite journal |volume=1 |pages=120–129 Vol. 1}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertSame('120–129', $template->get2('pages'));
+    }
+
+    public function testTidyPagesVolumeSuffix(): void {
+        $text = '{{cite journal |volume=45 |pages=22 Volume 45}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertSame('22', $template->get2('pages'));
+    }
+
+    public function testTidyPagesVolSuffixWithComma(): void {
+        $text = '{{cite journal |volume=1 |pages=120–129, vol. 1}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertSame('120–129', $template->get2('pages'));
+    }
+
+    public function testTidyPagesVolSuffixNoPeriod(): void {
+        $text = '{{cite journal |volume=1 |pages=120–129 Vol 1}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertSame('120–129', $template->get2('pages'));
+    }
+
+    public function testTidyPagesVolSuffixUppercase(): void {
+        $text = '{{cite journal |volume=1 |pages=120–129 VOL.1}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertSame('120–129', $template->get2('pages'));
+    }
+
 }


### PR DESCRIPTION
When pages like '120–129 vol.1' appear and volume is already correctly set, the trailing volume reference is now stripped during tidy_parameter(). This fixes a semi-frequent pattern where vol.X is incorrectly left in the pages value.

Regex matches: vol.1, Vol. 1, Volume 1, vol 1, Vol.1 etc. (case-insensitive, optional comma, optional period, optional spaces).