### PR TITLE
Make sure BOT_CURL_DEFAULT_MAX_RESPONSE_BYTES is probably never used

### DIFF
--- a/src/includes/bot_curl.php
+++ b/src/includes/bot_curl.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 const COOKIE_FILE_PATH = __DIR__ . '/cookie.txt'; // Proquest needs
-const BOT_CURL_DEFAULT_MAX_RESPONSE_BYTES = 134217728; // 128 MiB
+const BOT_CURL_DEFAULT_MAX_RESPONSE_BYTES = 1; // 128 MiB
 const BOT_CURL_ALLOWED_PROTOCOLS_USE = CURLPROTO_HTTP | CURLPROTO_HTTPS;
 const BOT_CURL_ALLOWED_PROTOCOLS_END = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP; // Some DOIs resolve to FTP sites, which is okay.  Some resolve to files, which we reject.
 

--- a/src/includes/bot_curl.php
+++ b/src/includes/bot_curl.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 const COOKIE_FILE_PATH = __DIR__ . '/cookie.txt'; // Proquest needs
-const BOT_CURL_DEFAULT_MAX_RESPONSE_BYTES = 1; // 128 MiB
+const BOT_CURL_DEFAULT_MAX_RESPONSE_BYTES = 134217728; // 128 MiB
 const BOT_CURL_ALLOWED_PROTOCOLS_USE = CURLPROTO_HTTP | CURLPROTO_HTTPS;
 const BOT_CURL_ALLOWED_PROTOCOLS_END = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP; // Some DOIs resolve to FTP sites, which is okay.  Some resolve to files, which we reject.
 

--- a/src/includes/doiTools.php
+++ b/src/includes/doiTools.php
@@ -852,6 +852,7 @@ function get_headers_array(string $url): false|array {
             $curl_options
         );
         foreach ([$curl_insecure_hdl, $curl_insecure_doi] as $ch) {
+            bot_curl_set_max_response_bytes($ch, 8 * 1024 * 1024);
             curl_setopt($ch, CURLOPT_HEADERFUNCTION, static function (CurlHandle $_ch, string $line) use (&$headers): int {
                 $length = mb_strlen($line, '8bit');
                 $line = mb_trim($line);

--- a/src/includes/doiTools.php
+++ b/src/includes/doiTools.php
@@ -134,6 +134,7 @@ function is_doi_active(string $doi): ?bool {
             CURLOPT_NOBODY => false,
             CURLOPT_USERAGENT => BOT_CROSSREF_USER_AGENT,
         ]);
+        bot_curl_set_max_response_bytes($ch, 4 * 1024 * 1024);
     }
     $doi = mb_trim($doi);
     $url = "https://api.crossref.org/v1/works/" . doi_encode($doi) . "?mailto=" . CROSSREFUSERNAME; // do not encode crossref email
@@ -785,6 +786,7 @@ function check_doi_for_jstor(string $doi, Template $template): void {
     static $ch = null;
     if ($ch === null) {
         $ch = bot_curl_init(1.0, []);
+        bot_curl_set_max_response_bytes($ch, 1 * 1024 * 1024);
     }
     if ($template->has('jstor')) {
         return;


### PR DESCRIPTION
Test default max response bytes for bot curl to 1 byte.