### PR TITLE
Fix documentation inaccuracies discovered during audit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Read AGENTS.md for full project context.
 
 Key points:
 
-- PHP 8.4+ project, GPL-3.0
+- PHP 8.4+ project, GPL-3.0-or-later
 - Tests: `php vendor/bin/phpunit`
 - Main logic: `src/includes/Template.php`
 - Code style: verbose, explicit, `elseif` not `else if`

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,92 +1,51 @@
-core:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/includes/Template.php
-      - src/includes/Parameter.php
-      - src/includes/Page.php
-
-api:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/includes/api/*
-
-tools:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/includes/NameTools.php
-      - src/includes/URLtools.php
-      - src/includes/MathTools.php
-      - src/includes/WikiThings.php
-      - src/includes/TextTools.php
-      - src/includes/doiTools.php
-      - src/includes/miscTools.php
-
-constants:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/includes/constants.php
-      - src/includes/constants/*
-
-infrastructure:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/includes/WikipediaBot.php
-      - src/includes/WebTools.php
-      - src/includes/setup.php
-      - src/includes/bot_curl.php
-      - src/includes/big_jobs.php
-      - src/includes/user_messages.php
-      - src/authenticate.php
-
-entrypoints:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/process_page.php
-      - src/gadgetapi.php
-      - src/generate_template.php
-      - src/category.php
-      - src/gitpull.php
-      - src/kill_big_job.php
-      - src/linked_pages.php
-      - src/preview_results.php
-
-frontend:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/index.html
-      - src/preview.html
-      - src/assets/*
-      - src/robots.txt
-      - src/.user.ini
-
-tests:
-  - changed-files:
-    - any-glob-to-any-file:
-      - tests/**/*
-
 ai:
   - changed-files:
     - any-glob-to-any-file:
       - AGENTS.md
