### PR TITLE
Fix Dependabot GitHub Actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,3 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3


### PR DESCRIPTION
## Summary

Dependabot rejected `.github/dependabot.yml` because `semver-major-days`, `semver-minor-days`, and `semver-patch-days` are not supported for the `github-actions` package ecosystem.

This change removes those unsupported keys from the GitHub Actions update block while preserving the supported `default-days: 7` cooldown and all Composer semver cooldown settings.

## Verification

- YAML parsing passes.
- `git diff --check` passes.