### PR TITLE
Preserve lowercase PMID template names

### DIFF
--- a/src/includes/constants/mistakes.php
+++ b/src/includes/constants/mistakes.php
@@ -1854,7 +1854,6 @@ const TEMPLATE_CONVERSIONS = [
     ['youtube', 'YouTube'],
     ['Youtube', 'YouTube'],
     ['pmc', 'PMC'],
-    ['pmid', 'PMID'],
     ['jstor', 'JSTOR'],
     ['lccn', 'LCCN'],
     ['Pmc', 'PMC'],

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -258,6 +258,12 @@ final class TemplatePart1Test extends testBaseClass {
         $this->assertSame("{{Citation}}", $expanded->parsed_text());
     }
 
+    public function testLowercasePmidTemplateNameIsPreserved(): void {
+        $text = '{{pmid|15896339}}';
+        $page = $this->process_page($text);
+        $this->assertSame($text, $page->parsed_text());
+    }
+
     public function testCleanUpTemplates2(): void {
         $text = "{{Citeweb|page=2}}";
         $expanded = $this->process_citation($text);


### PR DESCRIPTION
Per report https://en.wikipedia.org/wiki/User_talk:Citation_bot#pmid_caps
This patch will stop Citation Bot from changing an already valid, documented {{pmid}} to {{PMID}}.
The documentation (https://en.wikipedia.org/wiki/Template:PMID/doc#Usage) does not prescribe one capitalization exclusively. So we do not need to convert {{PMID}} to lowercase or {{pmid}} to uppercase.
Both forms remain supported and existing capitalization is preserved.

- Removed the unnecessary pmid to PMID normalization.
- Added regression coverage for the reported behavior.