### PR TITLE
Make the test command cross-platform

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -46,6 +46,8 @@
     <rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>
     <!-- Forbidden functions, for security and UTF-8 reasons -->
     <rule ref="Generic.PHP.ForbiddenFunctions">
+        <!-- tests/run_tests.php legitimately spawns paratest as a subprocess -->
+        <exclude-pattern>tests/run_tests.php</exclude-pattern>
         <properties>
             <property name="forbiddenFunctions" type="array">
                 <element key="assert" value="null"/>

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,6 @@
         "progpilot": "php -d memory_limit=1G vendor/bin/progpilot --configuration progpilot.yml src/*.php src/*/*.php src/*/*/*.php tests/*.php tests/*/*.php tests/*/*/*.php tests/*/*/*/*.php .phan/config.php",
         "psalm": "PSALM_ALLOW_XDEBUG=1 php ./vendor/bin/psalm --memory-limit=4G --show-info=true",
         "psalm-taint": "PSALM_ALLOW_XDEBUG=1 php ./vendor/bin/psalm --taint-analysis --memory-limit=4G",
-        "test": "php -d memory_limit=1G vendor/bin/paratest --processes=auto --runner=WrapperRunner --enforce-time-limit --default-time-limit=60000 --cache-directory=.phpunit.cache --coverage-clover=coverage.xml --log-junit=junit.xml --verbose 1>&2; TEST_EXIT=$?; sync; sync; php -d memory_limit=1G tests/parse_junit.php; sync; exit $TEST_EXIT"
+        "test": "php -d memory_limit=1G tests/run_tests.php"
     }
 }

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -7,9 +7,6 @@ declare(strict_types=1);
  *
  * Runs the PHPUnit test suite via paratest, then generates a JUnit
  * timing report, and finally exits with paratest's exit code.
- *
- * Replaces the previous bash-only composer script, which relied on
- * `sync` and `$?` syntax that is not available on Windows.
  */
 
 $paratest_command = PHP_BINARY . ' -d memory_limit=1G vendor/bin/paratest'

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Cross-platform test runner.
+ *
+ * Runs the PHPUnit test suite via paratest, then generates a JUnit
+ * timing report, and finally exits with paratest's exit code.
+ *
+ * Replaces the previous bash-only composer script, which relied on
+ * `sync` and `$?` syntax that is not available on Windows.
+ */
+
+$paratest_command = PHP_BINARY . ' -d memory_limit=1G vendor/bin/paratest'
+    . ' --processes=auto --runner=WrapperRunner --enforce-time-limit'
+    . ' --default-time-limit=60000 --cache-directory=.phpunit.cache'
+    . ' --coverage-clover=coverage.xml --log-junit=junit.xml --verbose';
+
+// Send paratest's output to stderr, keeping stdout for the timing report
+$process = proc_open(
+    $paratest_command,
+    [
+        0 => ['file', 'php://stdin', 'r'],
+        1 => ['file', 'php://stderr', 'w'],
+        2 => ['file', 'php://stderr', 'w'],
+    ],
+    $pipes
+);
+
+if (!is_resource($process)) {
+    fwrite(STDERR, "Failed to start paratest\n");
+    exit(1);
+}
+
+$paratest_exit_code = proc_close($process);
+
+// Generate the timing report on stdout; its exit code is not propagated
+passthru(PHP_BINARY . ' -d memory_limit=1G tests/parse_junit.php', $junit_exit_code);
+unset($junit_exit_code);
+
+exit($paratest_exit_code);


### PR DESCRIPTION
Replace the bash-only composer test script (which used sync and \True syntax unavailable on Windows) with tests/run_tests.php, a PHP wrapper that runs paratest, generates the JUnit timing report, and propagates paratest's exit code on any platform. Add a file-scoped phpcs exclusion for proc_open/passthru in the test runner, which legitimately spawns paratest as a subprocess.

While CI/test runs on Linux development might be done on windows, in such case tests may be run on windows.