### PR TITLE
Bump PHPStan to level 7

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 7
     dynamicConstantNames:
         - HTML_OUTPUT
         - SLOW_MODE


### PR DESCRIPTION
All source files now pass level 7 analysis with zero errors, so raise the default level to enforce the stricter checks in CI.