### PR TITLE
Fix regex match for ISO encoding

### DIFF
--- a/src/includes/api/APIarchives.php
+++ b/src/includes/api/APIarchives.php
@@ -229,8 +229,8 @@ function smart_decode(string $title, string $encode, string $archive_url): strin
     if (preg_match('~^\d{4}\-\d{1,2}$~', $encode)) {
         $encode = 'iso-' . $encode;
     }
-    if (preg_match('~^ISO\-(.+)$~', $encode)) {
-        $encode = 'iso-' . $encode[1];
+    if (preg_match('~^ISO-(.+)$~iD', $encode, $matches)) {
+        $encode = 'iso-' . $matches[1];
     }
     if (in_array($encode, INSANE_ENCODE, true)) {
         return "";

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -618,6 +618,11 @@ final class textToolsTest extends testBaseClass {
         $this->assertSame('ใทใงใใใณใฐ', $decoded); // Clearly random junk
     }
 
+    public function testSmartDecodeNormalizesUppercaseIsoEncoding(): void {
+        $encoded = urldecode('Fran%E7ois');
+        $this->assertSame('François', smart_decode($encoded, 'ISO-8859-1', ''));
+    }
+
     public function testVariousEncodes1(): void {
         $input = "\xe3\x82\xb7\xe3\x83\xa7\xe3\x83\x83\xe3\x83\x94\xe3\x83\xb3\xe3\x82\xb0";
         $sample = 'ショッピング';


### PR DESCRIPTION
fix uppercase archive charset normalization. smart_decode() turns ISO-8859-1 into iso-S because it uses $encode[1], the second character of the string, rather than a regex capture. Capture into $matches and use $matches[1]; add an uppercase-charset regression test. 