### PR TITLE
Fix parameter position of doi-access=free in {{doi}}/{{doi-inline}} templates

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -7106,8 +7106,12 @@ final class Template
         if ($doi !== '') {
             foreach (DOI_FREE_PREFIX as $prefix) {
                 if (mb_stripos($doi, $prefix) === 0) {
-                    $this->set('doi-access', 'free');
-                    report_add('doi-access: free');
+                    $p = new Parameter();
+                    $p->parse_text(' |doi-access=free');
+                    $p->param = 'doi-access';
+                    $p->val = 'free';
+                    $this->param[] = $p;
+                    report_add(echoable("Adding doi-access: free"));
                     break;
                 }
             }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1960,6 +1960,7 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y}}');
         $doi_t->set_free_doi_access();
         $this->assertSame('free', $doi_t->get2('doi-access'));
+        $this->assertStringContainsString('10.1186/s12915-020-00940-y| doi-access=free', $doi_t->parsed_text());
     }
 
     public function testDoiInlineFreePrefixDetected(): void {
@@ -1967,6 +1968,7 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $doi_t->parse_text('{{doi-inline|10.1186/s12915-020-00940-y|Title}}');
         $doi_t->set_free_doi_access();
         $this->assertSame('free', $doi_t->get2('doi-access'));
+        $this->assertStringContainsString('10.1186/s12915-020-00940-y|Title| doi-access=free', $doi_t->parsed_text());
     }
 
     public function testDoiNonFreePrefixNotDetected(): void {


### PR DESCRIPTION
## Summary

Fixes the parameter position of `doi-access=free` in standalone `{{doi}}`/`{{doi-inline}}` templates. Also fixes the console output format to match the standard `add()` method.

## Changes

**Template.php** — in `set_free_doi_access()`, replaced `$this->set('doi-access', 'free')` with direct Parameter creation and array append. The `set()` method uses `prior_parameters()` which inserts new parameters based on group ordering — when none of the prior group parameters exist (as is always the case for `{{doi}}` templates), the new parameter is inserted at position 0, before the unnamed DOI value. Appending directly to `$this->param[]` ensures `doi-access=free` appears after the DOI value.

**Tests** — added position assertions to verify the correct output order.

## Before/After

```
Before: {{doi|doi-access=free|10.5852/ejt.2013.69}}
After:  {{doi|10.5852/ejt.2013.69| doi-access=free}}
```

## Files

- `src/includes/Template.php` — 4 insertions, 2 deletions
- `tests/phpunit/includes/templatePart4Test.php` — 2 insertions