### PR TITLE
Add forbidden functions to PHPCS configuration and sort

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -52,18 +52,43 @@
             <property name="forbiddenFunctions" type="array">
                 <element key="assert" value="null"/>
                 <element key="create_function" value="null"/>
+                <element key="curl_close" value="null"/>
+                <element key="curl_share_close" value="null"/>
                 <element key="die" value="exit"/>
+                <element key="doubleval" value="null"/>
                 <element key="eval" value="null"/>
                 <element key="exec" value="null"/>
+                <element key="finfo_close" value="null"/>
+                <element key="imagedestroy" value="null"/>
+                <element key="is_double" value="null"/>
+                <element key="is_integer" value="null"/>
+                <element key="is_long" value="null"/>
                 <element key="ltrim" value="mb_ltrim"/>
+                <element key="mb_ereg_match" value="null"/>
+                <element key="mb_ereg_replace_callback" value="null"/>
+                <element key="mb_ereg_replaces" value="null"/>
+                <element key="mb_ereg_search_getpos" value="null"/>
+                <element key="mb_ereg_search_getregs" value="null"/>
+                <element key="mb_ereg_search_init" value="null"/>
+                <element key="mb_ereg_search_pos" value="null"/>
+                <element key="mb_ereg_search_regs" value="null"/>
+                <element key="mb_ereg" value="null"/>
+                <element key="mb_eregi_replace" value="null"/>
+                <element key="mb_regex_set_options" value="null"/>
+                <element key="mysqli_execute" value="null"/>
+                <element key="mysqli_get_charset" value="null"/>
+                <element key="mysqli_stmt_init" value="null"/>
                 <element key="passthru" value="null"/>
                 <element key="popen" value="null"/>
                 <element key="print" value="echo"/>
                 <element key="proc_open" value="null"/>
                 <element key="rtrim" value="mb_rtrim"/>
                 <element key="shell_exec" value="null"/>
+                <element key="spl_classes" value="null"/>
+                <element key="spl_object_hash" value="null"/>
                 <element key="str_pad" value="mb_str_pad"/>
                 <element key="str_split" value="mb_str_split"/>
+                <element key="strcoll" value="null"/>
                 <element key="strcut" value="mb_strcut"/>
                 <element key="stripos" value="mb_stripos"/>
                 <element key="strlen" value="mb_strlen"/>
@@ -81,18 +106,7 @@
                 <element key="trim" value="mb_trim"/>
                 <element key="ucfirst" value="mb_ucfirst"/>
                 <element key="ucwords" value="mb_ucwords"/>
-                <element key="mb_ereg_replaces" value="null"/>
-                <element key="mb_ereg" value="null"/>
-                <element key="mb_ereg_search_regs" value="null"/>
-                <element key="mb_ereg_search_init" value="null"/>
-                <element key="mb_ereg_replace_callback" value="null"/>
-                <element key="mb_eregi_replace" value="null"/>
-                <element key="mb_ereg_match" value="null"/>
-                <element key="mb_ereg_search_pos" value="null"/>
-                <element key="mb_ereg_search_getregs" value="null"/>
-                <element key="mb_ereg_search_getpos" value="null"/>
-                <element key="mb_regex_set_options" value="null"/>
-                <element key="curl_close" value="null"/>
+                <element key="xml_parser_free" value="null"/>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
This is all deprecated functions from PHP 8.4 and 8.5 and 8.6.  Many of these will never be used in this code base, but include just to be safe.