### PR TITLE
Scope workflow token permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,12 +11,14 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,11 +30,13 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   docker:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -1,9 +1,6 @@
 name: Trivy
 
-permissions:
-  contents: read
-  actions: read
-  security-events: write
+permissions: {}
 
 on:
   pull_request:
@@ -17,6 +14,9 @@ jobs:
   build:
     name: Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Reduces GitHub token permissions in three workflows to least privilege, addressing the OpenSSF Scorecard **Token-Permissions** finding (score 7/10). `security-events: write` is now granted only at the job that uploads scan results, instead of the whole workflow.

## Changes

- **`.github/workflows/codeql-analysis.yml`** — move `security-events: write` from top-level to the `analyze` job (top-level: `contents: read`).
- **`.github/workflows/docker-build.yml`** — move `security-events: write` from top-level to the `docker` job (top-level: `contents: read`).
- **`.github/workflows/trivy-analysis.yml`** — top-level set to `permissions: {}`; the `build` job gets `contents: read` + `security-events: write`; dropped the unused `actions: read`.

## Verification

All three workflows parse as valid YAML with the expected top-level/job permission structure.