### PR TITLE
Fix doi-access=free spacing in set_free_doi_access()

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -7107,9 +7107,11 @@ final class Template
             foreach (DOI_FREE_PREFIX as $prefix) {
                 if (mb_stripos($doi, $prefix) === 0) {
                     $p = new Parameter();
-                    $p->parse_text(' |doi-access=free');
+                    $p->pre = $this->param[0]->pre;
                     $p->param = 'doi-access';
+                    $p->eq = '=';
                     $p->val = 'free';
+                    $p->post = '';
                     $this->param[] = $p;
                     report_add(echoable("Adding doi-access: free"));
                     break;

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1960,7 +1960,7 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y}}');
         $doi_t->set_free_doi_access();
         $this->assertSame('free', $doi_t->get2('doi-access'));
-        $this->assertStringContainsString('10.1186/s12915-020-00940-y| doi-access=free', $doi_t->parsed_text());
+        $this->assertStringContainsString('10.1186/s12915-020-00940-y|doi-access=free', $doi_t->parsed_text());
     }
 
     public function testDoiInlineFreePrefixDetected(): void {
@@ -1968,7 +1968,15 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $doi_t->parse_text('{{doi-inline|10.1186/s12915-020-00940-y|Title}}');
         $doi_t->set_free_doi_access();
         $this->assertSame('free', $doi_t->get2('doi-access'));
-        $this->assertStringContainsString('10.1186/s12915-020-00940-y|Title| doi-access=free', $doi_t->parsed_text());
+        $this->assertStringContainsString('10.1186/s12915-020-00940-y|Title|doi-access=free', $doi_t->parsed_text());
+    }
+
+    public function testDoiFreePrefixPreservesLeadingSpace(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi| 10.1186/s12915-020-00940-y}}');
+        $doi_t->set_free_doi_access();
+        $this->assertSame('free', $doi_t->get2('doi-access'));
+        $this->assertStringContainsString('10.1186/s12915-020-00940-y| doi-access=free', $doi_t->parsed_text());
     }
 
     public function testDoiNonFreePrefixNotDetected(): void {


### PR DESCRIPTION
## Summary

Fixes a spacing bug where `set_free_doi_access()` always inserted a leading space before `doi-access=free` in standalone `{{doi}}`/`{{doi-inline}}` templates, regardless of the original template's formatting.

## Bug

- Input: `{{doi|10.5852/ejt.2013.69}}` → Output: `{{doi|10.5852/ejt.2013.69| doi-access=free}}` (incorrect space)
- Input: `{{doi| 10.5852/ejt.2013.69}}` → Output: `{{doi| 10.5852/ejt.2013.69| doi-access=free}}` (correct, but only coincidentally — the space was hard-coded)

## Root Cause

`set_free_doi_access()` at `Template.php:7110` called `$p->parse_text(' |doi-access=free')`, which always set `$p->pre = ' '` (a leading space). Since `join_params()` prepends `|` before each parameter, the output was always `| doi-access=free` — with a space — regardless of the template's style.

## Fix

Instead of parsing a hard-coded format string, the method now copies the spacing from the existing template's first parameter via `$this->param[0]->pre`. This correctly inherits the formatting style:

- `{{doi|10.5852/ejt.2013.69}}` → `{{doi|10.5852/ejt.2013.69|doi-access=free}}` (no extra space) ✓
- `{{doi| 10.5852/ejt.2013.69}}` → `{{doi| 10.5852/ejt.2013.69| doi-access=free}}` (space preserved) ✓

All `pre`, `eq`, `val`, and `post` properties are now set explicitly instead of relying on `parse_text()` defaults.

## Testing

- Updated two test assertions that encoded the buggy behavior (`testDoiFreePrefixDetected`, `testDoiInlineFreePrefixDetected`)
- Added `testDoiFreePrefixPreservesLeadingSpace` to verify the leading-space case
- All 4 DOI prefix tests pass