### PR TITLE
DEV_USERS: allow trusted developers to exceed normal category limit

### DIFF
--- a/src/category.php
+++ b/src/category.php
@@ -20,6 +20,7 @@ const GET_IS_OKAY = [
     'CS1 errors: extra text: pages',
     'CS1 errors: extra text: volume',
     'CS1 errors: invisible characters',
+    'CS1 maint: article number as page number',
     'CS1 maint: bibcode',
     'CS1 maint: date format',
     'CS1 maint: extra punctuation',

--- a/src/category.php
+++ b/src/category.php
@@ -32,6 +32,11 @@ const GET_IS_OKAY = [
     'Unflagged free DOI',
 ];
 
+const DEV_USERS = [
+    'AManWithNoPlan',
+    'Redalert2fan',
+];
+
 $category = '';
 $from_get = false;
 if (is_string(@$_POST["cat"])) {
@@ -72,6 +77,12 @@ bot_html_header();
 $api = new WikipediaBot();
 check_blocked();
 
+$dev_user_run = false;
+if (!defined('MAX_PAGES_OVERRIDE') && in_array($api->get_the_user(), DEV_USERS, true)) {
+    define('MAX_PAGES_OVERRIDE', 1000000);
+    $dev_user_run = true;
+}
+
 $pages_in_category = array_unique(WikipediaBot::category_members($category));
 shuffle($pages_in_category);
 $total = count($pages_in_category);
@@ -97,6 +108,10 @@ if (defined('MAX_PAGES_OVERRIDE') && $total > $default_web_limit) {
 }
 $edit_summary_end = "| Suggested by " . $api->get_the_user() . " | [[Category:{$category}]] | #UCB_Category ";
 if (defined('MAX_PAGES_OVERRIDE')) {
-    $edit_summary_end .= "| Whitelisted category ";
+    if ($dev_user_run) {
+        $edit_summary_end .= "| Developer - max category limit override ";
+    } else {
+        $edit_summary_end .= "| Whitelisted category ";
+    }
 }
 edit_a_list_of_pages($pages_in_category, $api, $edit_summary_end);


### PR DESCRIPTION
Adds a `DEV_USERS` constant in `category.php` allowing trusted developers
to bypass the normal category page limit of 12 when running category
requests via POST.

**Changes:**

- New `DEV_USERS` constant defines the whitelist (`AManWithNoPlan`,
  `Redalert2fan`)
- If the user is in `DEV_USERS` and `MAX_PAGES_OVERRIDE` is not already
  set (from a GET-whitelisted category), the override is set to 1,000,000
- Edit summary appends `| Developer - max category limit override` for
  dev runs vs `| Whitelisted category` for GET-whitelisted category runs

**Edit summary combinations:**

| Scenario | Suffix |
|---|---|
| Normal user, ≤12 pages | *(none)* |
| Normal user, >12 pages | Cancelled |
| GET-whitelisted category, ≤250K | `\| Whitelisted category` |
| DEV_USER, ≤12 pages | *(none)* |
| DEV_USER, 13–250K pages | `\| Developer - max category limit override` |
| Any, >250K pages | Cancelled |