### PR TITLE
Update default Dependabot cooldown days to 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3


### PR DESCRIPTION
insufficient cooldown in Dependabot updates: insufficient default-days configured (less than 7)

Tool
zizmor
Rule ID
zizmor/dependabot-cooldown
Description
dependabot-cooldown: insufficient cooldown in Dependabot updates