### PR TITLE
Add ResearchGate DOI guard and page-level display-authors detection from cs1 config

### DIFF
--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -40,6 +40,7 @@ class Page {
     private bool $odnb_sub_removed = false;
     private DateStyle $date_style = DateStyle::DATES_WHATEVER;
     private VancStyle $name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+    private string $page_display_authors = '';
     private string $read_at = '';
     private string $start_text = '';
     private int $lastrevid = 0;
@@ -129,6 +130,7 @@ class Page {
         $this->start_text = $this->text;
         $this->set_date_pattern();
         $this->set_name_list_style();
+        $this->set_page_display_authors();
 
         if (preg_match('~\#redirect *\[\[~i', $this->text)) {
             report_warning("Page is a redirect."); // @codeCoverageIgnoreStart
@@ -350,6 +352,7 @@ class Page {
         Template::$all_templates = &$all_templates; // Pointer to save memory
         Template::$date_style = $this->date_style;
         Template::$name_list_style = $this->name_list_style;
+        Template::$page_display_authors = $this->page_display_authors;
         foreach ($all_templates as $this_template) {
             if ($this_template->wikiname() === 'void') {
                 $this_template->block_modifications();
@@ -569,6 +572,7 @@ class Page {
         Template::$all_templates = [];
         Template::$date_style = DateStyle::DATES_WHATEVER;
         Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+        Template::$page_display_authors = '';
         unset($all_templates);
 
         $old_text = $this->text;
@@ -1022,6 +1026,13 @@ class Page {
             }
         }
         $this->name_list_style = $name_list_style;
+    }
+
+    private function set_page_display_authors(): void {
+        $pattern = '/{{\s*?cs1\s*?config[^}]*?display-authors\s*?=\s*?(\w+)\b[^}]*?}}/im';
+        if (preg_match($pattern, $this->text, $matches)) {
+            $this->page_display_authors = mb_strtolower($matches[1]);
+        }
     }
 
     private function set_cs2_mode(): void {

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -28,6 +28,7 @@ final class Template
     public static array $all_templates = []; // List of all the Template() on the Page() including this one.  Can only be set by the page class after all templates are made
     public static DateStyle $date_style = DateStyle::DATES_WHATEVER;
     public static VancStyle $name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+    public static string $page_display_authors = '';
     /** @psalm-suppress PropertyNotSetInConstructor */
     private string $rawtext; // Must start out as unset
     public string $last_searched_doi = '';
@@ -456,7 +457,7 @@ final class Template
     }
 
     public function fix_rogue_etal(): void {
-        if ($this->blank(DISPLAY_AUTHORS)) {
+        if ($this->blank(DISPLAY_AUTHORS) && self::$page_display_authors === '') {
             $i = 2;
             while (!$this->blank(['author' . (string) $i, 'last' . (string) $i])) {
                 $i++;
@@ -818,7 +819,9 @@ final class Template
                 if ((int) mb_substr($param_name, -4) > 0 || (int) mb_substr($param_name, -3) > 0 || (int) mb_substr($param_name, -2) > 30) {
                     // Stop at 30 authors - or page codes will become cluttered!
                     if ((bool) $this->get('last29') || (bool) $this->get('author29') || (bool) $this->get('surname29')) {
-                        $this->add_if_new('display-authors', '1');
+                        if (self::$page_display_authors === '') {
+                            $this->add_if_new('display-authors', '1');
+                        }
                     }
                     return false;
                 }
@@ -6788,7 +6791,9 @@ final class Template
                     if (mb_trim($val_base) === "") {
                         $this->forget($param);
                     }
-                    $this->add_if_new('display-authors', 'etal');
+                    if (self::$page_display_authors === '') {
+                        $this->add_if_new('display-authors', 'etal');
+                    }
                 }
             }
         }

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3393,6 +3393,9 @@ final class Template
         if (mb_strpos($this->get('doi'), '10.1093') !== false && $this->wikiname() !== 'cite web') {
             return;
         }
+        if (mb_strpos($this->get('doi'), '10.13140') !== false) {
+            return;
+        }
         if ($new_name === 'cite document' && $this->blank('publisher')) {
             return;
         }

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1984,4 +1984,11 @@ EP - 999 }}';
         $result = $template->parsed_text();
         $this->assertStringNotContainsString('((', $result);
     }
+
+    public function testResearchGateGuardBlocksBookConversion(): void {
+        $text = '{{cite journal | doi=10.13140/RG.2.1.1002.9609 }}';
+        $template = $this->make_citation($text);
+        $template->change_name_to('cite book');
+        $this->assertSame('cite journal', $template->wikiname());
+    }
 }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -2003,4 +2003,30 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertSame('Volume 62, 0001', $t->get2('issue'));
         $this->assertSame('62', $t->get2('volume'));
     }
+
+    public function testPageDisplayAuthorsPreventsRogueEtal(): void {
+        Template::$page_display_authors = '3';
+        $text = '{{cite journal |last1=Smith |last2=et al. }}';
+        $template = $this->make_citation($text);
+        $template->fix_rogue_etal();
+        $this->assertNull($template->get2('display-authors'));
+        Template::$page_display_authors = '';
+    }
+
+    public function testPageDisplayAuthorsPreventsHandleEtal(): void {
+        Template::$page_display_authors = '3';
+        $text = '{{cite web|authors=Joe et al.}}';
+        $template = $this->make_citation($text);
+        $template->handle_et_al();
+        $this->assertNull($template->get2('display-authors'));
+        Template::$page_display_authors = '';
+    }
+
+    public function testPageDisplayAuthorsUnsetStillSetsEtal(): void {
+        Template::$page_display_authors = '';
+        $text = '{{cite web|authors=Joe et al.}}';
+        $template = $this->make_citation($text);
+        $template->handle_et_al();
+        $this->assertSame('etal', $template->get2('display-authors'));
+    }
 }


### PR DESCRIPTION
## Summary

Adds ResearchGate DOI guard and page-level display-authors detection from cs1 config. Fixes two Wikipedia bug reports.

## Changes

**ResearchGate DOI guard** — fixes bug report
- `Template.php`: add `10.13140/` prefix check in `change_name_to()` — blocks template type conversion for ResearchGate DOIs (same pattern as existing Oxford `10.1093/` guard)
- `TemplatePart3Test.php`: 1 test — cite journal with RG DOI stays cite journal after `change_name_to('cite book')`

**display-authors + cs1 config** — fixes bug report 
- `Page.php`: add `set_page_display_authors()` method and property (same pattern as existing `set_name_list_style()`)
- `Template.php`: add static `$page_display_authors` property; guard `add_if_new('display-authors', ...)` in `add_if_new()`, `handle_et_al()`, and `fix_rogue_etal()`
- `templatePart4Test.php`: 3 tests — guards for `handle_et_al()`, `fix_rogue_etal()`, and regression test

