### PR TITLE
Add date-based TNSRE free DOI rule

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -7104,6 +7104,12 @@ final class Template
                 if ($pub_year > 0 && $pub_year > (int) $rule_value) {
                     $this->add_if_new('doi-access', 'free');
                 }
+            } elseif ($rule_type === 'AFTER_DATE') {
+                $pub_ts = $this->pub_exact_ts();
+                $free_after_ts = strtotime($rule_value);
+                if ($pub_ts !== null && $free_after_ts !== false && $pub_ts >= $free_after_ts) {
+                    $this->add_if_new('doi-access', 'free');
+                }
             } elseif ($rule_type === 'EMBARGO_MONTHS') {
                 $pub_ts = $this->pub_exact_ts();
                 if ($pub_ts === null) {

--- a/src/includes/api/APIarchives.php
+++ b/src/includes/api/APIarchives.php
@@ -1,7 +1,7 @@
 <?php
 
 declare(strict_types=1);
-
+PIKEASDFSADS AFsd
 function archive_throttle_delay(float $now, float $last, float $minimum_interval = 1.0): int {
     if ($last <= 0.0 || $minimum_interval <= 0.0) {
         return 0;

--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -920,7 +920,7 @@ const DOI_FREE_PREFIX = [
 
 /**
  * Conditional free DOI rules: DOIs that are free only under certain publication-date conditions.
- * Rule types: AFTER_YEAR (year > value), EMBARGO_MONTHS (pub date + value months <= now; falls back to end of year when only year is known).
+ * Rule types: AFTER_YEAR (year > value), AFTER_DATE (publication date >= value), EMBARGO_MONTHS (pub date + value months <= now; falls back to end of year when only year is known).
  * If no parseable date is present, no free tag is added.
  * @var array<array{prefix: string, type: string, value: string}>
  */
@@ -954,5 +954,10 @@ const DOI_FREE_CONDITIONAL = [
         'prefix' => '10.1140/epjc',
         'type'   => 'AFTER_YEAR',
         'value'  => '2014',
+    ],
+    [   // IEEE Transactions on Neural Systems and Rehabilitation Engineering: free since 1 July 2020
+        'prefix' => '10.1109/tnsre.',
+        'type'   => 'AFTER_DATE',
+        'value'  => '2020-07-01',
     ],
 ];

--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -773,7 +773,7 @@ final class ConstantsTest extends testBaseClass {
 
     public function testDoiConditionalStructure(): void {
         new TestPage();
-        $valid_types = ['AFTER_YEAR', 'EMBARGO_MONTHS'];
+        $valid_types = ['AFTER_YEAR', 'AFTER_DATE', 'EMBARGO_MONTHS'];
         foreach (DOI_FREE_CONDITIONAL as $idx => $rule) {
             $label = 'DOI_FREE_CONDITIONAL[' . $idx . ']';
             $this->assertIsArray($rule, $label);
@@ -787,6 +787,8 @@ final class ConstantsTest extends testBaseClass {
             $this->assertStringContainsString('/', $rule['prefix'], $label . ' prefix');
             if ($rule['type'] === 'AFTER_YEAR') {
                 $this->assertMatchesRegularExpression('~^\d{4}$~', $rule['value'], $label . ' value');
+            } elseif ($rule['type'] === 'AFTER_DATE') {
+                $this->assertMatchesRegularExpression('~^\d{4}-\d{2}-\d{2}$~', $rule['value'], $label . ' value');
             } else {
                 $this->assertGreaterThan(0, (int) $rule['value'], $label . ' value');
             }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1913,6 +1913,27 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
+    public function testDoiConditionalAfterDate_TnsreOnThreshold_Free(): void {
+        $text = '{{cite journal|doi=10.1109/tnsre.example|date=2020-07-01}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterDate_TnsreBeforeThreshold_NotFree(): void {
+        $text = '{{cite journal|doi=10.1109/tnsre.example|date=2020-06-30}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterDate_TnsreYearOnlyThreshold_NotFree(): void {
+        $text = '{{cite journal|doi=10.1109/tnsre.example|year=2020}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
     public function testDoiConditionalEmbargoMonths_PnasOldArticle_Free(): void {
         $text = '{{cite journal|doi=10.1073/pnas.0000000|date=January 2010}}';
         $template = $this->make_citation($text);


### PR DESCRIPTION
## Summary

IEEE Transactions on Neural Systems and Rehabilitation Engineering became freely available for articles published from 1 July 2020 onward.

This change adds date-based conditional DOI access handling for the `10.1109/tnsre.` prefix:

- Marks DOIs dated 1 July 2020 or later as free.
- Leaves pre-cutoff dates unmarked.
- Leaves year-only `2020` records unmarked because the exact publication date is unknown.
- Adds validation and behavior tests for the new `AFTER_DATE` rule.