### PR TITLE
Fix latent type errors in modifications merge and MathML conversion

### DIFF
--- a/src/includes/MathTools.php
+++ b/src/includes/MathTools.php
@@ -26,6 +26,9 @@ function convert_mathml_to_latex(string $mathml): string {
 
             // Handle <none/> tags - they represent empty positions
             $parts = preg_split('~<none/>~', $prescripts);
+            if ($parts === false) {
+                $parts = []; // preg_split only fails on regex compile error; fall back to no split
+            }
 
             // For isotope notation: <none/>number means superscript on left (mass number)
             if (count($parts) === 2 && mb_trim($parts[0]) === '') {

--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -515,7 +515,7 @@ class Page {
                 if (!isset($this->modifications[$key])) {
                     $this->modifications[$key] = $template_mods[$key];                                       // @codeCoverageIgnore
                     report_minor_error('unexpected modifications key: ' . echoable((string) $key));  // @codeCoverageIgnore
-                } elseif (is_array($this->modifications[$key])) {
+                } elseif (is_array($this->modifications[$key]) && is_array($template_mods[$key])) {
                     $this->modifications[$key] = array_unique([...$this->modifications[$key], ...$template_mods[$key]]);
                 } else {
                     $this->modifications[$key] = $this->modifications[$key] || $template_mods[$key]; // bool like mod_dashes
@@ -541,7 +541,7 @@ class Page {
                 if (!isset($this->modifications[$key])) {
                     $this->modifications[$key] = $template_mods[$key];                                       // @codeCoverageIgnore
                     report_minor_error('unexpected modifications key: ' . echoable((string) $key));  // @codeCoverageIgnore
-                } elseif (is_array($this->modifications[$key])) {
+                } elseif (is_array($this->modifications[$key]) && is_array($template_mods[$key])) {
                     $this->modifications[$key] = array_unique([...$this->modifications[$key], ...$template_mods[$key]]);
                 } else {
                     $this->modifications[$key] = $this->modifications[$key] || $template_mods[$key]; // bool like mod_dashes
@@ -562,7 +562,7 @@ class Page {
                     if (!isset($this->modifications[$key])) {
                         $this->modifications[$key] = $template_mods[$key];                                       // @codeCoverageIgnore
                         report_minor_error('unexpected modifications key: ' . echoable((string) $key));  // @codeCoverageIgnore
-                    } elseif (is_array($this->modifications[$key])) {
+                    } elseif (is_array($this->modifications[$key]) && is_array($template_mods[$key])) {
                         $this->modifications[$key] = array_unique([...$this->modifications[$key], ...$template_mods[$key]]);
                     } else {
                         $this->modifications[$key] = $this->modifications[$key] || $template_mods[$key]; // bool like mod_dashes

--- a/tests/phpunit/includes/mathToolsTest.php
+++ b/tests/phpunit/includes/mathToolsTest.php
@@ -19,6 +19,22 @@ final class mathToolsTest extends testBaseClass {
         $this->assertSame($expected, wikify_external_text($text_mml));
     }
 
+    public function testMathMLIsotopeWithoutNoneTag(): void {
+        // mmultiscripts with a prescript but no <none/> tag should not be
+        // treated as a left-superscript: falls through to the base element.
+        $text_mml = '<math><mmultiscripts>Ni<mprescripts/>67</mmultiscripts></math>';
+        $result = wikify_external_text($text_mml);
+        $this->assertSame('<math>Ni</math>', $result);
+    }
+
+    public function testMathMLIsotopeWithNoneOnRight(): void {
+        // <none/> on the right (mass number) side must not be treated as a
+        // left superscript: preg_split count is 2 but first part is non-empty.
+        $text_mml = '<math><mmultiscripts>Ni<mprescripts/>67<none/></mmultiscripts></math>';
+        $result = wikify_external_text($text_mml);
+        $this->assertSame('<math>Ni</math>', $result);
+    }
+
     public function testMathMLSuperscript(): void {
         // Test simple superscript: x^{2}
         $text_mml = '<math><msup><mi>x</mi><mn>2</mn></msup></math>';

--- a/tests/phpunit/includes/pageTest.php
+++ b/tests/phpunit/includes/pageTest.php
@@ -91,6 +91,16 @@ final class pageTest extends testBaseClass {
         $this->assertSame('Removed unsupported issue parameter from cite book. | [[:en:WP:UCB|Use this bot]]. [[:en:WP:DBUG|Report bugs]]. ', $page->edit_summary());
     }
 
+    public function testModificationsMergeAcrossTemplates(): void {
+        // Two templates each produce modifications; the merged result must
+        // combine array-typed keys (changeonly/additions/deletions) and
+        // bool-typed keys (dashes) without a TypeError.
+        $page = $this->process_page('{{cite journal|pages=44-55}}{{cite journal|title=X}}');
+        $summary = $page->edit_summary();
+        $this->assertStringContainsString('Altered pages', $summary);
+        $this->assertStringContainsString('dashes', $summary);
+    }
+
     public function testBotReadblocked(): void {
         $page = new TestPage();
         $page->get_text_from('User:Blocked Testing Account/readtest');


### PR DESCRIPTION
- Page.php: guard array spread in modifications merge with is_array on both sides (Template::modifications() mixes array and bool values per key)
- MathTools.php: handle preg_split() returning false before count()
- Add regression tests covering both code paths