### PR TITLE
fix: strip trailing backslash from DOI values 

### DIFF
--- a/src/includes/doiTools.php
+++ b/src/includes/doiTools.php
@@ -359,6 +359,9 @@ function sanitize_doi(string $doi): string {
             $doi = $try_doi;
         }
     }
+    if (mb_substr($doi, -1) === '\\') {
+        $doi = mb_substr($doi, 0, -1); // Remove trailing backslash (LaTeX artifact)
+    }
     $doi = safe_preg_replace('~^https?://d?x?\.?doi\.org/~i', '', $doi); // Strip URL part if present
     $doi = safe_preg_replace('~^/?d?x?\.?doi\.org/~i', '', $doi);
     $doi = safe_preg_replace('~^doi:~i', '', $doi); // Strip doi: part if present

--- a/tests/phpunit/includes/DoiToolsTest.php
+++ b/tests/phpunit/includes/DoiToolsTest.php
@@ -44,6 +44,12 @@ final class DoiToolsTest extends testBaseClass {
         $this->assertSame('10.0001/Rubbish_bot_failure_test', sanitize_doi('10.0001/Rubbish_bot_failure_test/summary'));
     }
 
+    public function testSanitizeDoiTrailingBackslash(): void {
+        new TestPage(); // Fill page name with test name for debugging
+        $this->assertSame('10.0001/Rubbish_bot_failure_test', sanitize_doi('10.0001/Rubbish_bot_failure_test\\')); // Trailing backslash
+        $this->assertSame('10.0001/Rubbish_bot_failure_test', sanitize_doi('10.0001/Rubbish_bot_failure_test')); // No backslash, unchanged
+    }
+
     public function testJstorInDoi(): void {
         $template = $this->prepare_citation('{{cite journal|jstor=|pmid=<!-- -->|pmc=<!-- -->|arxiv=<!-- -->}}');
         $doi = '10.2307/3241423?junk'; // test 10.2307 code and ? code


### PR DESCRIPTION
## Summary

Fixes (https://en.wikipedia.org/wiki/User_talk:Citation_bot#DOI_ends_in_%5C)
from Wikipedia User talk:Citation bot — DOIs with a trailing backslash
(LaTeX copy-paste artifact) are not sanitized, resulting in malformed
identifiers like `10.1234/abc\`.

## Changes

- **src/includes/doiTools.php** — Added trailing backslash check in
  `sanitize_doi()`, following the same pattern as the existing  trailing-period handling
- **tests/phpunit/includes/DoiToolsTest.php** — Added
  `testSanitizeDoiTrailingBackslash` with positive (backslash stripped) and
  negative (no backslash, unchanged) assertions
