### PR TITLE
Fix/doi access free pr

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -7263,14 +7263,18 @@ final class Template
         if ($doi !== '') {
             foreach (DOI_FREE_PREFIX as $prefix) {
                 if (mb_stripos($doi, $prefix) === 0) {
-                    $p = new Parameter();
-                    $p->pre = $this->param[0]->pre;
-                    $p->param = 'doi-access';
-                    $p->eq = '=';
-                    $p->val = 'free';
-                    $p->post = '';
-                    $this->param[] = $p;
-                    report_add(echoable("Adding doi-access: free"));
+                    if ($this->has_but_maybe_blank('doi-access')) {
+                        $this->set('doi-access', 'free');
+                    } else {
+                        $p = new Parameter();
+                        $p->pre = $this->param[0]->pre;
+                        $p->param = 'doi-access';
+                        $p->eq = '=';
+                        $p->val = 'free';
+                        $p->post = '';
+                        $this->param[] = $p;
+                        report_add(echoable("Adding doi-access: free"));
+                    }
                     break;
                 }
             }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1979,6 +1979,22 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertStringContainsString('10.1186/s12915-020-00940-y| doi-access=free', $doi_t->parsed_text());
     }
 
+    public function testDoiFreePrefixDoesNotDuplicateExistingAccess(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y|doi-access=free}}');
+        $doi_t->set_free_doi_access();
+        $this->assertSame(1, substr_count($doi_t->parsed_text(), 'doi-access=free'));
+        $this->assertSame('free', $doi_t->get2('doi-access'));
+    }
+
+    public function testDoiFreePrefixUpgradesExistingRestrictedAccess(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y|doi-access=limited}}');
+        $doi_t->set_free_doi_access();
+        $this->assertSame('free', $doi_t->get2('doi-access'));
+        $this->assertSame(1, substr_count($doi_t->parsed_text(), 'doi-access='));
+    }
+
     public function testDoiNonFreePrefixNotDetected(): void {
         $doi_t = new Template();
         $doi_t->parse_text('{{doi|10.1234/nonfree-example}}');

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1983,7 +1983,7 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $doi_t = new Template();
         $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y|doi-access=free}}');
         $doi_t->set_free_doi_access();
-        $this->assertSame(1, substr_count($doi_t->parsed_text(), 'doi-access=free'));
+        $this->assertSame(1, mb_substr_count($doi_t->parsed_text(), 'doi-access=free'));
         $this->assertSame('free', $doi_t->get2('doi-access'));
     }
 
@@ -1992,7 +1992,7 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y|doi-access=limited}}');
         $doi_t->set_free_doi_access();
         $this->assertSame('free', $doi_t->get2('doi-access'));
-        $this->assertSame(1, substr_count($doi_t->parsed_text(), 'doi-access='));
+        $this->assertSame(1, mb_substr_count($doi_t->parsed_text(), 'doi-access='));
     }
 
     public function testDoiNonFreePrefixNotDetected(): void {


### PR DESCRIPTION
## Summary

- Avoid adding duplicate `doi-access=free` parameters.
- Upgrade existing non-free DOI access values when the DOI is known to be free.
- Add regression tests for both cases.
- Use `mb_substr_count()` in tests to satisfy PHPCS.

## Test Plan

- Focused DOI access tests pass: 5 tests, 9 assertions.
- Changed files are limited to `Template.php` and `templatePart4Test.php`.