### PR TITLE
Fix type errors in Page and Parameter

### DIFF
--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -879,7 +879,7 @@ class Page {
     }
 
     /**
-     * @param class-string $class
+     * @param class-string<Template|WikiThings> $class
      * @return array<WikiThings|Template>
      */
     public function extract_object(string $class): array {
@@ -906,7 +906,6 @@ class Page {
         $preg_ok = true;
         foreach ($regexp_in as $regexp) {
             while ($preg_ok = preg_match($regexp, $text, $match)) {
-                /** @var WikiThings|Template $obj */
                 $obj = new $class();
                 try {
                     $obj->parse_text($match[0]);
@@ -998,7 +997,7 @@ class Page {
             $reverse = array_reverse($objects);
             foreach ($reverse as $obj) {
                 --$i;
-                $this->text = str_ireplace(sprintf($obj::PLACEHOLDER_TEXT, $i), $obj->parsed_text(), $this->text); // Case insensitive, since placeholder might get title case, etc.
+                $this->text = str_ireplace(sprintf(constant($obj::class . '::PLACEHOLDER_TEXT'), $i), $obj->parsed_text(), $this->text); // Case insensitive, since placeholder might get title case, etc.
             }
         }
     }

--- a/src/includes/Parameter.php
+++ b/src/includes/Parameter.php
@@ -40,6 +40,7 @@ final class Parameter {
             if (preg_match('~^([ \n\r\t\p{Zs}]*)([\s\S]*?)(\s*+)$~u', $split[1], $post_eq) === false) { // Try non-unicode if this fails
                 preg_match('~^([ \n\r\t\p{Zs}]*)([\s\S]*?)(\s*+)$~', $split[1], $post_eq);  // @codeCoverageIgnore
             }
+            /** @var array{string, string, string, string} $post_eq */
             if (count($pre_eq) === 0) {
                 $this->eq = $split[0] . '=' . $post_eq[1];
             } else {


### PR DESCRIPTION
Page: constrain extract_object() \ to class-string<Template|WikiThings>
so new \() is properly typed, and resolve PLACEHOLDER_TEXT via constant() in replace_object() (the base WikiThings class does not define it, only subclasses do). Parameter: add @var array{string, string, string, string} annotation for the preg_match post_eq result. Resolves 8 PHPStan level 7 errors.