### PR TITLE
Refactor throttle_archive function with delay calculation

### DIFF
--- a/src/includes/api/APIarchives.php
+++ b/src/includes/api/APIarchives.php
@@ -2,15 +2,27 @@
 
 declare(strict_types=1);
 
-function throttle_archive (): void {
-    static $last = 0.0;
-    $min_time = 1000000.0; // One second
-    $now = microtime(true);
-    $left = (int) ($min_time - ($now - $last));
-    if ($left > 0 && $left < $min_time) {
-        usleep($left); // less than min_time is paranoia, but do not want an infinite delay
+function archive_throttle_delay(float $now, float $last, float $minimum_interval = 1.0): int {
+    if ($last <= 0.0 || $minimum_interval <= 0.0) {
+        return 0;
     }
-    $last = $now;
+
+    $remaining = $minimum_interval - ($now - $last);
+    if ($remaining <= 0.0) {
+        return 0;
+    }
+
+    return min((int) ceil($remaining * 1000000), (int) ceil($minimum_interval * 1000000));
+}
+
+function throttle_archive(): void {
+    static $last = 0.0;
+    $now = microtime(true);
+    $delay = archive_throttle_delay($now, $last);
+    if ($delay > 0) {
+        usleep($delay);
+    }
+    $last = microtime(true);
 }
 
 /**

--- a/tests/phpunit/includes/api/archiveTest.php
+++ b/tests/phpunit/includes/api/archiveTest.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../../testBaseClass.php';
 
 final class archiveTest extends testBaseClass {
+
+    public function testArchiveThrottleDelayUsesSecondsAndReturnsMicroseconds(): void {
+        $this->assertSame(0, archive_throttle_delay(100.0, 0.0));
+        $this->assertSame(750000, archive_throttle_delay(100.25, 100.0));
+        $this->assertSame(0, archive_throttle_delay(101.0, 100.0));
+        $this->assertSame(0, archive_throttle_delay(102.0, 100.0));
+    }
+
     public function testUseArchive1(): void {
         $text = '{{cite journal|archive-url=https://web.archive.org/web/20160418061734/http://www.weimarpedia.de/index.php?id=1&tx_wpj_pi1%5barticle%5d=104&tx_wpj_pi1%5baction%5d=show&tx_wpj_pi1%5bcontroller%5d=article&cHash=0fc8834241a91f8cb7d6f1c91bc93489}}';
         $template = $this->make_citation($text);


### PR DESCRIPTION
Keep throttle timestamps in seconds, calculate microsecond sleeps correctly, record completion time, and test the conversion.