### PR TITLE
Improve error logging in gadgetapi

### DIFF
--- a/src/gadgetapi.php
+++ b/src/gadgetapi.php
@@ -99,7 +99,7 @@ try {
     @ob_end_clean();
     // Above is paranoid panic code.    So paranoid that we even empty buffers two extra times
     if (function_exists('bot_debug_log')) {
-        bot_debug_log(
+        bot_debug_log('gadgetapi failure: ' . $exception::class . ': ' . $exception->getMessage());
     } else {
         error_log('gadgetapi failure: ' . $exception::class . ': ' . $exception->getMessage());
     }

--- a/src/gadgetapi.php
+++ b/src/gadgetapi.php
@@ -98,7 +98,10 @@ try {
     @ob_end_clean();
     @ob_end_clean();
     // Above is paranoid panic code.    So paranoid that we even empty buffers two extra times
-
-    bot_debug_log('gadgetapi failure: ' . $exception::class . ': ' . $exception->getMessage());
+    if (function_exists('bot_debug_log')) {
+        bot_debug_log(
+    } else {
+        error_log('gadgetapi failure: ' . $exception::class . ': ' . $exception->getMessage());
+    }
     gadget_api_error('internal_error', 500);
 }


### PR DESCRIPTION
Log gadgetapi failures using bot_debug_log if available, otherwise use error_log.