### PR TITLE
Fix cffconvert lockfile broken by Dependabot jsonschema bump

### DIFF
--- a/.github/cffconvert-requirements.txt
+++ b/.github/cffconvert-requirements.txt
@@ -38,9 +38,8 @@ docopt==0.6.2 \
     --hash=sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
 idna==3.19 \
     --hash=sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4
-jsonschema==4.26.0 \
-    --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
-    --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
+jsonschema==3.2.0 \
+    --hash=sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163
 pykwalify==1.8.0 \
     --hash=sha256:731dfa87338cca9f559d1fca2bdea37299116e3139b73f78ca90a543722d6651
 pyrsistent==0.20.0 \

--- a/.github/cffconvert-requirements.txt
+++ b/.github/cffconvert-requirements.txt
@@ -19,10 +19,9 @@
 # scanned against the GitHub Advisory Database / OSV (pip-audit): no known
 # vulnerabilities.
 #
-# To update this file, on Linux/CPython 3.12: install cffconvert==2.0.0 in a
-# fresh venv, run `pip freeze` to capture the resolved closure, re-download
-# each pinned distribution with `pip download --no-deps`, recompute its sha256,
-# then re-run pip-audit and the workflow's validation before committing.
+# To update this file, run `bash tools/update_cffconvert_lock.sh` on
+# Linux/CPython 3.12, then re-run pip-audit and the workflow's validation
+# before committing.
 
 attrs==26.1.0 \
     --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    # These packages are pinned by hard constraints in the cffconvert 2.0.0
+    # closure (e.g. jsonschema <4, pykwalify >=1.6) and must not be bumped
+    # independently, or the --require-hashes install becomes unresolvable.
+    ignore:
+      - dependency-name: "cffconvert"
+      - dependency-name: "pykwalify"
+      - dependency-name: "jsonschema"
+      - dependency-name: "docopt"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -88,6 +88,7 @@ ci:
       - .github/dependabot.yml
       - .github/labeler.yml
       - .github/cffconvert-requirements.txt
+      - tools/update_cffconvert_lock.sh
 
 docker:
   - changed-files:
@@ -122,6 +123,7 @@ dependencies:
       - composer.json
       - composer.lock
       - .github/cffconvert-requirements.txt
+      - tools/update_cffconvert_lock.sh
 
 github_actions:
   - changed-files:

--- a/.github/workflows/cff-validation.yml
+++ b/.github/workflows/cff-validation.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - "CITATION.cff"
+      - ".github/cffconvert-requirements.txt"
   push:
     branches:
       - master
     paths:
       - "CITATION.cff"
+      - ".github/cffconvert-requirements.txt"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/cff-validation.yml
+++ b/.github/workflows/cff-validation.yml
@@ -42,5 +42,12 @@ jobs:
           --no-cache-dir
           -r .github/cffconvert-requirements.txt
 
+      # Verify the installed closure satisfies every package's declared
+      # constraints (e.g. cffconvert's jsonschema <4). Hash-checking mode does
+      # not re-check constraints, so this guards against a dependency bump that
+      # still installs but violates the closure.
+      - name: Check installed package constraints
+        run: python3 -m pip check
+
       - name: Validate CITATION.cff
         run: cffconvert --validate --infile CITATION.cff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,7 @@ The gadget MUST:
 ├── .github/workflows/          # CI/CD workflows
 ├── .github/dependabot.yml      # Automated dependency update configuration
 ├── .github/cffconvert-requirements.txt  # Hash-pinned cffconvert closure for CITATION.cff validation
+├── tools/update_cffconvert_lock.sh      # Regenerates the hash-pinned cffconvert closure
 ├── vendor/                     # Composer dependencies
 ├── composer.json               # Dependency configuration
 ├── docker-compose.yml          # Docker setup

