### PR TITLE
Add chapter URL detection, newline handling, and JSTOR ID extraction

### DIFF
--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -19,6 +19,7 @@ const DOI_BAD_ENDS2 = ['/abstract', '/full', '/pdf', '/epdf', '/asset/', '/summa
  * This function converts formatting from external sources into wiki style
  */
 function wikify_external_text(string $title): string {
+    $title = str_replace(["\r\n", "\n", "\r"], ' ', $title);
     $replacement = [];
     $placeholder = [];
     $title = safe_preg_replace_callback('~(?:\$\$)([^\$]+)(?:\$\$)~iu',

--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -1496,6 +1496,9 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
             return false;
         }
     } // JSTOR
+    if (preg_match('~^https?://(?:www\.|)jstor\.org/stable/(\d{3,})$~i', $url, $matches) && $template->blank('jstor')) {
+        $template->add_if_new('jstor', $matches[1]);
+    }
     if (preg_match('~^https?://(?:www\.|)archive\.org/detail/jstor\-(\d{5,})$~i', $url, $matches)) {
         $template->add_if_new('jstor', $matches[1]);
         if (!$url_sent) {

--- a/src/includes/miscTools.php
+++ b/src/includes/miscTools.php
@@ -355,6 +355,9 @@ function should_url2chapter(Template $template, bool $force): bool {
     if ((mb_stripos($url, 'emerald.com') !== false || mb_stripos($url, 'emeraldinsight.com') !== false) && mb_stripos($url, '/chapter-') !== false) {
         return true;
     }
+    if (mb_stripos($url, 'wiley.com') !== false && preg_match('~\.ch\d+$~i', $url)) {
+        return true;
+    }
     return false;
 }
 

--- a/tests/phpunit/includes/MiscToolsTest.php
+++ b/tests/phpunit/includes/MiscToolsTest.php
@@ -419,6 +419,21 @@ final class MiscToolsTest extends testBaseClass {
         $this->assertTrue(should_url2chapter($template, false));
     }
 
+    public function testShouldUrl2ChapterWileyChapter(): void {
+        $template = $this->make_citation('{{cite book |chapter=Test |url=https://onlinelibrary.wiley.com/doi/10.1002/9781119999999.ch23}}');
+        $this->assertTrue(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterWileyJournal(): void {
+        $template = $this->make_citation('{{cite book |chapter=Test |url=https://onlinelibrary.wiley.com/doi/10.1002/j.1460-244X.1963.tb00217.x}}');
+        $this->assertFalse(should_url2chapter($template, false));
+    }
+
+    public function testShouldUrl2ChapterWileySubdomain(): void {
+        $template = $this->make_citation('{{cite book |chapter=Test |url=https://onlinelibrary.wiley.com/doi/book/10.1002/0470845015.ch1}}');
+        $this->assertTrue(should_url2chapter($template, false));
+    }
+
     public function testRunTypeModsReturnsInt(): void {
         $result = run_type_mods(-1, 10, 20, 30, 40);
         $this->assertIsInt($result);

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1567,9 +1567,12 @@ EP - 999 }}';
     }
 
     public function testNullDOInoCrash(): void { // This DOI does not work, but CrossRef does have a record
-        $text = '{{cite journal | doi=10.5604/01.3001.0012.8474 |doi-broken-date=<!-- --> |pmid=<!-- -->|pmc=<!-- -->}}';
-        $template = $this->process_citation($text);
-        $this->assertSame('{{cite journal |last1=Kofel |first1=Dominika |title=To Dye or Not to Dye: Bioarchaeological Studies of Hala Sultan Tekke Site, Cyprus |journal=Światowit |date=2019 |volume=56 |pages=89–98 | doi=10.5604/01.3001.0012.8474 |doi-broken-date=<!-- --> |pmid=<!-- -->|pmc=<!-- -->}}', $template->parsed_text());
+        $this->requires_secrets(function (): void {
+            HandleCache::$cache_hdl_bad['10.5604/01.3001.0012.8474'] = true; // Force broken-doi scenario: DOI now resolves but test needs broken-with-metadata
+            $text = '{{cite journal | doi=10.5604/01.3001.0012.8474 |doi-broken-date=<!-- --> |pmid=<!-- -->|pmc=<!-- -->}}';
+            $template = $this->process_citation($text);
+            $this->assertSame('{{cite journal |last1=Kofel |first1=Dominika |title=To Dye or Not to Dye: Bioarchaeological Studies of Hala Sultan Tekke Site, Cyprus |journal=Światowit |date=2019 |volume=56 |pages=89–98 | doi=10.5604/01.3001.0012.8474 |doi-broken-date=<!-- --> |pmid=<!-- -->|pmc=<!-- -->}}', $template->parsed_text());
+        });
     }
 
     public function testTidySomeStuff(): void {

--- a/tests/phpunit/includes/UrlToolsTest.php
+++ b/tests/phpunit/includes/UrlToolsTest.php
@@ -1016,4 +1016,18 @@ final class UrlToolsTest extends testBaseClass {
         $this->assertNull($template->get2('url'));
         $this->assertSame('cite news', $template->wikiname());
     }
+
+    public function testJstorStableToIdentifier(): void {
+        $text = '{{cite journal|url=https://www.jstor.org/stable/3347357|title=X}}';
+        $template = $this->make_citation($text);
+        $this->assertTrue($template->get_identifiers_from_url());
+        $this->assertSame('3347357', $template->get2('jstor'));
+    }
+
+    public function testJstorStableKeepsExistingDifferent(): void {
+        $text = '{{cite journal|url=https://www.jstor.org/stable/3347357|jstor=999999|title=X}}';
+        $template = $this->make_citation($text);
+        $template->get_identifiers_from_url();
+        $this->assertSame('999999', $template->get2('jstor'));
+    }
 }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1232,4 +1232,17 @@ final class textToolsTest extends testBaseClass {
     public function testCleanVolumeNostradamusReturnsEmpty(): void {
         $this->assertSame('', clean_volume('nostradamus'));
     }
+
+    public function testWikifyExternalTextNewlineToSpace(): void {
+        $this->assertSame('Lax monad something else', wikify_external_text("Lax monad\nsomething else"));
+    }
+
+    public function testWikifyExternalTextCRLFToSpace(): void {
+        $this->assertSame('Line one Line two', wikify_external_text("Line one\r\nLine two"));
+    }
+
+    public function testWikifyExternalTextNewlineWithMath(): void {
+        $result = wikify_external_text("x\n$$ y $$");
+        $this->assertStringNotContainsString("\n", $result);
+    }
 }


### PR DESCRIPTION

Source:

- miscTools.php: detect Wiley Online Library chapter URLs (.ch\d+$ suffix on wiley.com) in should_url2chapter() 

- TextTools.php: replace raw \r\n/\n/\r with spaces at the start of wikify_external_text() to prevent title truncation from API metadata 
- URLtools.php: extract JSTOR stable ID from jstor.org/stable/ URLs and add |jstor= parameter 

Tests:

- MiscToolsTest.php: 3 tests for Wiley chapter URL detection (positive: .ch23, negative: /doi/ journal, positive: subdomain)

- textToolsTest.php: 3 tests for newline-to-space conversion (\n, \r\n, with math)

- UrlToolsTest.php: 2 tests for JSTOR ID extraction (clean URL, existing |jstor= preserved)

- TemplatePart3Test.php: fix testNullDOInoCrash — add requires_secrets() guard and HandleCache::$cache_hdl_bad to force broken-DOI scenario while preserving the original test intention (the DOI now resolves at doi.org, so the cache forces verify_doi() to treat it as broken while CrossRef expansion still populates metadata)
