### PR TITLE
Add open-access DOI prefixes

### DIFF
--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 const DOI_FREE_PREFIX = [
+    '10.1001/jamanetworkopen',
     '10.1002/1878-0261',
     '10.1002/2056-4538',
     '10.1002/2211-5463',
@@ -307,6 +308,7 @@ const DOI_FREE_PREFIX = [
     '10.1016/j.euros',
     '10.1016/j.finr',
     '10.1016/j.fraope',
+    '10.1016/j.fob',
     '10.1016/j.gimo',
     '10.1016/j.gpb',
     '10.1016/j.heliyon',


### PR DESCRIPTION
Add DOI prefixes for JAMA Network Open (10.1001/jamanetworkopen) and Frontiers in Cell and Developmental Biology (10.1016/j.fob) to the list of known open-access publishers.