### PR TITLE
Fix mistake_id search logic for common mistakes

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3129,8 +3129,8 @@ final class Template
 
         foreach ($this->param as $p) {
             if (mb_strlen($p->param) > 0) {
-                $mistake_id = array_search($p->param, $mistake_keys);
-                if ($mistake_id) {
+                $mistake_id = array_search($p->param, $mistake_keys, true);
+                if ($mistake_id !== false) {
                     $new = $mistake_corrections[$mistake_id];
                     if ($this->blank($new)) {
                         $old = $p->param;
@@ -3199,8 +3199,8 @@ final class Template
                 } else {
                     report_modification("Unrecognized parameter " . echoable($p->param) . " ");
                 }
-                $mistake_id = array_search($p->param, $mistake_keys);
-                if ($mistake_id) {
+                $mistake_id = array_search($p->param, $mistake_keys, true);
+                if ($mistake_id !== false) {
                     // Check for common mistakes.  This will over-ride anything found by levenshtein: important for "editor1link" !-> "editor-link" (though this example is no longer relevant as of 2017)
                     $p->param = $mistake_corrections[$mistake_id];
                     report_modification('replaced with ' . echoable($mistake_corrections[$mistake_id]) . ' (common mistakes list)');

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -9,6 +9,13 @@ require_once __DIR__ . '/../../testBaseClass.php';
 
 final class TemplatePart1Test extends testBaseClass {
 
+    public function testFirstCommonMistakeIsCorrected(): void {
+        $template = $this->make_citation('{{cite journal|show-authors=3}}');
+        $template->correct_param_mistakes();
+        $this->assertSame('3', $template->get2('display-authors'));
+        $this->assertNull($template->get2('show-authors'));
+    }
+
     public function testLotsOfFloaters2(): void {
         $text_in = '{{cite journal|isssue 3 volumee 5 | tittle Love|journall Dog|series Not mine today|chapte cows|this is random stuff | zauthor Joe }}';
         $text_out = '{{cite journal| journal=L Dog | series=Not mine today |isssue 3 volumee 5 | tittle Love|chapte cows|this is random stuff | zauthor Joe }}';


### PR DESCRIPTION
Handle array_search() index zero correctly in both common-mistake paths; add a regression test for show-authors.
