### PR TITLE
Fix remaining type errors across misc files

### DIFF
--- a/src/gadgetapi.php
+++ b/src/gadgetapi.php
@@ -21,8 +21,8 @@ try {
     if (!is_string(@$_POST['text']) || !is_string(@$_POST['summary'])) {
         throw new Exception('not a string');    // @codeCoverageIgnore
     }
-    $originalText = $_POST['text'];
-    $editSummary = $_POST['summary'];
+    $originalText = (string) $_POST['text'];
+    $editSummary = (string) $_POST['summary'];
     unset($_GET, $_POST, $_REQUEST); // Memory minimize
 
     if (mb_strlen($originalText) < 6) {

--- a/src/includes/big_jobs.php
+++ b/src/includes/big_jobs.php
@@ -7,7 +7,10 @@ declare(strict_types=1);
 /** "hard" as in "try hard" and ignore errors */
 function hard_touch(string $file): void {
     touch($file);
-    @fclose(@fopen($file, 'a')); // Do something else to file
+    $handle = @fopen($file, 'a'); // Do something else to file
+    if ($handle !== false) {
+        @fclose($handle);
+    }
 }
 
 function big_jobs_name(): string { // NEVER save this string. Always use this function so that clearstatcache is called

--- a/src/includes/bot_curl.php
+++ b/src/includes/bot_curl.php
@@ -24,11 +24,13 @@ function bot_curl_init(float $time, array $ops): CurlHandle {
         report_error("curl_init failure"); // @codeCoverageIgnore
     }
     // 1 - Global Defaults
+    /** @var non-empty-string $user_agent */
+    $user_agent = BOT_USER_AGENT;
     curl_setopt_array($ch, [
         CURLOPT_FOLLOWLOCATION => true,
         CURLOPT_BUFFERSIZE => 524288, // 512kB chunks
         CURLOPT_MAXREDIRS => 20, // No infinite loops for us, 20 for Elsevier and Springer websites
-        CURLOPT_USERAGENT => BOT_USER_AGENT,
+        CURLOPT_USERAGENT => $user_agent,
         CURLOPT_AUTOREFERER => true,
         CURLOPT_REFERER => "https://en.wikipedia.org",
         CURLOPT_COOKIESESSION => true,

--- a/src/includes/setup.php
+++ b/src/includes/setup.php
@@ -99,7 +99,9 @@ if (file_exists(__DIR__ . '/../env.php')) {
     ob_start();
     /** @psalm-suppress MissingFile */
     include_once __DIR__ . '/../env.php';
-    $env_output = mb_trim(ob_get_contents());
+    $env_output_contents = ob_get_contents();
+    $env_output = ($env_output_contents === false) ? '' : mb_trim($env_output_contents);
+    unset($env_output_contents);
     if ($env_output) {
         bot_debug_log("got this:\n" . $env_output);  // Something unexpected, so log it
     }


### PR DESCRIPTION
gadgetapi: cast POST summary/text to string (is_string check already guards). big_jobs: guard fopen() false before fclose(). bot_curl: type the user agent as non-empty-string for the curl stub. setup: guard ob_get_contents() false before mb_trim. Resolves the 4 remaining PHPStan level 7 errors.