### PR TITLE
Tag standalone {{doi}}/{{doi-inline}} templates with free-DOI access

### DIFF
--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -365,6 +365,12 @@ class Page {
         $our_templates_slight = [];
         /** @var array<Template> $our_templates_conferences */
         $our_templates_conferences = [];
+        // Tag standalone {{doi}} and {{doi-inline}} templates with free-DOI access
+        foreach ($all_templates as $this_template) {
+            if (in_array($this_template->wikiname(), ['doi', 'doi-inline'], true)) {
+                $this_template->set_free_doi_access();
+            }
+        }
         report_phase('Remedial work to prepare citations');
         foreach ($all_templates as $this_template) {
             set_time_limit(120);

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -7100,6 +7100,20 @@ final class Template
         return '';
     }
 
+    /** For {{doi}}/{{doi-inline}} templates: add doi-access=free if DOI matches a free prefix */
+    public function set_free_doi_access(): void {
+        $doi = $this->param_value(0);
+        if ($doi !== '') {
+            foreach (DOI_FREE_PREFIX as $prefix) {
+                if (mb_stripos($doi, $prefix) === 0) {
+                    $this->set('doi-access', 'free');
+                    report_add('doi-access: free');
+                    break;
+                }
+            }
+        }
+    }
+
     public function get_without_comments_and_placeholders(string $name): string {
         $ret = $this->get($name);
         $ret = safe_preg_replace('~<!--.*?-->~su', '', $ret); // Comments

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1955,6 +1955,27 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
+    public function testDoiFreePrefixDetected(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y}}');
+        $doi_t->set_free_doi_access();
+        $this->assertSame('free', $doi_t->get2('doi-access'));
+    }
+
+    public function testDoiInlineFreePrefixDetected(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi-inline|10.1186/s12915-020-00940-y|Title}}');
+        $doi_t->set_free_doi_access();
+        $this->assertSame('free', $doi_t->get2('doi-access'));
+    }
+
+    public function testDoiNonFreePrefixNotDetected(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi|10.1234/nonfree-example}}');
+        $doi_t->set_free_doi_access();
+        $this->assertNull($doi_t->get2('doi-access'));
+    }
+
     public function testOpenAccessRemoved(): void {
         $text = '{{cite journal|title=Test|doi=10.1234/example|open-access=yes}}';
         $template = $this->process_citation($text);


### PR DESCRIPTION
Adds a new public method Template::set_free_doi_access() that checks if the {{doi}} or {{doi-inline}} template's DOI matches a free prefix and adds doi-access=free. Called from Page::expand_text() for all extracted templates.

Also adds report_add() for console output during bot runs. Modifications tracking via Template::modifications() is automatic.

The {{doi}}/{{doi-inline}} template names are standard across all supported Wikipedias (wikiname() normalizes to lowercase).