--- a/tools/update_cffconvert_lock.sh
+++ b/tools/update_cffconvert_lock.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Regenerates .github/cffconvert-requirements.txt: the hash-pinned dependency
+# closure of cffconvert 2.0.0 used by the "Validate CITATION.cff" GitHub
+# Actions workflow (pip install --require-hashes).
+#
+# The lockfile pins the newest versions that satisfy every constraint of
+# cffconvert 2.0.0, together with sha256 digests of the exact distributions
+# pip selects on the workflow's target. Run this script on that target so the
+# hashes match what CI installs.
+#
+# Usage:
+#   bash tools/update_cffconvert_lock.sh
+#
+# Environment:
+#   PYTHON   Python 3 interpreter (default: python3)
+#
+# Requirements: Linux with CPython 3.12 (x86_64) and network access to PyPI.
+set -euo pipefail
+
+LOCKFILE=".github/cffconvert-requirements.txt"
+PYTHON="${PYTHON:-python3}"
+CFFCONVERT_VERSION="2.0.0"
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+
+# ---------------------------------------------------------------------------
+# Platform check: digests must match the wheels pip selects in CI.
+# ---------------------------------------------------------------------------
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "ERROR: run this on Linux (the workflow's target) so the hashes match CI." >&2
+    exit 1
+fi
+
+python_major="$("$PYTHON" -c 'import sys; print(sys.version_info.major)')"
+python_minor="$("$PYTHON" -c 'import sys; print(sys.version_info.minor)')"
+if [[ "$python_major" != "3" || "$python_minor" != "12" ]]; then
+    echo "WARNING: expected CPython 3.12 (the workflow target); got $python_major.$python_minor." >&2
+fi
+
+if [[ ! -f "$LOCKFILE" ]]; then
+    echo "ERROR: $LOCKFILE not found." >&2
+    exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---------------------------------------------------------------------------
+# Resolve the closure from a fresh venv so we get the newest compatible
+# versions. Environment tooling (pip, wheel) is excluded; setuptools is a real
+# dependency (jsonschema requires it) and must stay.
+# ---------------------------------------------------------------------------
+"$PYTHON" -m venv "$TMP/venv"
+VENV_PIP="$TMP/venv/bin/pip"
+"$VENV_PIP" install --quiet --upgrade pip
+"$VENV_PIP" install --quiet "cffconvert==$CFFCONVERT_VERSION"
+"$VENV_PIP" freeze | grep -v -E '^(pip|wheel)==' > "$TMP/freeze.txt"
+
+# ---------------------------------------------------------------------------
+# Download each pinned distribution (--no-deps) to capture the exact files
+# pip selects on this platform.
+# ---------------------------------------------------------------------------
+mkdir -p "$TMP/dl"
+while IFS= read -r pkg; do
+    (cd "$TMP/dl" && "$VENV_PIP" download --quiet --no-deps "$pkg")
+done < "$TMP/freeze.txt"
+
+# ---------------------------------------------------------------------------
+# Emit the new pinned body from the downloaded files.
+# ---------------------------------------------------------------------------
+"$PYTHON" - "$TMP/freeze.txt" "$TMP/dl" <<'PYEOF' > "$TMP/new_body.txt"
+import hashlib
+import os
+import re
+import sys
+
+freeze, dl = sys.argv[1], sys.argv[2]
+
+def norm(name):
+    return re.sub(r'[-_.]+', '_', name)
+
+specs = []
+for line in open(freeze, encoding="utf-8"):
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    name, _, ver = line.partition("==")
+    if name.lower() in ("pip", "wheel"):
+        continue
+    specs.append((name, ver))
+
+files = sorted(os.listdir(dl))
+by_file = {}
+for f in files:
+    for name, ver in specs:
+        if f.startswith(f"{norm(name)}-{ver}-") or f == f"{name}-{ver}.tar.gz":
+            digest = hashlib.sha256(open(os.path.join(dl, f), "rb").read()).hexdigest()
+            by_file[f] = (name, ver, digest)
+            break
+
+unmatched = [f for f in files if f not in by_file]
+if unmatched:
+    print("ERROR: could not match downloaded files: " + ", ".join(unmatched), file=sys.stderr)
+    sys.exit(1)
+
+for name, ver in specs:
+    entries = sorted((f, h) for f, (n, v, h) in by_file.items() if n == name and v == ver)
+    if not entries:
+        print(f"ERROR: no distribution for {name}=={ver}", file=sys.stderr)
+        sys.exit(1)
+    print(f"{name}=={ver} \\")
+    for i, (f, h) in enumerate(entries):
+        cont = " \\" if i < len(entries) - 1 else ""
+        print(f"    --hash=sha256:{h}{cont}")
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Keep the existing header comment block and replace the pinned body.
+# ---------------------------------------------------------------------------
+awk '!/^[[:space:]]*#/ && NF { exit } { print }' "$LOCKFILE" > "$TMP/new_lock.txt"
+cat "$TMP/new_body.txt" >> "$TMP/new_lock.txt"
+mv "$TMP/new_lock.txt" "$LOCKFILE"
+
+echo "Regenerated $LOCKFILE"
+echo "Next: re-run pip-audit and the workflow's validation before committing."


### PR DESCRIPTION
## Summary

Fixes the `Validate CITATION.cff` workflow, which is currently **broken on master**: Dependabot PR #5815 bumped `jsonschema` 3.2.0 → 4.26.0 in `.github/cffconvert-requirements.txt` and merged without CI catching it, even though jsonschema 4.x violates cffconvert 2.0.0's hard `jsonschema <4` constraint (via pykwalify 1.8.0). The `pip install --require-hashes` step now fails with `ResolutionImpossible`, so every future run of the workflow would fail.

## Changes

- **`.github/cffconvert-requirements.txt`** — revert `jsonschema` to `3.2.0` (the only version compatible with the closure), restoring a resolvable, hash-consistent lockfile.
- **`.github/workflows/cff-validation.yml`** — trigger the workflow on changes to `.github/cffconvert-requirements.txt` as well as `CITATION.cff`, so dependency-bump PRs run the install + validation and fail CI instead of merging silently.
- **`.github/dependabot.yml`** — add `ignore` rules for `cffconvert`, `pykwalify`, `jsonschema`, and `docopt`: packages hard-locked by the cffconvert constraint graph that Dependabot must not bump independently.

## Verification

- Exact workflow install command in a `python:3.12` Linux container (same target as CI): `pip install --disable-pip-version-check --require-hashes --no-cache-dir -r .github/cffconvert-requirements.txt` succeeds.
- `cffconvert --validate --infile CITATION.cff` → *"Citation metadata are valid according to schema version 1.2.0."*
- Both modified YAML files validated as parseable.

