### PR TITLE
Fix type errors in APIBibCode and APIPubMed

### DIFF
--- a/src/includes/api/APIBibCode.php
+++ b/src/includes/api/APIBibCode.php
@@ -464,7 +464,7 @@ function adsabs_api(array $ids, array &$templates, string $identifier): void {  
 /**
  * @param string $options should be a series of field names, colons (optionally urlencoded), and  URL-ENCODED search strings, separated by (unencoded) ampersands. Surround search terms in (url-encoded) ""s, i.e. doi:"10.1038/bla(bla)bla"
  */
-function query_adsabs(string $options): object {
+function query_adsabs(string $options): stdClass {
     set_time_limit(120);
     // API docs at https://github.com/adsabs/adsabs-dev-api/blob/master/API_documentation_UNIXshell/Search_API.ipynb
     if (AdsAbsControl::small_gave_up_yet()) {
@@ -486,7 +486,7 @@ function query_adsabs(string $options): object {
 }
 
 /** @param array<string|bool|array<string>> $curl_opts */
-function Bibcode_Response_Processing(array $curl_opts, string $adsabs_url): object {
+function Bibcode_Response_Processing(array $curl_opts, string $adsabs_url): stdClass {
     try {
         $ch = bot_curl_init(1.0, $curl_opts); // Type varies greatly
         $return = bot_curl_exec($ch);

--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -125,17 +125,22 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                     switch ($subItem["Name"]) {
                                         case "pubmed":
                                         case "pmid":
-                                            preg_match("~\d+~", (string) $subItem, $match);
-                                            $this_template->add_if_new("pmid", $match[0], 'entrez');
+                                            if (preg_match("~\d+~", (string) $subItem, $match)) {
+                                                $this_template->add_if_new("pmid", $match[0], 'entrez');
+                                            }
                                             break;
                                         case "pmc":
-                                            preg_match("~\d+~", (string) $subItem, $match);
-                                            $this_template->add_if_new('pmc', $match[0], 'entrez');
+                                            if (preg_match("~\d+~", (string) $subItem, $match)) {
+                                                $this_template->add_if_new('pmc', $match[0], 'entrez');
+                                            }
                                             break;
                                         case "pmcid":
                                             if (preg_match("~embargo-date: ?(\d{4})\/(\d{2})\/(\d{2})~", (string) $subItem, $match)) {
-                                                    $date_emb = date("F j, Y", mktime(0, 0, 0, (int) $match[2], (int) $match[3], (int) $match[1])); // @codeCoverageIgnore
-                                                    $this_template->add_if_new('pmc-embargo-date', $date_emb, 'entrez');                              // @codeCoverageIgnore
+                                                $embargo_ts = mktime(0, 0, 0, (int) $match[2], (int) $match[3], (int) $match[1]); // @codeCoverageIgnore
+                                                if ($embargo_ts !== false) {                                                 // @codeCoverageIgnore
+                                                    $date_emb = date("F j, Y", $embargo_ts);                                  // @codeCoverageIgnore
+                                                    $this_template->add_if_new('pmc-embargo-date', $date_emb, 'entrez');      // @codeCoverageIgnore
+                                                }                                                                              // @codeCoverageIgnore
                                             }
                                             break;
                                         case "doi":
@@ -175,6 +180,7 @@ function get_entrez_xml(string $type, string $query): ?SimpleXMLElement {
 
 /**
  * Must use post in order to get DOIs with <, >, [, and ] in them and other problems
+ * @param non-empty-string $url
  */
 function xml_post(string $url, string $post): ?SimpleXMLElement {
     static $ch = null;


### PR DESCRIPTION
APIBibCode: type query_adsabs() and Bibcode_Response_Processing() as stdClass (json_decode output), making the numFound/docs property accesses valid. APIPubMed: guard preg_match results before [0] access, guard mktime() false in the embargo-date check, and type the xml_post URL param as non-empty-string for the curl stub. Resolves 9 PHPStan level 7 errors.