### PR TITLE
Fix type errors in TextTools and URLtools

### DIFF
--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -793,10 +793,14 @@ function tidy_date_inside(string $string): string {
     }
     // Google sends ranges
     if (preg_match('~^(\d{4})(\-\d{2}\-\d{2})\s+\-\s+(\d{4})(\-\d{2}\-\d{2})$~', $string, $matches)) { // Date range
-        if ($matches[1] === $matches[3]) {
-            return date('j F', strtotime($matches[1] . $matches[2])) . ' – ' . date('j F Y', strtotime($matches[3] . $matches[4]));
-        } else {
-            return date('j F Y', strtotime($matches[1] . $matches[2])) . ' – ' . date('j F Y', strtotime($matches[3] . $matches[4]));
+        $start_ts = strtotime($matches[1] . $matches[2]);
+        $end_ts = strtotime($matches[3] . $matches[4]);
+        if ($start_ts !== false && $end_ts !== false) {
+            if ($matches[1] === $matches[3]) {
+                return date('j F', $start_ts) . ' – ' . date('j F Y', $end_ts);
+            } else {
+                return date('j F Y', $start_ts) . ' – ' . date('j F Y', $end_ts);
+            }
         }
     }
     // Huge amount of character cleaning

--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -909,7 +909,11 @@ function url_simplify(string $url): string {
     $url = str_replace(['/abstract/', '/full/', '/full+pdf/', '/pdf/', '/document/', '/html/', '/html+pdf/', '/abs/', '/epdf/', '/doi/', '/xprint/', '/print/', '.short', '.long', '.abstract', '.full', '///', '//'],
                                             ['/', '/', '/', '/', '/', '/', '/', '/', '/', '/', '/', '/', '/', '/', '/', '/', '/', '/'], $url);
     $url = mb_substr($url, 0, -1); // Remove the ending slash we added
-    $url = (string) preg_split("~[\?\#]~", $url, 2)[0];
+    $url_parts = preg_split("~[\?\#]~", $url, 2);
+    if ($url_parts === false) {
+        return $url; // @codeCoverageIgnore
+    }
+    $url = $url_parts[0];
     return str_ireplace('https', 'http', $url);
 }
 
@@ -1694,9 +1698,9 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
                 if ($template->blank('pmc')) {
                     report_modification("Converting URL to PMC parameter");
                 }
-                $new_pmc = (string) @$match[1] . @$match[2] . @$match[3];
+                $new_pmc = $match[1] . ($match[2] ?? '') . ($match[3] ?? '');
                 // php stan does not understand that this could because of the insanity of regex and 8-bit characters and PHP bugs end up being empty
-                if ($new_pmc === '') { // @phpstan-ignore-line
+                if ($new_pmc === '') {
                     bot_debug_log("PMC oops");
                     return false;
                 }


### PR DESCRIPTION
TextTools: guard strtotime() false returns in the Google date-range branch before passing timestamps to date(). URLtools: handle preg_split() false in URL cleanup, and use null-coalescing for the alternation match groups in the PMC extraction. Resolves 7 PHPStan level 7 errors.