### PR TITLE
fix: scope pmid/pmc guard in arxiv journal revert to no-journal path only

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -6294,13 +6294,13 @@ final class Template
                     $this->tidy_parameter('publisher');
                 }
             }
-            if ($this->wikiname() === 'cite journal' && mb_stripos($this->initial_name, 'journal') === false && $this->blank(['pmid', 'pmc'])) {
+            if ($this->wikiname() === 'cite journal' && mb_stripos($this->initial_name, 'journal') === false) {
                 if ($this->has('arxiv') || $this->has('eprint')) {
                     $arxiv_journal = $this->has('journal') && mb_stripos($this->get('journal'), 'arxiv') !== false;
-                    if ($this->blank(WORK_ALIASES) || $arxiv_journal) {
-                        if ($arxiv_journal) {
-                            $this->forget('journal');
-                        }
+                    if ($arxiv_journal) {
+                        $this->forget('journal');
+                        $this->change_name_to('cite arxiv');
+                    } elseif ($this->blank(WORK_ALIASES) && $this->blank(['pmid', 'pmc'])) {
                         $this->change_name_to('cite arxiv');
                     }
                 } elseif ($this->blank(WORK_ALIASES)) {


### PR DESCRIPTION
**Title:** `fix: scope pmid/pmc guard in arxiv journal revert to no-journal path only`

**Body:**

## Summary

Fixes a regression from #5619 where the `&& $this->blank(['pmid', 'pmc'])` guard on the outer condition at `final_tidy()` line 6297 blocks the arXiv journal revert even when PubMed returns `journal=ArXiv`. The guard is still preserved for the "no journal at all" path, keeping #5619's intended behavior.

## Root Cause

PR #5619 added `&& $this->blank(['pmid', 'pmc'])` to the outer condition that gates the `cite journal → cite arxiv` revert. This was meant to prevent reverting when a PMID/PMC signals a legitimate journal publication. But in the original bug case, PMID **is** present (PubMed adds it) AND the journal is `ArXiv` (a fake name, not a real journal) — the guard blocks the revert and `journal=Arxiv` survives.

## Change

`src/includes/Template.php:6297-6309` — removed `&& $this->blank(['pmid', 'pmc'])` from the outer condition and relocated it to only gate the "no journal" path:

- **arXiv journal path** (journal contains 'arxiv'): always reverts to `cite arxiv`, regardless of PMID/PMC
- **No-journal path** (`blank(WORK_ALIASES)`): reverts only when no PMID/PMC (preserves #5619)
- **Real journal path**: never reverts (unchanged)
- The cleanup block from #5619 (strip pmid/pmc/jstor/issn from reverted `cite arxiv`) still runs
