### PR TITLE
Restrict WSB free DOI access to post-March 2023

### DIFF
--- a/src/includes/constants/free_doi.php
+++ b/src/includes/constants/free_doi.php
@@ -285,7 +285,6 @@ const DOI_FREE_PREFIX = [
     '10.1002/wjo2.',
     '10.1002/wlb3.',
     '10.1002/wll2.',
-    '10.1002/wsb.',
     '10.1007/s12543',
     '10.1007/s40565',
     '10.1016/j.aace',
@@ -960,5 +959,10 @@ const DOI_FREE_CONDITIONAL = [
         'prefix' => '10.1109/tnsre.',
         'type'   => 'AFTER_DATE',
         'value'  => '2020-07-01',
+    ],
+    [   // Wildlife Society Bulletin: free since Volume 47, Issue 1, March 2023
+        'prefix' => '10.1002/wsb.',
+        'type'   => 'AFTER_DATE',
+        'value'  => '2023-03-01',
     ],
 ];

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1934,6 +1934,41 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
+    public function testDoiConditionalAfterDate_WsbOnThreshold_Free(): void {
+        $text = '{{cite journal|doi=10.1002/wsb.example|date=2023-03-01}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterDate_WsbBeforeThreshold_NotFree(): void {
+        $text = '{{cite journal|doi=10.1002/wsb.example|date=2023-02-28}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterDate_WsbYearOnlyThreshold_NotFree(): void {
+        $text = '{{cite journal|doi=10.1002/wsb.example|year=2023}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterDate_WsbNoDate_NotFree(): void {
+        $text = '{{cite journal|doi=10.1002/wsb.example}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
+
+    public function testDoiConditionalAfterDate_WsbExistingAccessPreserved(): void {
+        $text = '{{cite journal|doi=10.1002/wsb.example|date=2023-06-01|doi-access=limited}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('limited', $template->get2('doi-access'));
+    }
+
     public function testDoiConditionalEmbargoMonths_PnasOldArticle_Free(): void {
         $text = '{{cite journal|doi=10.1073/pnas.0000000|date=January 2010}}';
         $template = $this->make_citation($text);


### PR DESCRIPTION
## Summary

The Wildlife Society Bulletin (prefix `10.1002/wsb`) was listed in the unconditional `DOI_FREE_PREFIX`, so the bot tagged every WSB DOI as `doi-access=free`. WSB only became free starting with Volume 47, Issue 1 (March 2023).

- Remove `10.1002/wsb.` from `DOI_FREE_PREFIX`.
- Add a date-based conditional rule (`AFTER_DATE` `2023-03-01`) to `DOI_FREE_CONDITIONAL`, matching the existing TNSRE mechanism.
- Add 5 tests covering on-threshold, before-threshold, year-only, no-date, and existing-access-preserved cases.

Behavior after fix: WSB articles dated March 2023+ (month known) are tagged free; older, year-only, or undated articles are not.

## Verification

- TDD: new tests failed before the change (`'free' is null`) and pass after.
- All 16 `testDoiConditional*` tests pass (48 assertions).
- `ConstantsTest` `testFreeDOI` + `testDoiConditionalStructure` pass (993 assertions).
- `php -l` and `git diff --check` clean.