### PR TITLE
Fix/link checker ignores

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,3 @@
 http://localhost:8081
+https://localhost:8081
+https://mdwiki.org/*


### PR DESCRIPTION
The link checker workflow (run #2) failed with exit code 2 . Investigation revealed two pre-existing false positives:

1. docker-compose.yml:7 has https://localhost:8081 in a port-mapping comment — only http://localhost:8081 was in .lycheeignore
2. src/index.html:88 links to https://mdwiki.org/wiki/Special:Contributions/Citation_bot — mdwiki.org blocks automated requests (403)


Changes:
- Added https://localhost:8081 to .lycheeignore (complements existing http://localhost:8081)
- Added https://mdwiki.org/* to .lycheeignore