### PR TITLE
Fix Antibiotics and Chemotherapy classification

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -4674,7 +4674,7 @@ final class Template
                     if ($this->wikiname() === 'cite arxiv') {
                         $this->change_name_to('cite journal');
                     }
-                    if ($this->is_book_series($param)) {
+                    if ($this->is_book_series_for_journal($param)) {
                         $this->change_name_to('cite book');
                         if ($this->blank('series')) {
                             $this->rename($param, 'series');
@@ -7759,6 +7759,22 @@ final class Template
 
     public function is_book_series(string $param): bool {
         return string_is_book_series($this->get($param));
+    }
+
+    private function is_book_series_for_journal(string $param): bool {
+        if (!$this->is_book_series($param)) {
+            return false;
+        }
+        if ($param !== 'journal') {
+            return true;
+        }
+        $journal = str_replace(['[[', ']]'], '', $this->get($param));
+        $journal = (string) preg_replace('~\s+~u', ' ', $journal);
+        $journal = mb_strtolower(mb_trim($journal));
+        if ($journal !== 'antibiotics and chemotherapy') {
+            return true;
+        }
+        return mb_stripos($this->get('doi'), '10.1159/') === 0;
     }
 
     public function has_good_free_copy(): bool {

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -1193,6 +1193,69 @@ final class TemplatePart2Test extends testBaseClass {
         $this->assertSame('Advances in Enzymology and Related Areas of Molecular Biology', $template->get2('series'));
     }
 
+    public function testAntibioticsAndChemotherapyWithoutDoiRemainsJournal(): void {
+        $template = $this->make_citation('{{cite journal|journal=Antibiotics and Chemotherapy}}');
+        $template->tidy_parameter('journal');
+        $this->assertSame('cite journal', $template->wikiname());
+        $this->assertSame('Antibiotics and Chemotherapy', $template->get2('journal'));
+        $this->assertNull($template->get2('series'));
+    }
+
+    public function testAntibioticsAndChemotherapyWithBlankDoiRemainsJournal(): void {
+        $template = $this->make_citation('{{cite journal|journal=Antibiotics and Chemotherapy|doi=}}');
+        $template->tidy_parameter('journal');
+        $this->assertSame('cite journal', $template->wikiname());
+        $this->assertSame('Antibiotics and Chemotherapy', $template->get2('journal'));
+        $this->assertNull($template->get2('series'));
+    }
+
+    public function testAntibioticsAndChemotherapyRussianDoiRemainsJournal(): void {
+        $template = $this->make_citation('{{cite journal|journal=Antibiotics and Chemotherapy|doi=10.37489/0235-2990-2021-66-3-4-82-98}}');
+        $template->tidy_parameter('journal');
+        $this->assertSame('cite journal', $template->wikiname());
+        $this->assertSame('Antibiotics and Chemotherapy', $template->get2('journal'));
+        $this->assertNull($template->get2('series'));
+    }
+
+    public function testAntibioticsAndChemotherapy24411DoiRemainsJournal(): void {
+        $template = $this->make_citation('{{cite journal|journal=Antibiotics and Chemotherapy|doi=10.24411/0235-2990-2019-100012}}');
+        $template->tidy_parameter('journal');
+        $this->assertSame('cite journal', $template->wikiname());
+        $this->assertSame('Antibiotics and Chemotherapy', $template->get2('journal'));
+        $this->assertNull($template->get2('series'));
+    }
+
+    public function testAntibioticsAndChemotherapyUnknownDoiRemainsJournal(): void {
+        $template = $this->make_citation('{{cite journal|journal=Antibiotics and Chemotherapy|doi=10.99999/example}}');
+        $template->tidy_parameter('journal');
+        $this->assertSame('cite journal', $template->wikiname());
+        $this->assertSame('Antibiotics and Chemotherapy', $template->get2('journal'));
+        $this->assertNull($template->get2('series'));
+    }
+
+    public function testAntibioticsAndChemotherapyRussianDoiRemainsJournalAfterFinalTidy(): void {
+        $template = $this->make_citation('{{cite journal|journal=Antibiotics and Chemotherapy|doi=10.37489/0235-2990-2021-66-3-4-82-98}}');
+        $template->final_tidy();
+        $this->assertSame('cite journal', $template->wikiname());
+        $this->assertSame('Antibiotics and Chemotherapy', $template->get2('journal'));
+        $this->assertNull($template->get2('series'));
+    }
+
+    public function testAntibioticsAndChemotherapyKargerDoiRemainsBookSeries(): void {
+        $template = $this->make_citation('{{cite journal|journal=Antibiotics and Chemotherapy|doi=10.1159/000395442}}');
+        $template->tidy_parameter('journal');
+        $this->assertSame('cite book', $template->wikiname());
+        $this->assertNull($template->get2('journal'));
+        $this->assertSame('Antibiotics and Chemotherapy', $template->get2('series'));
+    }
+
+    public function testOtherBookSeriesClassificationIsUnchanged(): void {
+        $template = $this->make_citation('{{cite journal|journal=Methods of Molecular Biology}}');
+        $template->tidy_parameter('journal');
+        $this->assertSame('cite book', $template->wikiname());
+        $this->assertSame('Methods of Molecular Biology', $template->get2('series'));
+    }
+
     public function testNameStuff(): void {
         $text = '{{cite journal|author1=[[Robert Jay Charlson|Charlson]] |first1=R. J.}}';
         $template = $this->process_citation($text);


### PR DESCRIPTION
## Summary

Fixes the Citation Bot bug reported in [User talk:Citation bot](https://en.wikipedia.org/wiki/User_talk:Citation_bot#Antibiotics_and_Chemotherapy_is_a_journal,_not_a_book_series).

The bot incorrectly converted citations to *Antibiotics and Chemotherapy* from `cite journal` to `cite book`, moving `journal=` to `series=`.

## Cause

`Antibiotics and Chemotherapy` was included in the generic book-series list. The bot classified it by publication name alone, despite the name referring both to a journal and to Karger book chapters.

## Fix

Add a narrowly scoped DOI-aware exception:

- `10.37489/...` and `10.24411/...` remain journal citations.
- Missing, blank, or unknown DOI prefixes remain unchanged.
- `10.1159/...` retains the existing book-series conversion.
- Other book-series classifications are unchanged.

## Tests

Added regression tests covering all classification paths, including repeated `final_tidy()` processing.