### PR TITLE
Fix: call set_page_display_authors() in parse_text() method

### DIFF
--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -151,6 +151,7 @@ class Page {
         $this->start_text = $this->text;
         $this->set_date_pattern();
         $this->set_name_list_style();
+        $this->set_page_display_authors();
         $this->title = '';
         self::$last_title = '';
         $this->read_at = '';


### PR DESCRIPTION
The previous commit (#5657) added set_page_display_authors() to get_text_from() (the Wikipedia API path) but missed adding it to parse_text() (the local text parsing path). This meant the page-level {{cs1 config|display-authors=...}} was not detected when processing text directly, and the guards that prevent adding per-citation display-authors were never triggered.