### PR TITLE
Pin Docker base image by digest to address OpenSSF scorecard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # If you make any changes to this file, don't forget to rebuild the Docker image using the --build flag:
 # docker-compose up --build -d
 
-FROM php:8.5-apache
+FROM php:8.5-apache@sha256:ae83253bb4d8b8b9715e0846ac915dae15d19818947f0a27cbcf88f4711a76fa
 
 # Install PHP XDebug, for step debugging and for PHPUnit code coverage report.
 # You can leave port 9007 for all your Docker containers. It doesn't conflict across containers like the localhost port does.


### PR DESCRIPTION
Pin the php:8.5-apache base image to its immutable sha256 digest to address the OpenSSF Scorecard Pinned-Dependencies finding (the image was previously referenced only by a mutable tag, which can change unexpectedly).

Dockerfile: FROM php:8.5-apache → FROM php:8.5-apache@sha256:ae83253bb4d8b8b9715e0846ac915dae15d19818947f0a27cbcf88f4711a76fa