### PR TITLE
fix: prevent volume_title from overwriting article title when conference placeholder exists

### DIFF
--- a/src/includes/api/APIdoi.php
+++ b/src/includes/api/APIdoi.php
@@ -125,7 +125,16 @@ function expand_by_doi(Template $template, bool $force = false): void {
             // Check if this is a book chapter based on DOI type from the new API
             $doi_type = isset($crossRefNewAPI->type) ? (string) $crossRefNewAPI->type : '';
             $is_book_chapter = ($doi_type === 'book-chapter' || $doi_type === 'chapter' || $doi_type === 'book-section');
-            if ($crossRef->volume_title && ($template->blank(WORK_ALIASES) || $template->wikiname() === 'cite book' || ($is_book_chapter && !in_array($template->wikiname(), NO_CHAPTER_ADD)))) {
+            $work_aliases_are_blank = $template->blank(WORK_ALIASES);
+            if ($work_aliases_are_blank) {
+                foreach (WORK_ALIASES as $work_alias) {
+                    if ($template->has('CITATION_BOT_PLACEHOLDER_' . $work_alias) && !$template->blank('CITATION_BOT_PLACEHOLDER_' . $work_alias)) {
+                        $work_aliases_are_blank = false;
+                        break;
+                    }
+                }
+            }
+            if ($crossRef->volume_title && ($work_aliases_are_blank || $template->wikiname() === 'cite book' || ($is_book_chapter && !in_array($template->wikiname(), NO_CHAPTER_ADD)))) {
                 if (mb_strtolower($template->get('title')) === mb_strtolower((string) $crossRef->article_title)) {
                     // title= already holds the article title: rename it to chapter= for most templates,
                     // but for cite encyclopedia/encyclopaedia prefer keeping title= and do not add a

--- a/tests/phpunit/includes/api/DoiTest.php
+++ b/tests/phpunit/includes/api/DoiTest.php
@@ -327,6 +327,29 @@ final class DoiTest extends testBaseClass {
         $this->assertSame($text, $template->parsed_text());
     }
 
+    public function testConferenceCitationPreservesArticleTitleFromDoi(): void {
+        $text = '{{citation
+ | last1=Shugart | first1=Alan | last2=Tong | first2=Yang-hu
+ | year=1966
+ | title=IBM 2321 data cell drive
+ | journal=Proceedings of the April 26–28, 1966, Spring Joint Computer Conference
+ | publisher=Association for Computing Machinery (ACM)
+ | place=New York City, New York
+ | pages=335–345
+ | doi=10.1145/1464182.1464223
+ | isbn=978-1-4503-7892-5
+ | url=http://portal.acm.org/citation.cfm?id=1464223
+ | doi-access=free
+}}';
+        $template = $this->process_citation($text);
+        $title = $template->get2('title');
+        if ($title === null) {
+            $this->markTestSkipped('CrossRef API did not respond (rate limit or outage)');
+        }
+        $this->assertSame('IBM 2321 data cell drive', $title);
+        $this->assertNull($template->get2('chapter'));
+    }
+
     public function testGetBioRxivPublishedDoi(): void {
         $result = get_biorxiv_published_doi('10.1234/invalid');
         $this->assertNull($result);


### PR DESCRIPTION
fix: prevent volume_title from overwriting article title when conference placeholder exists

## Problem

When a {{citation}} template has |journal= (a conference proceedings name like "Proceedings of...") and |title= (the actual article title), handleConferencePretendingToBeAJournal() moves both to CITATION_BOT_PLACEHOLDER_* parameters before calling expand_by_doi(). At APIdoi.php:128, the condition $template->blank(WORK_ALIASES) returns true (because journal is in the placeholder), causing the code to enter the book-chapter branch which overwrites the article title with the volume/proceedings title from CrossRef.

## Fix

Before the branch decision, check if any CITATION_BOT_PLACEHOLDER_* work alias exists with a non-blank value. If found, treat WORK_ALIASES as not blank — routing to the else branch which correctly sets title = article_title.

Completes the fix started by #5606, #5610, and #5613 — which guarded add_if_new for live and placeholder work aliases in the chapter/contribution/article/section cases, but missed the title case.

## Changes

1. **src/includes/api/APIdoi.php** — Added placeholder work alias check before the volume_title branch decision (9 lines added, 1 modified)
2. **tests/phpunit/includes/api/DoiTest.php** — Regression test with the exact citation from the bug report, skips gracefully when CrossRef API is unavailable

## Verification

- Test passes: 2 assertions (title preserved as "IBM 2321 data cell drive", chapter not added)
- Only caller that creates CITATION_BOT_PLACEHOLDER_* work aliases is handleConferencePretendingToBeAJournal — no regression risk
- Pattern follows the identical approach from PR #5613