### PR TITLE
fix: block chapter/contribution/article/section when citation template has placeholder work aliases

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -1532,6 +1532,11 @@ final class Template
                             return false;
                         }
                     }
+                    foreach (WORK_ALIASES as $work_alias) {
+                        if ($this->has('CITATION_BOT_PLACEHOLDER_' . $work_alias) && !$this->blank('CITATION_BOT_PLACEHOLDER_' . $work_alias)) {
+                            return false;
+                        }
+                    }
                 }
                 if (!$this->blank('book-title') && $this->has('title')) {
                     return false;
@@ -1549,8 +1554,15 @@ final class Template
                 if (!$this->blank('book-title') && $this->has('title')) {
                     return false;
                 }
-                if (!$this->blank(WORK_ALIASES) && $this->wikiname() === 'citation') {
-                    return false;
+                if ($this->wikiname() === 'citation') {
+                    if (!$this->blank(WORK_ALIASES)) {
+                        return false;
+                    }
+                    foreach (WORK_ALIASES as $work_alias) {
+                        if ($this->has('CITATION_BOT_PLACEHOLDER_' . $work_alias) && !$this->blank('CITATION_BOT_PLACEHOLDER_' . $work_alias)) {
+                            return false;
+                        }
+                    }
                 } // TODO - check for things that should be swapped etc.
                 $value = preg_replace('~^\[\d+\]\s*~', '', $value); // Remove chapter numbers
                 if ($this->blank(CHAPTER_ALIASES)) {
@@ -1563,8 +1575,15 @@ final class Template
                 if (!$this->blank('book-title') && $this->has('title')) {
                     return false;
                 }
-                if (!$this->blank(WORK_ALIASES) && $this->wikiname() === 'citation') {
-                    return false;
+                if ($this->wikiname() === 'citation') {
+                    if (!$this->blank(WORK_ALIASES)) {
+                        return false;
+                    }
+                    foreach (WORK_ALIASES as $work_alias) {
+                        if ($this->has('CITATION_BOT_PLACEHOLDER_' . $work_alias) && !$this->blank('CITATION_BOT_PLACEHOLDER_' . $work_alias)) {
+                            return false;
+                        }
+                    }
                 } // TODO - check for things that should be swapped etc.
                 $value = preg_replace('~^\[\d+\]\s*~', '', $value); // Remove chapter numbers
                 if ($this->blank(CHAPTER_ALIASES)) {


### PR DESCRIPTION

Prevent CS1 alias conflicts when a {{citation}} template has |journal= (or other WORK_ALIASES) and handleConferencePretendingToBeAJournal temporarily moves them to CITATION_BOT_PLACEHOLDER_* parameters before calling expand_by_doi. The existing add_if_new guards only checked live parameters, which appear blank while values are in placeholders.

This completes the fix started by #5606 (which guarded add_if_new for live WORK_ALIASES) and #5610 (which guarded rename paths for existing chapter aliases). Both missed the placeholder window.

Fixes the remaining case where |chapter= is added to {{citation}} templates that already have |journal=.