-      - .gemini/GEMINI.md
-      - .claude/**
-      - .cursor/**
       - .github/copilot-instructions.md
+      - .aider.conf.yml
+      - .gemini/GEMINI.md
 
-docs:
+api:
   - changed-files:
     - any-glob-to-any-file:
-      - docs/**/*
-      - '*.md'
-      - CITATION.cff
-      - LICENSE
+      - src/includes/api/**
 
 ci:
   - changed-files:
     - any-glob-to-any-file:
-      - .github/workflows/*
-      - .github/dependabot.yml
-      - .github/labeler.yml
+      - .github/workflows/**
+
+config:
+  - changed-files:
+    - any-glob-to-any-file:
+      - composer.json
+      - composer.lock
+      - phpunit.xml.dist
+      - phpstan.neon
+      - psalm.xml
+      - .phpcs.xml
+      - progpilot.yml
+      - .phplint.yml
+      - .markdownlint-cli2.yaml
+      - src/env.php.example
+      - CITATION.cff
+      - catalog-info.yaml
+
+constants:
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/includes/constants/**
+      - src/includes/constants.php
+
+core:
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/includes/Template.php
+      - src/includes/Page.php
+      - src/includes/Parameter.php
+      - src/includes/WikiThings.php
+      - src/includes/WikipediaBot.php
 
 docker:
   - changed-files:
@@ -94,32 +53,48 @@ docker:
       - Dockerfile
       - docker-compose.yml
 
-config:
+docs:
   - changed-files:
     - any-glob-to-any-file:
+      - docs/**
+      - '**/README.md'
+      - AGENTS.md
+      - CITATION.cff
+      - .github/copilot-instructions.md
+
+entrypoints:
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/*.php
+      - src/index.html
+
+infrastructure:
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/includes/setup.php
+      - src/includes/bot_curl.php
+      - src/includes/user_messages.php
+      - src/includes/miscTools.php
+      - src/includes/WebTools.php
+      - src/includes/big_jobs.php
+
+php:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.php'
+
+tests:
+  - changed-files:
+    - any-glob-to-any-file:
+      - tests/**
       - phpunit.xml.dist
-      - progpilot.yml
-      - progpilot.json
-      - .phpcs.xml
-      - .phplint.yml
-      - phpstan.neon
-      - psalm.xml
-      - .trivyignore
-      - .markdownlint-cli2.yaml
-      - .lycheeignore
-      - .gitignore
-      - .aider.conf.yml
-      - .phan/config.php
-      - catalog-info.yaml
 
-deps:
+tools:
   - changed-files:
     - any-glob-to-any-file:
-      - composer.json
-      - composer.lock
-
-security:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/env.php.example
-      - src/authenticate.php
+      - src/includes/NameTools.php
+      - src/includes/TextTools.php
+      - src/includes/URLtools.php
+      - src/includes/doiTools.php
+      - src/includes/MathTools.php
+      - src/robots.txt

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,51 +1,91 @@
-ai:
-  - changed-files:
-    - any-glob-to-any-file:
-      - AGENTS.md
-      - .github/copilot-instructions.md
-      - .aider.conf.yml
-      - .gemini/GEMINI.md
-
-api:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/includes/api/**
-
-ci:
-  - changed-files:
-    - any-glob-to-any-file:
-      - .github/workflows/**
-
-config:
-  - changed-files:
-    - any-glob-to-any-file:
-      - composer.json
-      - composer.lock
-      - phpunit.xml.dist
-      - phpstan.neon
-      - psalm.xml
-      - .phpcs.xml
-      - progpilot.yml
-      - .phplint.yml
-      - .markdownlint-cli2.yaml
-      - src/env.php.example
-      - CITATION.cff
-      - catalog-info.yaml
-
-constants:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/includes/constants/**
-      - src/includes/constants.php
-
 core:
   - changed-files:
     - any-glob-to-any-file:
       - src/includes/Template.php
-      - src/includes/Page.php
       - src/includes/Parameter.php
+      - src/includes/Page.php
       - src/includes/WikiThings.php
+
+api:
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/includes/api/*
+
+tools:
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/includes/NameTools.php
+      - src/includes/URLtools.php
+      - src/includes/MathTools.php
+      - src/includes/TextTools.php
+      - src/includes/doiTools.php
+      - src/includes/miscTools.php
+
+constants:
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/includes/constants.php
+      - src/includes/constants/*
+
+infrastructure:
+  - changed-files:
+    - any-glob-to-any-file:
       - src/includes/WikipediaBot.php
+      - src/includes/WebTools.php
+      - src/includes/setup.php
+      - src/includes/bot_curl.php
+      - src/includes/big_jobs.php
+      - src/includes/user_messages.php
+      - src/authenticate.php
+
+entrypoints:
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/process_page.php
+      - src/gadgetapi.php
+      - src/generate_template.php
+      - src/category.php
+      - src/gitpull.php
+      - src/kill_big_job.php
+      - src/linked_pages.php
+      - src/preview_results.php
+      - src/index.html
+      - src/preview.html
+      - src/assets/*
+      - src/robots.txt
+      - src/.user.ini
+
+tests:
+  - changed-files:
+    - any-glob-to-any-file:
+      - tests/**/*
+
+ai:
+  - changed-files:
+    - any-glob-to-any-file:
+      - AGENTS.md
+      - .gemini/GEMINI.md
+      - .claude/**
+      - .cursor/**
+      - .github/copilot-instructions.md
+      - .aider.conf.yml
+
+docs:
+  - changed-files:
+    - any-glob-to-any-file:
+      - docs/**/*
+      - tests/phpunit/README.md
+      - '**/*.md'
+      - CITATION.cff
+      - LICENSE
+      - .github/copilot-instructions.md
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows/*
+      - .github/dependabot.yml
+      - .github/labeler.yml
 
 docker:
   - changed-files:
@@ -53,48 +93,33 @@ docker:
       - Dockerfile
       - docker-compose.yml
 
-docs:
+config:
   - changed-files:
     - any-glob-to-any-file:
-      - docs/**
-      - '**/README.md'
-      - AGENTS.md
-      - CITATION.cff
-      - .github/copilot-instructions.md
-
-entrypoints:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/*.php
-      - src/index.html
-
-infrastructure:
-  - changed-files:
-    - any-glob-to-any-file:
-      - src/includes/setup.php
-      - src/includes/bot_curl.php
-      - src/includes/user_messages.php
-      - src/includes/miscTools.php
-      - src/includes/WebTools.php
-      - src/includes/big_jobs.php
-
-php:
-  - changed-files:
-    - any-glob-to-any-file:
-      - '**/*.php'
-
-tests:
-  - changed-files:
-    - any-glob-to-any-file:
-      - tests/**
       - phpunit.xml.dist
+      - progpilot.yml
+      - progpilot.json
+      - .phpcs.xml
+      - .phplint.yml
+      - phpstan.neon
+      - psalm.xml
+      - .trivyignore
+      - .markdownlint-cli2.yaml
+      - .lycheeignore
+      - .gitignore
+      - .phan/config.php
+      - catalog-info.yaml
+      - src/env.php.example
+      - composer.json
+      - composer.lock
 
-tools:
+dependencies:
   - changed-files:
     - any-glob-to-any-file:
-      - src/includes/NameTools.php
-      - src/includes/TextTools.php
-      - src/includes/URLtools.php
-      - src/includes/doiTools.php
-      - src/includes/MathTools.php
-      - src/robots.txt
+      - composer.json
+      - composer.lock
+
+github_actions:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ Citation Bot is a Wikipedia maintenance tool that automatically expands and form
 
 The system has three main components:
 
-1. **Web Interface** (`index.html` + `process_page.php`) - Batch processes entire Wikipedia pages
-2. **Gadget API** (`gadgetapi.php`) - Real-time in-browser citation expansion during editing
-3. **Template Generator** (`generate_template.php`) - Creates a single wiki citation from an identifier
+1. **Web Interface** (`src/index.html` + `src/process_page.php`) - Batch processes entire Wikipedia pages
+2. **Gadget API** (`src/gadgetapi.php`) - Real-time in-browser citation expansion during editing
+3. **Template Generator** (`src/generate_template.php`) - Creates a single wiki citation from an identifier
 
 ### Core Processing Flow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,10 @@ This file provides context for AI assistants working on the Citation Bot project
 
 - Language: PHP 8.4+
 - Main logic: Template.php
-- Test command: php src/process_page.php "Page"
+- Test command: composer run test
+- CLI smoke-test (requires credentials, use --savetofiles to avoid writing to Wikipedia): php src/process_page.php "Page" --savetofiles
 - Code style: verbose, explicit, spaced-out, highly formatted style
-- First task: Read src/includes/Template.php and src/includes/Parameter.php
+- First task: Read src/includes/Template.php, src/includes/Parameter.php, and src/includes/constants/parameters.php
 
 ## Project Overview
 
@@ -17,18 +18,19 @@ Citation Bot is a Wikipedia maintenance tool that automatically expands and form
 **Key Facts:**
 
 - **Language:** PHP 8.4+
-- **License:** GPL-3.0
-- **Status:** Stable/Inactive (maintenance mode)
+- **License:** GPL-3.0-or-later
+- **Status:** Production service is active; repository is classified as stable/inactive (maintenance mode)
 - **Repository:** <https://github.com/ms609/citation-bot>
 - **Production:** <https://citations.toolforge.org>
 - **Platform:** Wikimedia Toolforge (Kubernetes)
 
 ## Architecture
 
-The system has two main components:
+The system has three main components:
 
 1. **Web Interface** (`index.html` + `process_page.php`) - Batch processes entire Wikipedia pages
 2. **Gadget API** (`gadgetapi.php`) - Real-time in-browser citation expansion during editing
+3. **Template Generator** (`generate_template.php`) - Creates a single wiki citation from an identifier
 
 ### Core Processing Flow
 
@@ -45,7 +47,7 @@ Add Missing Metadata → Clean Formatting → Post to Wikipedia
 - **`src/includes/Template.php`** - Template class - Core citation expansion logic
 - **`src/includes/Parameter.php`** - Parameter class - Template parameter handling
 - **`src/includes/WikipediaBot.php`** - WikipediaBot class - Wikipedia API client with OAuth
-- **`src/includes/WikiThings.php`** - Wiki markup handling (nowiki, comments, etc.) — contains abstract class WikiThings + 8 concrete subclasses
+- **`src/includes/WikiThings.php`** - Wiki markup handling (nowiki, comments, etc.) — contains abstract class WikiThings + 9 concrete subclasses
 - **`src/includes/URLtools.php`** - URL normalization and metadata extraction (standalone functions, no class)
 - **`src/includes/NameTools.php`** - Author name parsing and formatting (standalone functions, no class)
 - **`src/includes/MathTools.php`** - MathML to LaTeX conversion (standalone function, no class)
@@ -55,7 +57,7 @@ Add Missing Metadata → Clean Formatting → Post to Wikipedia
 **Important characteristics of this codebase:**
 
 - Uses a verbose, explicit, spaced-out, highly formatted style
-- Assignments within conditionals are common
+- Assignments within conditionals are common (to note possible side effects)
 - Multi-line if/foreach/else statements (with braces)
 - Method calls that modify state often occur within assignments
 - Do not use `else if` but do use `elseif` (they behave differently)
@@ -66,8 +68,9 @@ Add Missing Metadata → Clean Formatting → Post to Wikipedia
 
 ```php
 if ($doi = $template->get('doi')) {
-  if ($metadata = CrossRef::query($doi)) {
-    $template->add_if_new('title', $metadata->title);
+  $crossRef = query_crossref($doi);
+  if ($crossRef) {
+    $template->add_if_new('title', $crossRef->title);
   }
 }
 ```
@@ -75,11 +78,11 @@ if ($doi = $template->get('doi')) {
 **Avoid (too compact for this project):**
 
 ```php
-if ($doi = $template->get('doi') && $metadata = CrossRef::query($doi))
-  $template->add_if_new('title', $metadata->title);
+if ($doi = $template->get('doi') && $crossRef = query_crossref($doi))
+  $template->add_if_new('title', $crossRef->title);
 ```
 
-## External API Integration
+## Metadata Sources and Identifier Processors
 
 The bot integrates with multiple external services.  Sometimes these APIs will fail:
 
@@ -90,16 +93,16 @@ The bot integrates with multiple external services.  Sometimes these APIs will f
 | PubMed Central | PMC | Open access articles |
 | arXiv | arXiv ID | Scientific preprints |
 | JSTOR | JSTOR ID | Scholarly articles |
-| Zotero | URL | Generic URL metadata extraction |
+| Zotero (via Citoid) | URL | Generic URL metadata extraction via Wikimedia's Citoid endpoint |
 | SSRN (via Zotero) | SSRN ID | Social Science Research Network metadata |
 | NASA ADS | Bibcode | Astrophysical literature via SAO/NASA ADS |
-| Semantic Scholar | S2 ID / DOI | Paper metadata and citation data |
+| Semantic Scholar | S2 ID / DOI | Identifier mapping and open-access status lookup |
 | Google Books | ISBN / Google ID | Book metadata |
 | Unpaywall | DOI | Open-access location finder |
-| ISSN | ISSN | Journal metadata lookup |
-| Internet Archive | URL | Wayback Machine metadata |
+| ISSN (local) | ISSN | Hardcoded ISSN-to-newspaper mapping (no live API) |
+| Internet Archive | URL | Archive-hosted page title retrieval (Wayback Machine, Ghostarchive) |
 | PII | PII | Publisher Item Identifier to DOI conversion |
-| SICI | SICI | Serial Item and Contribution Identifier |
+| SICI (local) | SICI | Serial Item and Contribution Identifier (local parsing, no external API) |
 
 ## Operating Modes
 
@@ -109,7 +112,7 @@ The bot integrates with multiple external services.  Sometimes these APIs will f
 - Adds missing parameters
 - Cleans formatting
 - **Excludes:** bibcode searches, URL expansion
-- **Reason:** Must complete within browser timeout
+- **Reason:** Must complete within the 120-second configured time limit
 
 ### Slow Mode (Web Interface Default)
 
@@ -123,8 +126,8 @@ The bot integrates with multiple external services.  Sometimes these APIs will f
 
 ```bash
 docker compose up -d
-# Access at http://localhost:8081
-docker exec -it citation-bot-php-1 composer update
+# Access at http://localhost:8081/src/
+docker exec -it citation-bot-php-1 composer install
 ```
 
 ### Toolforge Deployment
@@ -147,9 +150,9 @@ php src/process_page.php "PageName|Another Page" --slow --savetofiles
 
 Must include:
 
-- OAuth tokens (consumer token/secret, access token/secret)
-- Bot username
-- API keys (CrossRef, JSTOR, etc.)
+- OAuth tokens: `PHP_OAUTH_CONSUMER_TOKEN`, `PHP_OAUTH_CONSUMER_SECRET`, `PHP_OAUTH_ACCESS_TOKEN`, `PHP_OAUTH_ACCESS_SECRET` (required for CLI)
+- Web user OAuth: `PHP_WP_OAUTH_CONSUMER`, `PHP_WP_OAUTH_SECRET` (required for web interface)
+- Optional: `PHP_ADSABSAPIKEY` (ADS), `PHP_S2APIKEY` (Semantic Scholar), `NLM_APIKEY`/`NLM_EMAIL` (NCBI), `DEPLOY_PASSWORD` (deployment endpoint)
 
 **Security:**
 
@@ -162,7 +165,7 @@ chmod go-rwx src/env.php
 The project uses extensive automated testing:
 
 - **PHPUnit** - Unit tests (via paratest for parallel execution)
-- **PHPStan** - Static analysis (strict mode)
+- **PHPStan (level 6)** - Static analysis
 - **Psalm** - Static analysis for coding quality
 - **Psalm (taint analysis)** - Security-focused taint data checks
 - **Phan** - PHP static analyzer
@@ -200,7 +203,7 @@ All tests must pass before merging.
 
 ### Adding New Template Parameters
 
-1. Update parameter mapping in `Parameter.php`
+1. Update the relevant constants or aliases in `src/includes/constants/parameters.php`
 2. Add extraction logic in relevant `API*.php` files
 3. Update `Template.php` if parameter needs special handling
 4. Add validation rules if needed
@@ -211,7 +214,7 @@ All tests must pass before merging.
 
 The gadget MUST:
 
-- Complete within 60 seconds
+- Complete within the 120-second configured time limit
 - Not perform slow operations (bibcode search, URL expansion)
 - Handle browser timeout gracefully
 - Provide useful partial results if API calls fail
@@ -221,7 +224,7 @@ The gadget MUST:
 - Respect rate limits
 - Use OAuth authentication
 - Include proper User-Agent
-- Implement retry with exponential backoff
+- Implement retry with bounded backoff and honor Retry-After headers
 - Never post if page hasn't changed
 
 ## File Organization
@@ -238,7 +241,7 @@ The gadget MUST:
 │   ├── category.php            # Category processing
 │   ├── linked_pages.php        # Processes pages linking to a given page
 │   ├── kill_big_job.php        # Kill large batch jobs
-│   ├── gitpull.php             # Deployment webhook
+│   ├── gitpull.php             # Password-protected deployment/update endpoint
 │   └── includes/
 │       ├── setup.php           # Bootstrap configuration
 │       ├── constants.php       # Application constants
@@ -334,10 +337,10 @@ Check `src/includes/setup.php` for debug flags and logging configuration.
 
 ## Performance Considerations
 
-- Each external API call adds latency (100-500ms)
+- (Historical observation; unverified) Each external API call adds latency (100-500ms)
 - Wikipedia API calls are rate-limited
-- Slow mode can take 30-120 seconds for large pages
-- Fast mode targets < 10 seconds
+- (Historical observation; unverified) Slow mode can take 30-120 seconds for large pages
+- (Historical observation; unverified) Fast mode targets < 10 seconds
 - Batch processing is more efficient than individual pages
 
 ## Security Best Practices
@@ -399,14 +402,12 @@ composer update
 
 ## Wikipedia Citation Template Reference
 
-The bot supports all standard Wikipedia citation templates:
+The bot recognizes many CS1/CS2 citation templates and processes them at different levels of depth. See `src/includes/constants/parameters.php` for the authoritative lists of fully, slightly, and barely processed templates. Examples include:
 
 - `{{cite journal}}` - Academic journals
 - `{{cite book}}` - Books
 - `{{cite web}}` - Websites
 - `{{cite news}}` - News articles
-- `{{cite conference}}` - Conference papers
-- `{{cite thesis}}` - Theses and dissertations
 - `{{citation}}` - Any reference
 - And many more...
 
@@ -431,7 +432,7 @@ The bot supports all standard Wikipedia citation templates:
 
 ## Project Status & Maintenance
 
-- **Status:** Inactive/stable - not under active development
+- **Status:** Production service active; repository classified as stable/inactive (maintenance mode)
 - **Maintenance:** Provided as time allows
 - **Community:** Open source contributions welcome
 - **Response time:** May vary due to volunteer nature
@@ -446,8 +447,8 @@ The bot supports all standard Wikipedia citation templates:
 
 When helping with this project:
 
-1. **Remember:** Avoid dense code style with inline assignments
-2. **Test:** Always test with real Wikipedia pages
+1. **Remember:** Avoid dense compound conditionals; assignments in clearly separated conditions are common in this codebase
+2. **Test:** For behavior that depends on real wikitext or APIs, additionally smoke-test a representative page with `--savetofiles`; never rely on this instead of the automated suite
 3. **Security:** Never expose OAuth tokens or API keys
 4. **Performance:** Consider gadget timeout constraints
 5. **Standards:** Follow existing patterns in the codebase
@@ -470,9 +471,9 @@ The project prioritizes readability and maintainability over compactness. With 1
 
 ### Why Maintenance Mode?
 
-The bot has reached a stable, feature-complete state. It reliably processes thousands of Wikipedia pages daily. New features are welcome but the focus is on stability and bug fixes.  Also, the main coders have busy lives.
+The bot has reached a stable, feature-complete state. It reliably processes Wikipedia pages daily. New features are welcome but the focus is on stability and bug fixes.  Also, the main coders have busy lives.
 
 ---
 
-**Last updated:** June 2026
+**Last updated:** July 2026
 **Maintained by:** Citation Bot community

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,4 +22,4 @@ abstract: >-
   Wikipedia. It retrieves citation data from a variety of
   sources including CrossRef (DOI), PMID, PMC and JSTOR, and
   returns a formatted citation.
-license: AGPL-3.0
+license: GPL-3.0-or-later

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN echo "xdebug.mode=debug,coverage" >> /usr/local/etc/php/conf.d/docker-php-ex
     && echo "xdebug.idekey=VSCODE" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
+# Required runtime extensions
+RUN docker-php-ext-install curl mbstring xml simplexml
+
 # Needed for PHPUnit time limit options (e.g. --enforce-time-limit --default-time-limit 13000)
 RUN docker-php-ext-install pcntl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,16 @@ RUN echo "xdebug.mode=debug,coverage" >> /usr/local/etc/php/conf.d/docker-php-ex
     && echo "xdebug.idekey=VSCODE" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
+# Install system packages required to build PHP extensions + composer dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        libcurl4-openssl-dev \
+        libonig-dev \
+        libxml2-dev \
+        git \
+        zip \
+        unzip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Required runtime extensions (simplexml is built into the php:8.4-apache image)
 RUN docker-php-ext-install curl mbstring xml
 
@@ -38,8 +48,6 @@ RUN docker-php-ext-install curl mbstring xml
 RUN docker-php-ext-install pcntl
 
 # Install composer. Once the container is built and running, you can do `composer install` with the following shell command: `docker exec -it citation-bot-php-1 composer install`
-RUN apt-get update && apt-get install --no-install-recommends -y git zip unzip \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,13 @@ RUN echo "xdebug.mode=debug,coverage" >> /usr/local/etc/php/conf.d/docker-php-ex
     && echo "xdebug.idekey=VSCODE" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-# Required runtime extensions
-RUN docker-php-ext-install curl mbstring xml simplexml
+# Required runtime extensions (simplexml is built into the php:8.4-apache image)
+RUN docker-php-ext-install curl mbstring xml
 
 # Needed for PHPUnit time limit options (e.g. --enforce-time-limit --default-time-limit 13000)
 RUN docker-php-ext-install pcntl
 
-# Install composer. Once the container is built and running, you can do `composer update` with the following shell command: `docker exec -it citation-bot-php-1 composer update`
+# Install composer. Once the container is built and running, you can do `composer install` with the following shell command: `docker exec -it citation-bot-php-1 composer install`
 RUN apt-get update && apt-get install --no-install-recommends -y git zip unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8081:80" # http://localhost:8081
+      - "8081:80" # http://localhost:8081/src/
     volumes:
       - .:/var/www/html
     environment:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,15 +4,26 @@ Thanks for contributing to the maintenance of Citation Bot.
 
 ## Testing
 
-We use phpunit to test code; please write test case examples for new code you create. It is helpful if each test case example describes the specific function that it is trying to test.
+We use PHPUnit to test code; please write test case examples for new code you create. It is helpful if each test case example describes the specific function that it is trying to test.
 
 ## Quality verification
 
 All code is run through several tests.  The primary test is a suite of example pages and citation templates. There are a variety of static code analysis tests that look for common errors. The security tainted data tests make sure that all "untrusted input" (data from wikipedia pages) is output wrapped with the echoable() function: this is not done primarily for security, but for proper output formatting. There are even tests for the validity of HTML, CSS, JSON, Markdown, and YAML.
 
+| Tool | Purpose | Composer script |
+|------|---------|----------------|
+| PHPUnit + ParaTest | Test suite | `composer run test` |
+| PHPLint | Syntax check | `composer run phplint` |
+| PHP CodeSniffer | Code style | `composer run phpcs` |
+| PHPStan (level 6) | Static analysis | `composer run phpstan` |
+| Psalm | Static analysis | `composer run psalm` |
+| Psalm (taint) | Security taint analysis | `composer run psalm-taint` |
+| Phan | Static analysis | `composer run phan` |
+| Progpilot | Security analysis | `composer run progpilot` |
+
 ## Submitting changes
 
-Please send a GitHub Pull Request with a clear list of what you've done (read more about [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)). Including a test case that demonstrates the bug you are trying to fix in the pull request would be much appreciated, to avoid errors resurfacing. Please follow our coding conventions (below) and make sure all of your commits are atomic (one feature per commit).
+Please send a GitHub Pull Request against the `master` branch with a clear list of what you've done (read more about [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)). Use `development` only for coordinated restructuring work. Including a test case that demonstrates the bug you are trying to fix in the pull request would be much appreciated, to avoid errors resurfacing. Please follow our coding conventions (below) and make sure all of your commits are atomic (one feature per commit).
 
 Always write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
 
@@ -24,7 +35,7 @@ $ git commit -m "A brief summary of the commit
 
 ## API keys
 
-The test suite detects missing keys and skips tests.  A developer should consider getting their own keys set up for development.
+Tests can run without private credentials, but credential-dependent sections may be bypassed and reported as passing rather than skipped. For fuller coverage, copy `src/env.php.example` to `src/env.php` and configure your own development credentials; never commit that file.
 
 ## Coding conventions
 
@@ -73,4 +84,4 @@ The bot reports its activity to users using:
 - External data sources that send unexpected data, including Wikipedia - be defensive in your programming.
 - External data sources that suddenly change data - we need tests to detect this
 - CS1/CS2 sometimes changes and what was a good edit yesterday is a bad edit today.  Thus the Wikipedia talk page for the bot needs to be monitored for bugs and suggestions.
-- Do not merge changes without running the test suite. At a minimum, run the full test suite and ensure the non-static tests execute beyond initial startup before merging. “Minor changes” are frequently incorrect and must be validated by tests.  Trust us, we have failed.
+- Do not merge changes without running the test suite. At a minimum, run the full test suite and ensure the non-static tests execute beyond initial startup before merging. "Minor changes" are frequently incorrect and must be validated by tests.  Trust us, we have failed.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We use PHPUnit to test code; please write test case examples for new code you cr
 All code is run through several tests.  The primary test is a suite of example pages and citation templates. There are a variety of static code analysis tests that look for common errors. The security tainted data tests make sure that all "untrusted input" (data from wikipedia pages) is output wrapped with the echoable() function: this is not done primarily for security, but for proper output formatting. There are even tests for the validity of HTML, CSS, JSON, Markdown, and YAML.
 
 | Tool | Purpose | Composer script |
-|------|---------|----------------|
+| ------- | --------- | ----------------- |
 | PHPUnit + ParaTest | Test suite | `composer run test` |
 | PHPLint | Syntax check | `composer run phplint` |
 | PHP CodeSniffer | Code style | `composer run phpcs` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,9 +35,9 @@ Citation Bot automatically expands and formats references on Wikipedia when requ
 
 This is more properly a bot-gadget-tool combination. The parts are:
 
-- Citation Bot, found in `index.html` (web frontend) and `process_page.php` (information is POSTed to this and it does the citation expansion; backend). This automatically posts a new page revision with expanded citations and thus requires a bot account. All activity takes place on Toolforge. Single pages can be GETed.
-- Citation expander (<https://en.wikipedia.org/wiki/MediaWiki:Gadget-citations.js>) + `gadgetapi.php`. This comprises an Ajax front-end in the on-wiki gadget and a PHP backend API.
-- `generate_template.php` creates the wiki reference given an identifier (for example: <https://citations.toolforge.org/generate_template.php?doi=10.1109/SCAM.2013.6648183>)
+- Citation Bot, found in `src/index.html` (web frontend) and `src/process_page.php` (information is POSTed to this and it does the citation expansion; backend). This automatically posts a new page revision with expanded citations and thus requires a bot account. The public production deployment runs on Toolforge. Single pages can be requested via GET, which requires prior web authorization (a `CiteBot` cookie); use the web form (POST) or CLI for multiple pages.
+- Citation expander (<https://en.wikipedia.org/wiki/MediaWiki:Gadget-citations.js>) + `src/gadgetapi.php`. This comprises an Ajax front-end in the on-wiki gadget and a PHP backend API.
+- `src/generate_template.php` creates the wiki reference given an identifier (for example: <https://citations.toolforge.org/generate_template.php?doi=10.1109/SCAM.2013.6648183>)
 
 Bugs and requested changes are listed here: <https://en.wikipedia.org/wiki/User_talk:Citation_bot>.
 
@@ -45,16 +45,16 @@ Bugs and requested changes are listed here: <https://en.wikipedia.org/wiki/User_
 
 The Citation Bot has two main user-facing interfaces with different performance characteristics:
 
-### Web Interface (`index.html` + `process_page.php`)
+### Web Interface (`src/index.html` + `src/process_page.php`)
 
 - **Default mode**: Thorough mode (slow mode enabled via checkbox, checked by default)
 - **Slow mode operations**: Searches for new bibcodes and expands URLs via external APIs
 - **Use case**: Users who want comprehensive citation expansion and can wait longer
-- **Timeout limit**: Typically completes for all pages, even if the web interface times out
+- **Timeout limit**: Request-level processing continues as long as the HTTP connection holds, but individual page lists are subject to internal size caps (see "Structure" below)
 
-### Citation Expander Gadget (`gadgetapi.php`)
+### Citation Expander Gadget (`src/gadgetapi.php`)
 
-- **Default mode**: Fast mode only (slow mode is always disabled)
+- **Default mode**: Fast mode (slow mode is not requested by the on-wiki gadget)
 - **Operations performed**:
   - ✓ Expands PMIDs, DOIs, arXiv, JSTOR IDs to full citations
   - ✓ Adds missing citation parameters (authors, title, journal, date, pages, etc.)
@@ -88,6 +88,12 @@ Entry points (under `src/`):
 - `src/category.php`: processes all pages within a Wikipedia category
 - `src/linked_pages.php`: processes all pages that link to a given page
 
+Operational/support endpoints:
+
+- `src/authenticate.php`: OAuth authorization flow for web users
+- `src/gitpull.php`: password-protected deployment/update endpoint
+- `src/kill_big_job.php`: lets users kill their own long-running batch jobs
+
 Includes (under `src/includes/`):
 
 - `src/includes/constants.php`: constants defined; further constants are split into files under `src/includes/constants/`
@@ -103,7 +109,7 @@ Includes (under `src/includes/`):
 - `src/includes/user_messages.php`: functions for reporting bot activity to users
 - `src/includes/doiTools.php`: DOI-specific validation and normalization functions
 - `src/includes/big_jobs.php`: handling for large batch jobs
-- `src/includes/api/API*.php`: sets up needed functions for expanding PMID/DOI/URL/etc
+- `src/includes/api/API*.php`: sets up needed functions for expanding PMID/DOI/URL/etc. Note: `APIissn.php` and `APIsici.php` are loaded indirectly by `Page.php` and `Template.php` rather than through `setup.php`.
 - `src/includes/Page.php`: Represents an individual page to expand citations on. Key methods are `Page::get_text_from()`, `Page::expand_text()`, and `Page::write()`.
 - `src/includes/Template.php`: most of the actual expansion happens here. `Template::add_if_new()` is generally (but not always) used to add parameters to the updated template; `Template::tidy()` cleans up the template, but may add parameters as well and have side effects.
 - `src/includes/WikiThings.php`: Handles comments, nowiki, etc. tags
@@ -123,7 +129,7 @@ The bot requires PHP >= 8.4.
 
 To run the bot from a new environment, you will need to create an `src/env.php` file (if one doesn't already exist) that sets the needed authentication tokens as environment variables.  To do this, you can rename `src/env.php.example` to `src/env.php`, set the variables in the file, and then make sure the file is not world readable or writable:
 
-    chmod go-rwx env.php
+    chmod go-rwx src/env.php
 
  To run the bot as a webservice from WM Toolforge:
 
@@ -135,26 +141,30 @@ Or for testing in the shell:
 
     webservice --backend=kubernetes php8.4 shell
 
-Before entering the k8s shell, it may be necessary to install phpunit (as wget is not available in the k8s shell).
-
 ## Running on the command line
 
-In order to run on the command line one needs OAuth tokens as documented in `src/env.php.example` (there are additional API keys that are needed to run some functions).  Change BOT_USER_AGENT in `src/includes/setup.php` to something else. Use composer to `composer require mediawiki/oauthclient:2.3.0`.  Then the bot can be run such as:
+In order to run on the command line one needs OAuth tokens as documented in `src/env.php.example` (there are additional API keys that are needed to run some functions).  The bot's User-Agent strings (`BOT_USER_AGENT` and `BOT_CROSSREF_USER_AGENT`) are defined in `src/includes/constants.php`. Use Composer to install dependencies:
+
+    composer install
+
+Then the bot can be run such as:
 
     /usr/bin/php ./src/process_page.php "Covid Watch|Water|COVID-19_apps" --slow --savetofiles
 
-The command line tool will also accept `page_list.txt` and `page_list2.txt` as page names.  In those cases the bot expects a file of such name to contain a single line of | separated page names.  This code requires PHP 8.4 with optional packages included: php84-mbstring php84-sockets php84-opcache php84-openssl php84-xmlrpc php84-gettext php84-curl php84-intl php84-iconv
+The command line tool will also accept `page_list.txt` and `page_list2.txt` as page names.  In those cases the bot expects a file of such name to contain a single line of | separated page names.  This code requires PHP 8.4 with the following extensions installed: curl, mbstring, xml (SimpleXML). Additional extensions may be needed for development tools and test coverage.
 
 Command line parameters:
 
 - `--slow` - retrieve bibcodes and expand URLs
-- `--savetofiles` - save processed pages as files (with .md extension) instead of submitting them to Wikipedia
+- `--savetofiles` - write changed page text only to sanitized `.md` filenames in the current working directory instead of submitting them to Wikipedia
 
 ## Running in web browser locally
 
-One way to set up a localhost that runs in your web browser is to use Docker. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) on your computer, open a shell, `cd` to the root directory of this repo, type `docker compose up -d`, then visit <http://localhost:8081>.
+One way to set up a localhost that runs in your web browser is to use Docker. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) on your computer, open a shell, `cd` to the root directory of this repo, type `docker compose up -d`, then visit <http://localhost:8081/src/>.
 
-To install Composer dependencies, start the container as noted above, then type `docker exec -it citation-bot-php-1 composer update`.
+To install Composer dependencies, start the container as noted above, then type:
+
+    docker compose exec php composer install
 
 To do most bot tasks, you'll need to create an env.php file and populate it with API keys. See src/env.php.example in the src directory.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,7 +109,7 @@ Includes (under `src/includes/`):
 - `src/includes/user_messages.php`: functions for reporting bot activity to users
 - `src/includes/doiTools.php`: DOI-specific validation and normalization functions
 - `src/includes/big_jobs.php`: handling for large batch jobs
-- `src/includes/api/API*.php`: sets up needed functions for expanding PMID/DOI/URL/etc. Note: `APIissn.php` and `APIsici.php` are loaded indirectly by `Page.php` and `Template.php` rather than through `setup.php`.
+- `src/includes/api/API*.php`: sets up needed functions for expanding PMID/DOI/URL/etc. Note: `APIissn.php` and `APIsici.php` are loaded directly by `Page.php` and `Template.php` rather than through `setup.php`.
 - `src/includes/Page.php`: Represents an individual page to expand citations on. Key methods are `Page::get_text_from()`, `Page::expand_text()`, and `Page::write()`.
 - `src/includes/Template.php`: most of the actual expansion happens here. `Template::add_if_new()` is generally (but not always) used to add parameters to the updated template; `Template::tidy()` cleans up the template, but may add parameters as well and have side effects.
 - `src/includes/WikiThings.php`: Handles comments, nowiki, etc. tags

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-Only the most current version is supported and deployed.
+Only the current deployed revision of `master` is supported.
 
 | Version        | Supported          |
 | -------------- | ------------------ |
-| Master Branch  | :white_check_mark: |
+| `master`       | :white_check_mark: |
 | All Others     | :x:                |
 
 ## Reporting a Vulnerability

--- a/tests/phpunit/README.md
+++ b/tests/phpunit/README.md
@@ -1,10 +1,11 @@
 # Tests for Citation Bot classes
 
-To run the tests for Parameter.php (for example), first check that PHP is installed and that the php directory is added to your system `PATH` environment variable. Then navigate to the root directory in which you have checked out the citation bot code, i.e. the folder containing setup.php.
+To run the tests for Parameter.php (for example), first check that PHP is installed.
+Then navigate to the repository root (the directory containing `composer.json`).
 
-Then, run the following command from the command line:
+Then, run the following command:
 
-    php vendor/bin/phpunit --bootstrap src/includes/setup.php tests/phpunit/gadgetapiTest.php
+    php vendor/bin/phpunit tests/phpunit/includes/parameterTest.php
 
 ## Running the Full Test Suite
 
@@ -14,21 +15,27 @@ The recommended way to run all tests is:
 
 This uses ParaTest for parallel test execution:
 
-- `--processes=auto`: Automatically uses all available CPU cores
-- `--runner=WrapperRunner`: PHPUnit 12 compatibility
-- `--coverage-clover coverage.xml`: Code coverage reports
-- `--verbose`: Shows individual test execution times in console output
+- `--processes=auto`: Automatically selects worker count based on CPU cores
+- `--runner=WrapperRunner`: ParaTest's default wrapper runner
+- `--coverage-clover coverage.xml`: Combined Clover coverage output
+- `--log-junit=junit.xml`: Records per-test results and durations
+- `tests/parse_junit.php`: Prints durations sorted slowest-first
+- `--verbose`: Prints additional ParaTest worker/debug information
 
-ParaTest provides 2-4x speedup by distributing tests across multiple processes. Required because PHPUnit 12 removed native parallel execution support.
+Parallel execution can reduce runtime, depending on CPU count, network-bound tests,
+and external API limits.
 
-The verbose output displays timing information for each test, making it easy to identify slow tests and monitor performance.
+**Prerequisites:** The Composer test script is designed for Linux, Docker, or WSL.
+It requires PCOV or Xdebug coverage support, `pcntl`, and Composer dependencies
+installed. For a portable focused test during development, use:
 
-To run the tests on Toolforge, first
+    php vendor/bin/phpunit path/to/Test.php
+
+To run the tests on Toolforge, first:
 
     webservice --backend=kubernetes php8.4 shell
 
-then install phpunit and then test:
+Then install dependencies and run:
 
-    php ../phpunit-12.phar --bootstrap [etc]
-
-Use Ctrl-D to escape from Toolforge.
+    composer install
+    php vendor/bin/phpunit tests/phpunit/includes/parameterTest.php


### PR DESCRIPTION
- License: Unify GPL-3.0-or-later across CITATION.cff, AGENTS.md, copilot-instructions.md
- AGENTS.md: Fix test command, subclass count (8→9), PHPStan level 6, code examples, API table descriptions, configuration requirements, timeout values, performance caveats, template coverage wording, quick reference guidelines
- README.md: Fix Docker URL (/src/), composer commands (install not update/require), User-Agent file path, chmod path, GET auth requirement, missing entry points, extension docs, gadget mode wording
- CONTRIBUTING.md: Add tool reference table, PR branch guidance (master), accurate API-key bypass description
- SECURITY.md: Format branch name as master, clarify version scope
- tests/phpunit/README.md: Fix wrong test example, accurate ParaTest option descriptions, portable commands, working Toolforge instructions
- Dockerfile: Add required runtime extensions (curl, mbstring, xml, simplexml)
- docker-compose.yml: Update URL comment