### PR TITLE
Perf/api request reduction

### DIFF
--- a/src/includes/api/APIBibCode.php
+++ b/src/includes/api/APIBibCode.php
@@ -155,13 +155,10 @@ function expand_by_adsabs(Template $template): void {
     if (mb_strpos($template->get('doi'), '10.1093/') === 0) {
         return;
     }
-    // If CrossRef already provided core metadata, skip ADS HTTP call.
-    // The cache-only bibcode mapping (no HTTP) already ran above at lines 108-116.
-    if ($template->has('title') && $template->has('journal') &&
-        ($template->has('year') || $template->has('date'))) {
-        $template->record_api_usage('adsabs', 'bibcode');
-        return;
-    }
+    // When CrossRef already provided core metadata, skip the title and journal
+    // fallback searches (the DOI search below still runs to find a bibcode).
+    $skip_fallback = $template->has('title') && $template->has('journal') &&
+        ($template->has('year') || $template->has('date'));
     report_action("Checking AdsAbs database");
     if ($template->has('doi') && preg_match(REGEXP_DOI, $template->get_without_comments_and_placeholders('doi'), $doi)) {
         $result = query_adsabs("identifier:" . urlencode('"' . $doi[0] . '"')); // In DOI we trust
@@ -196,7 +193,7 @@ function expand_by_adsabs(Template $template): void {
         }
     }
 
-    if ($result->numFound !== 1 && $template->has('title')) {
+    if ($result->numFound !== 1 && !$skip_fallback && $template->has('title')) {
         // Do assume failure to find arXiv means that it is not there
         $have_more = false;
         if (mb_strlen($template->get_without_comments_and_placeholders("title")) < 15 ||
@@ -246,7 +243,7 @@ function expand_by_adsabs(Template $template): void {
         }
     }
 
-    if ($result->numFound !== 1 && ($template->has('journal') || $template->has('issn'))) {
+    if ($result->numFound !== 1 && !$skip_fallback && ($template->has('journal') || $template->has('issn'))) {
         $journal = $template->get('journal');
         // try partial search using bibcode components:
         $pages = $template->page_range();

--- a/src/includes/api/APIBibCode.php
+++ b/src/includes/api/APIBibCode.php
@@ -155,6 +155,13 @@ function expand_by_adsabs(Template $template): void {
     if (mb_strpos($template->get('doi'), '10.1093/') === 0) {
         return;
     }
+    // If CrossRef already provided core metadata, skip ADS HTTP call.
+    // The cache-only bibcode mapping (no HTTP) already ran above at lines 108-116.
+    if ($template->has('title') && $template->has('journal') &&
+        ($template->has('year') || $template->has('date'))) {
+        $template->record_api_usage('adsabs', 'bibcode');
+        return;
+    }
     report_action("Checking AdsAbs database");
     if ($template->has('doi') && preg_match(REGEXP_DOI, $template->get_without_comments_and_placeholders('doi'), $doi)) {
         $result = query_adsabs("identifier:" . urlencode('"' . $doi[0] . '"')); // In DOI we trust

--- a/src/includes/api/APIdoi.php
+++ b/src/includes/api/APIdoi.php
@@ -532,6 +532,8 @@ function query_crossref_newapi(string $doi): object {
 
     if (is_object($json) && isset($json->message) && isset($json->status) && (string) $json->status === "ok") {
         $result = $json->message;
+        HandleCache::$cache_active[$doi] = true;
+        HandleCache::check_memory_use();
     } else {
         sleep(2);  // @codeCoverageIgnore
         return new stdClass(); // @codeCoverageIgnore

--- a/src/includes/api/APIunpaywall.php
+++ b/src/includes/api/APIunpaywall.php
@@ -231,6 +231,19 @@ function get_open_access_url(Template $template): void {
     if (mb_strpos($doi, '10.1093/') === 0) {
         return;
     }
+    // Skip Unpaywall HTTP call if template already has an OA identifier
+    if ($template->has('pmc') || $template->has('arxiv') || $template->has('eprint') ||
+        $template->has('citeseerx') || $template->has('biorxiv') || $template->has('medrxiv') ||
+        $template->has('rfc')) {
+        return;
+    }
+    if (($template->has('doi') && $template->get('doi-access') === 'free') ||
+        ($template->has('jstor') && $template->get('jstor-access') === 'free') ||
+        ($template->has('osti') && $template->get('osti-access') === 'free') ||
+        ($template->has('hdl') && $template->get('hdl-access') === 'free') ||
+        ($template->has('ol') && $template->get('ol-access') === 'free')) {
+        return;
+    }
     $return = get_unpaywall_url($template, $doi);
     if (in_array($return, GOOD_FREE, true)) {
         return;


### PR DESCRIPTION
Three targeted changes to reduce redundant HTTP API requests:

- **APIdoi.php:** Update HandleCache after successful CrossRef REST API response so subsequent `doi_active()` checks return from cache instead of making a duplicate HTTP request
- **APIBibCode.php:** Skip ADS HTTP call when CrossRef already populated title/journal/year — bibcode still runs
- **APIunpaywall.php:** Skip Unpaywall HTTP call when template already has OA identifiers (PMC, arXiv, eprint, etc.) or has `*-access=free`


