### PR TITLE
Refactor parameter validation assertions in ConstantsTest

### DIFF
--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -763,13 +763,12 @@ final class ConstantsTest extends testBaseClass {
                 $found[] = $param; // There are a few places in the code where parameters are assumed to not have numbers - look for s2cid
             }
         }
-        $this->assertFaker();
         if (!empty($found)) {
             $this->flush();
             print_r($found);
             $this->flush();
-            $this->assertFailure();
         }
+        $this->assertEmpty($found, 'New Parameter with numbers found');
     }
 
     public function testDoiConditionalStructure(): void {


### PR DESCRIPTION
Replace assertFaker and assertFailure with assertEmpty to check for new parameters with numbers.