### PR TITLE
JSTOR: handle book IDs (j.ctt*), strip query params, and handle .pdf suffix

### DIFF
--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -1461,6 +1461,12 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
             $url = 'https://www.jstor.org/stable/' . $matches[1];
             $update_url($url_type, $url);
         }
+        if (preg_match('~^(https?://(?:www\.|)jstor\.org/stable/[^?]+)\?~i', $url, $matches)) {
+            if ($matches[1] !== $url) {
+                $url = $matches[1];
+                $update_url($url_type, $url);
+            }
+        }
 
         if (preg_match('~^https?://(?:www\.|)jstor\.org/stable/(?:pdf|pdfplus)/(.+)\.pdf$~i', $url, $matches) ||
             preg_match('~^https?://(?:www\.|)jstor\.org/tc/accept\?origin=(?:\%2F|/)stable(?:\%2F|/)pdf(?:\%2F|/)(\d{3,})\.pdf$~i', $url, $matches)) {
@@ -1496,7 +1502,7 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
             return false;
         }
     } // JSTOR
-    if (preg_match('~^https?://(?:www\.|)jstor\.org/stable/(\d{3,})$~i', $url, $matches) && $template->blank('jstor')) {
+    if (preg_match('~^https?://(?:www\.|)jstor\.org/stable/([\w.]+?)(?:\.pdf)?$~i', $url, $matches) && $template->blank('jstor')) {
         $template->add_if_new('jstor', $matches[1]);
     }
     if (preg_match('~^https?://(?:www\.|)archive\.org/detail/jstor\-(\d{5,})$~i', $url, $matches)) {

--- a/tests/phpunit/includes/UrlToolsTest.php
+++ b/tests/phpunit/includes/UrlToolsTest.php
@@ -1030,4 +1030,25 @@ final class UrlToolsTest extends testBaseClass {
         $template->get_identifiers_from_url();
         $this->assertSame('999999', $template->get2('jstor'));
     }
+
+    public function testJstorBookIdExtraction(): void {
+        $text = '{{cite journal|url=https://www.jstor.org/stable/j.ctt802dw|title=X}}';
+        $template = $this->make_citation($text);
+        $this->assertTrue($template->get_identifiers_from_url());
+        $this->assertSame('j.ctt802dw', $template->get2('jstor'));
+    }
+
+    public function testJstorCleanQueryParams(): void {
+        $text = '{{cite journal|url=https://www.jstor.org/stable/j.ctt802dw?turn_away=true&refreqid=fastly-default:xxx|title=X}}';
+        $template = $this->make_citation($text);
+        $this->assertTrue($template->get_identifiers_from_url());
+        $this->assertSame('j.ctt802dw', $template->get2('jstor'));
+    }
+
+    public function testJstorPdfExtensionStripped(): void {
+        $text = '{{cite journal|url=https://www.jstor.org/stable/3347357.pdf|title=X}}';
+        $template = $this->make_citation($text);
+        $this->assertTrue($template->get_identifiers_from_url());
+        $this->assertSame('3347357', $template->get2('jstor'));
+    }
 }


### PR DESCRIPTION
- Widens stable ID extraction regex from (\d{3,}) to ([\w.]+?)(?:\.pdf)?$ to capture book IDs like j.ctt802dw while stripping .pdf file extensions.
- Strips all query parameters from jstor.org/stable/ URLs before extraction.
- Adds 3 tests: book ID extraction, query param cleanup, .pdf suffix handling.
- Verified no false positives: .pdf suffix is properly handled and does not produce incorrect captures.