### PR TITLE
Normalize non-breaking hyphen (U+2011) to regular hyphen in citation parameters

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3625,6 +3625,8 @@ final class Template
                 $this->set($param, safe_preg_replace('~^\=+\s*(?![^a-zA-Z0-9\[\'\"])~u', '', $this->get($param))); // Remove leading ='s sign if in front of letter or number
                 $this->set($param, safe_preg_replace('~&#x2010;~u', '-', $this->get($param)));
                 $this->set($param, safe_preg_replace('~\x{2010}~u', '-', $this->get($param)));
+                $this->set($param, safe_preg_replace('~&#x2011;~u', '-', $this->get($param)));
+                $this->set($param, safe_preg_replace('~\x{2011}~u', '-', $this->get($param)));
                 $this->set($param, safe_preg_replace('~&#x2013;~u', '&ndash;', $this->get($param)));
                 $this->set($param, safe_preg_replace('~&#x2014;~u', '&mdash;', $this->get($param)));
                 $this->set($param, safe_preg_replace('~&#x00026;~u', '&', $this->get($param)));


### PR DESCRIPTION
**Normalize non-breaking hyphen (U+2011) to regular hyphen in citation parameters**

Fixes bug from the Wikipedia bug tracker: non-breaking hyphens (`‑`, U+2011) in citation parameters — such as journal names like `Eighteenth‑Century Studies` — are now normalized to regular hyphens during `tidy_parameter()`.

This is an extension of the existing hyphen normalization at `Template.php:3626-3627`, which already handles U+2010 (hyphen), U+2013 (en-dash as `&ndash;`), and U+2014 (em-dash as `&mdash;`). Two lines were added to also cover U+2011 (non-breaking hyphen), matching the same pattern used for ISSN normalization at line 4433.

**Before:** `Eighteenth‑Century Studies` (non-breaking hyphen renders correctly but prevents desirable line-breaking after "Eighteenth‑")

**After:** `Eighteenth-Century Studies` (regular hyphen, allows natural line breaks)
