### PR TITLE
Refactor book review detection functions

### DIFF
--- a/src/includes/api/APIBibCode.php
+++ b/src/includes/api/APIBibCode.php
@@ -730,51 +730,56 @@ function expand_book_adsabs(Template $template, object $record): void {
     return;
 }
 
-function looksLikeBookReview(Template $template, object $record): bool {
-    if ($template->wikiname() === 'cite book' || $template->wikiname() === 'citation') {
-        $book_count = 0;
-        if ($template->has('publisher')) {
-            $book_count += 1;
-        }
-        if ($template->has('isbn')) {
-            $book_count += 2;
-        }
-        if ($template->has('location')) {
-            $book_count += 1;
-        }
-        if ($template->has('chapter')) {
-            $book_count += 2;
-        }
-        if ($template->has('oclc')) {
-            $book_count += 1;
-        }
-        if ($template->has('lccn')) {
-            $book_count += 2;
-        }
-        if ($template->has('journal')) {
-            $book_count -= 2;
-        }
-        if ($template->has('series')) {
-            $book_count += 1;
-        }
-        if ($template->has('edition')) {
-            $book_count += 2;
-        }
-        if ($template->has('asin')) {
-            $book_count += 2;
-        }
-        if (mb_stripos($template->get('url'), 'google') !== false && mb_stripos($template->get('url'), 'book') !== false) {
-            $book_count += 2;
-        }
-        if (isset($record->year) && $template->year() && (int) $record->year !== (int) $template->year()) {
-            $book_count += 1;
-        }
-        if ($template->wikiname() === 'cite book') {
-            $book_count += 3;
-        }
-        if ($book_count > 3) {
-            return true;
+function citationLooksLikeBook(Template $template): bool {
+    if ($template->wikiname() !== 'cite book' && $template->wikiname() !== 'citation') {
+        return false;
+    }
+    if ($template->wikiname() === 'cite book') {
+        return true;
+    }
+
+    $book_score = 0;
+    foreach (['publisher', 'location', 'oclc', 'series'] as $weak_book_field) {
+        if ($template->has($weak_book_field)) {
+            $book_score += 1;
         }
     }
-    return false;
+    foreach (['isbn', 'chapter', 'lccn', 'edition', 'asin'] as $strong_book_field) {
+        if ($template->has($strong_book_field)) {
+            $book_score += 2;
+        }
+    }
+    if (mb_stripos($template->get('url'), 'google') !== false && mb_stripos($template->get('url'), 'book') !== false) {
+        $book_score += 2;
+    }
+    return $book_score >= 2;
+}
+
+function adsRecordLooksLikeReview(object $record): bool {
+    if (isset($record->bibcode) && is_string($record->bibcode) && is_a_book_bibcode($record->bibcode)) {
+        return false;
+    }
+
+    $doctype = isset($record->doctype) && is_string($record->doctype) ? mb_strtolower($record->doctype) : '';
+    if (in_array($doctype, ['book', 'inbook', 'proceedings', 'inproceedings', 'catalog', 'eprint', 'abstract', 'phdthesis', 'mastersthesis'], true)) {
+        return false;
+    }
+
+    $title = '';
+    if (isset($record->title) && is_array($record->title) && isset($record->title[0]) && is_string($record->title[0])) {
+        $title = $record->title[0];
+    }
+    if (preg_match('~\b(?:book review|review of)\b~i', $title)) {
+        return true;
+    }
+
+    if (in_array($doctype, ['article', 'editorial', 'letter'], true)) {
+        return true;
+    }
+
+    return isset($record->pub) && (isset($record->doi) || isset($record->volume) || isset($record->page));
+}
+
+function looksLikeBookReview(Template $template, object $record): bool {
+    return citationLooksLikeBook($template) && adsRecordLooksLikeReview($record);
 }

--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -267,7 +267,7 @@ function query_pubmed(Template $template): array {
             return $results;
         }
     }
-    $is_book = looksLikeBookReview($template, (object) []);
+    $is_book = citationLooksLikeBook($template);
     if ($template->has('title') && $template->first_surname() && !$is_book) {
         $results = do_pumbed_query($template, ["title", "surname", "year", "volume"]);
         if ($results[1] === 1) {

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1344,23 +1344,44 @@ EP - 999 }}';
     public function testlooksLikeBookReview(): void {
         $text = '{{cite journal|journal=X|url=book}}';
         $template = $this->make_citation($text);
-        $record = (object) null;
+        $record = (object) ['doctype' => 'article'];
+        $this->assertFalse(citationLooksLikeBook($template));
         $this->assertFalse(looksLikeBookReview($template, $record));
     }
 
     public function testlooksLikeBookReview2(): void {
         $text = '{{cite journal|journal=X|url=book|year=2002|isbn=x|location=x|oclc=x}}';
         $template = $this->make_citation($text);
-        $record = (object) null;
-        $record->year = '2000';
+        $record = (object) ['doctype' => 'article'];
         $this->assertFalse(looksLikeBookReview($template, $record));
     }
 
     public function testlooksLikeBookReview3(): void {
         $text = '{{cite book|journal=X|url=book|year=2002|isbn=x|location=x|oclc=x}}';
         $template = $this->make_citation($text);
-        $record = (object) null;
-        $record->year = '2000';
+        $record = (object) ['doctype' => 'article'];
+        $this->assertTrue(looksLikeBookReview($template, $record));
+    }
+
+    public function testCitationBookMatchedToAdsBookIsNotReview(): void {
+        $template = $this->make_citation('{{cite book|title=Combinatory Analysis}}');
+        $record = (object) ['doctype' => 'book', 'bibcode' => '1915cana.book.....M'];
+        $this->assertTrue(citationLooksLikeBook($template));
+        $this->assertFalse(adsRecordLooksLikeReview($record));
+        $this->assertFalse(looksLikeBookReview($template, $record));
+    }
+
+    public function testCitationBookMatchedToAdsArticleIsReview(): void {
+        $template = $this->make_citation('{{citation|title=Combinatory Analysis|publisher=Cambridge University Press|location=London|year=1915}}');
+        $record = (object) [
+            'doctype' => 'article',
+            'bibcode' => '1915Natur..96Q.478.',
+            'doi' => ['10.1038/096478a0'],
+            'pub' => 'Nature',
+            'title' => ['Combinatory Analysis'],
+        ];
+        $this->assertTrue(citationLooksLikeBook($template));
+        $this->assertTrue(adsRecordLooksLikeReview($record));
         $this->assertTrue(looksLikeBookReview($template, $record));
     }
 


### PR DESCRIPTION
Separate citation book-likeness from ADS record review-likeness, require both before rejecting an ADS match, and add the reported Nature-review regression case.
