### PR TITLE
Fix/ssrn retry loop

### DIFF
--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -129,7 +129,15 @@ final class Zotero {
                     self::expand_by_zotero($template, 'https://tools.ietf.org/html/rfc' . $template->get('rfc'));
                 }
                 if ($template->has('ssrn')) {
-                    self::expand_by_zotero($template, 'https://papers.ssrn.com/sol3/papers.cfm?abstract_id=' . $template->get('ssrn'));
+                    for ($attempt = 0; $attempt < 3; $attempt++) {
+                        if ($attempt > 0) {
+                            sleep($attempt === 1 ? 2 : 5);
+                        }
+                        self::expand_by_zotero($template, 'https://papers.ssrn.com/sol3/papers.cfm?abstract_id=' . $template->get('ssrn'));
+                        if ($template->has('title')) {
+                            break;
+                        }
+                    }
                     static $ssrn_calls = 0;
                     $ssrn_calls++;
                     sleep($ssrn_calls <= 1 ? 2 : 5);

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -129,6 +129,11 @@ final class Zotero {
                     self::expand_by_zotero($template, 'https://tools.ietf.org/html/rfc' . $template->get('rfc'));
                 }
                 if ($template->has('ssrn')) {
+                    // Progressive backoff before SSRN Zotero calls to prevent rate limiting
+                    static $ssrn_calls = 0;
+                    $ssrn_calls++;
+                    sleep($ssrn_calls <= 1 ? 2 : 5);
+                    // Attempt Zotero expansion with retries if no metadata received
                     for ($attempt = 0; $attempt < 3; $attempt++) {
                         if ($attempt > 0) {
                             sleep($attempt === 1 ? 2 : 5);
@@ -138,9 +143,6 @@ final class Zotero {
                             break;
                         }
                     }
-                    static $ssrn_calls = 0;
-                    $ssrn_calls++;
-                    sleep($ssrn_calls <= 1 ? 2 : 5);
                 }
             }
             $doi = $template->get('doi'); // might have changed

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -143,6 +143,9 @@ final class Zotero {
                             break;
                         }
                     }
+                    if (!$template->has('title')) {
+                        report_warning("SSRN metadata not available from Citoid for abstract_id=" . $template->get('ssrn'));
+                    }
                 }
             }
             $doi = $template->get('doi'); // might have changed

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -144,7 +144,7 @@ final class Zotero {
                         }
                     }
                     if (!$template->has('title')) {
-                        report_warning("SSRN metadata not available from Citoid for abstract_id=" . $template->get('ssrn'));
+                        report_warning("SSRN metadata not available from Citoid for abstract_id=" . echoable($template->get('ssrn')));
                     }
                 }
             }


### PR DESCRIPTION
### Changes

- **Backoff** — 2s delay before the first SSRN Zotero call, 5s before subsequent calls on the same page. Prevents rate-limit collisions between consecutive SSRN references.
- **Retry** — If the Zotero call returns no metadata, retries up to 2 more times with 2s then 5s delays. Handles transient failures from SSRN's unreliable server.
- **Warning** — When all 3 attempts fail, emits a `report_warning` in the bot's output: "SSRN metadata not available from Citoid for abstract_id=..."