### PR TITLE
Prevent adding unsupported doi parameter to {{cite SSRN}} templates

### DIFF
--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -738,9 +738,11 @@ final class Zotero {
                     $result->DOI = $matches[1];
             }
             $possible_doi = sanitize_doi($result->DOI);
-            // SSRN Zotero translator returns an incomplete DOI "10.2139/" — the ssrn= parameter
-            // is the canonical identifier; the DOI is redundant and {{cite SSRN}} doesn't support it.
-            if ($template->has('ssrn') && !$template->blank('ssrn') && preg_match('~^10\.2139/?$~i', $possible_doi)) {
+            // SSRN Zotero translator returns DOIs under the SSRN prefix (10.2139/...).
+            // The ssrn= parameter is the canonical identifier; the DOI is redundant,
+            // and {{cite SSRN}} doesn't support the doi parameter.
+            if (($template->has('ssrn') && !$template->blank('ssrn') && preg_match('~^10\.2139~i', $possible_doi)) ||
+                $template->wikiname() === 'cite ssrn') {
                 $possible_doi = '';
             }
             if (doi_works($possible_doi)) {

--- a/tests/phpunit/includes/SSRNTest.php
+++ b/tests/phpunit/includes/SSRNTest.php
@@ -43,6 +43,25 @@ final class SSRNTest extends testBaseClass {
         $this->addToAssertionCount(count($cases) * 4);
     }
 
+    /** Verify that Zotero returning a complete SSRN DOI does not add it to cite ssrn template */
+    public function testSrrnZoteroDoesNotAddDoi(): void {
+        $text = '{{cite ssrn|ssrn=3724000|title=Test}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = '';
+        $zotero_data = [];
+        $zotero_data[0] = (object) [
+            'title' => 'Test',
+            'itemType' => 'report',
+            'DOI' => '10.2139/ssrn.3724000',
+        ];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertNull($template->get2('doi'));
+        $this->assertSame('cite ssrn', $template->wikiname());
+        $this->assertSame('3724000', $template->get2('ssrn'));
+    }
+
     public function testSrrnPrepareFull(): void {
         $cases = [];
         $cases[] = ['pmc', '{{cite ssrn|ssrn=936346|pmc=123456}}',


### PR DESCRIPTION
Prevent bot from adding unsupported doi parameter to {{cite SSRN}} templates when expanding metadata via Zotero.