### PR TITLE
Clarify linked pages user page restriction

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ Entry points (under `src/`):
 - `src/gadgetapi.php`: PHP backend API for the on-wiki Citation Expander gadget
 - `src/generate_template.php`: creates a wiki reference given an identifier
 - `src/category.php`: processes all pages within a Wikipedia category
-- `src/linked_pages.php`: processes all pages that link to a given `User:` page
+- `src/linked_pages.php`: processes all pages that are linked from a given `User:` page
 
 Operational/support endpoints:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ Entry points (under `src/`):
 - `src/gadgetapi.php`: PHP backend API for the on-wiki Citation Expander gadget
 - `src/generate_template.php`: creates a wiki reference given an identifier
 - `src/category.php`: processes all pages within a Wikipedia category
-- `src/linked_pages.php`: processes all pages that link to a given page
+- `src/linked_pages.php`: processes all pages that link to a given `User:` page
 
 Operational/support endpoints:
 

--- a/src/index.php
+++ b/src/index.php
@@ -65,6 +65,7 @@ session_write_close();
         <img style="display:none" src="assets/spinner_18_18.gif" id="LinkSpinner" alt="Loading" aria-hidden="true" />
         <br />
       </p>
+      <p>Only user pages (<code>User:...</code>) can be used with this feature.</p>
     </fieldset>
     <p>
     </p>


### PR DESCRIPTION
## Summary
- Add visible help text explaining that Process all linked pages accepts only User: pages.
- Update the repository README to document the same restriction.
