### PR TITLE
Fix/title Strip non-printable characters (U+FFFC and control characters) from Zotero/Citoid-sourced titles.

### DIFF
--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -397,6 +397,10 @@ final class Zotero {
         unset($result->nameOfAct);
         unset($result->language);
         unset($result->source);
+        // Strip non-printable characters from title (e.g. U+FFFC from URL percent-encoding)
+        if (isset($result->title)) {
+            $result->title = safe_preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\x{FFFC}]/u', '', (string) $result->title);
+        }
         /* Different API endpoints */
         if (isset($result->identifiers->doi) && empty($result->DOI)) {
             $result->DOI = $result->identifiers->doi;

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1494,4 +1494,28 @@ final class zoteroTest extends testBaseClass {
         Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
         $this->assertNull($template->get2('work'));
     }
+
+    public function testUfffcStrippedFromTitle(): void {
+        $text = '{{cite web|id=}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = '';
+        $zotero_data = [];
+        $zotero_data[0] = (object) ['title' => "Clean Title\u{fffc} with Object Replacement Character", 'itemType' => 'webpage'];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertSame('Clean Title with Object Replacement Character', $template->get2('title'));
+    }
+
+    public function testControlCharsStrippedFromTitle(): void {
+        $text = '{{cite web|id=}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = '';
+        $zotero_data = [];
+        $zotero_data[0] = (object) ['title' => "Title\x00with\x01control\x08chars", 'itemType' => 'webpage'];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertSame('Titlewithcontrolchars', $template->get2('title'));
+    }
 }


### PR DESCRIPTION
## Summary

Strip non-printable characters (U+FFFC and control characters) from Zotero/Citoid-sourced titles.

## Problem

When a citation URL contains percent-encoded non-printable characters such as `%ef%bf%bc` (U+FFFC Object Replacement Character), the decoded character can propagate into the page's HTML `<title>` tag. The Citoid/Zotero API returns this character in the `title` field, and the bot stores it verbatim with no sanitization.

For example, a URL like `https://example.com/page%ef%bf%bc/` results in a citation title containing the literal U+FFFC character.

## Fix

In `process_zotero_response()`, strip non-printable control characters (U+0000–U+0008, U+000B, U+000C, U+000E–U+001F, U+007F–U+009F) and U+FFFC from `$result->title` once on the object immediately after the data is parsed, before it reaches any of the three code paths that consume it.

## Changes

- **`src/includes/api/APIzotero.php`**: Add `safe_preg_replace` cleanup of non-printable characters from `$result->title`
- **`tests/phpunit/includes/api/zoteroTest.php`**: Add two tests verifying U+FFFC and control characters are stripped
