### PR TITLE
write-result-accounting

### DIFF
--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/big_jobs.php';      // @codeCoverageIgnore
  * should not terminate a multi-page run.
  *
  * @param string $page_title
- * @param callable(): bool $operation
+ * @param callable(): ?bool $operation
  * @return ?bool true when the page changed, false when it did not, null on failure
  */
 function run_page_with_exception_boundary(string $page_title, callable $operation): ?bool {
@@ -44,6 +44,19 @@ function run_write_with_retries(callable $operation, int $max_retries): bool {
         }
     }
     return false;
+}
+
+/**
+ * Convert the legacy write API's two signals into the page runner's tri-state.
+ *
+ * A successful-but-skipped write (for example an edit conflict detected before
+ * submission) is unchanged, while an exhausted retry sequence is a failure.
+ */
+function page_result_from_write(bool $write_succeeded, bool $write_skipped): ?bool {
+    if (!$write_succeeded) {
+        return null;
+    }
+    return !$write_skipped;
 }
 
 /**
@@ -129,7 +142,7 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
                 $total,
                 $done,
                 &$final_edit_overview
-            ): bool {
+            ): ?bool {
                 if (mb_strpos($page_title, 'Wikipedia:Requests') === false && $page->get_text_from($page_title) && $page->expand_text()) {
                     if (SAVETOFILES_MODE) {
                         // Sanitize file name by replacing characters that are not allowed on most file systems to underscores, and also replace path characters
@@ -155,7 +168,8 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
                             static fn (): bool => $page->write($api, $edit_sum),
                             MAX_TRIES
                         );
-                        if ($write_succeeded) {
+                        $write_result = page_result_from_write($write_succeeded, $api->last_write_was_skipped());
+                        if ($write_result === true) {
                             $last_rev = WikipediaBot::get_last_revision($page_title);
                             html_echo(
                             "\n  <a href=\"" . WIKI_ROOT . "?title=" . urlencode($page_title) . "&amp;diff=prev&amp;oldid="
@@ -166,11 +180,16 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
                                 "\n [ <a href=\"" . WIKI_ROOT . "?title=" . urlencode($page_title) . "&amp;diff=prev&amp;oldid="
                             . $last_rev . "\">diff</a>" .
                             " | <a href=\"" . WIKI_ROOT . "?title=" . urlencode($page_title) . "&amp;action=history\">history</a> ] " . "<a href=\"" . WIKI_ROOT . "?title=" . urlencode($page_title) . "\">" . echoable($page_title) . "</a>";
+                        } elseif ($write_result === false) {
+                            report_warning("Write skipped because the page changed while Citation Bot was working.");
+                            $final_edit_overview .= "\n Write skipped.           " . "<a href=\"" . WIKI_ROOT . "?title=" . urlencode($page_title) . "\">" . echoable($page_title) . "</a>";
                         } else {
                             report_warning("Write failed.");
                             $final_edit_overview .= "\n Write failed.            " . "<a href=\"" . WIKI_ROOT . "?title=" . urlencode($page_title) . "\">" . echoable($page_title) . "</a>";
                         }
+                        return $write_result;
                     }
+                    // SAVETOFILES_MODE successfully produced (or attempted) the changed output.
                     return true;
                 }
 

--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/big_jobs.php';      // @codeCoverageIgnore
  * should not terminate a multi-page run.
  *
  * @param string $page_title
- * @param callable(): bool|null $operation
+ * @param callable(): (bool|null) $operation
  * @return bool|null true when the page changed, false when it did not, null on failure
  */
 function run_page_with_exception_boundary(string $page_title, callable $operation): ?bool {

--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -15,8 +15,8 @@ require_once __DIR__ . '/big_jobs.php';      // @codeCoverageIgnore
  * should not terminate a multi-page run.
  *
  * @param string $page_title
- * @param callable(): ?bool $operation
- * @return ?bool true when the page changed, false when it did not, null on failure
+ * @param callable(): bool|null $operation
+ * @return bool|null true when the page changed, false when it did not, null on failure
  */
 function run_page_with_exception_boundary(string $page_title, callable $operation): ?bool {
     try {

--- a/src/includes/WikipediaBot.php
+++ b/src/includes/WikipediaBot.php
@@ -23,6 +23,7 @@ final class WikipediaBot {
     private static CurlHandle $ch_logout;
     private string $the_user = '';
     private static ?self $last_WikipediaBot = null;
+    private bool $last_write_skipped = false;
 
     public static function make_ch(): void {
         static $init_done = false;
@@ -73,6 +74,10 @@ final class WikipediaBot {
             report_error('User Not Set');         // @codeCoverageIgnore
         }
         return $this->the_user;
+    }
+
+    public function last_write_was_skipped(): bool {
+        return $this->last_write_skipped;
     }
 
     public static function ret_okay(?object $response): bool { // We send back true for thing that are page specific
@@ -181,6 +186,7 @@ final class WikipediaBot {
 
     /** @phpstan-impure */
     public function write_page(string $page, string $text, string $editSummary, int $lastRevId, string $startedEditing): bool {
+        $this->last_write_skipped = false;
         if (mb_stripos($text, "CITATION_BOT_PLACEHOLDER") !== false) {
             report_minor_error("\n ! Placeholder left escaped in text. Aborting for page " . echoable($page));  // @codeCoverageIgnore
             return false;                                                                             // @codeCoverageIgnore
@@ -203,7 +209,8 @@ final class WikipediaBot {
 
         if (($lastRevId !== 0 && $myPage->lastrevid !== $lastRevId)
          || ($startedEditing !== '' && strtotime($baseTimeStamp) > strtotime($startedEditing))) {
-            report_warning("Possible edit conflict detected. Aborting.");      // @codeCoverageIgnore
+            report_warning("Possible edit conflict detected. Aborting.");     // @codeCoverageIgnore
+            $this->last_write_skipped = true;                                 // @codeCoverageIgnore
             return true;                                                      // @codeCoverageIgnore
         }  // This returns true so that we do not try again
 

--- a/tests/phpunit/includes/WriteOutcomeTest.php
+++ b/tests/phpunit/includes/WriteOutcomeTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../testBaseClass.php';
+
+final class WriteOutcomeTest extends testBaseClass {
+    public function testSuccessfulWriteCountsAsChanged(): void {
+        $this->assertTrue(page_result_from_write(true, false));
+    }
+
+    public function testConflictSkipCountsAsUnchanged(): void {
+        $this->assertFalse(page_result_from_write(true, true));
+    }
+
+    public function testExhaustedWriteRetriesCountAsFailure(): void {
+        $this->assertNull(page_result_from_write(false, false));
+    }
+
+    public function testFailureTakesPrecedenceOverSkipFlag(): void {
+        $this->assertNull(page_result_from_write(false, true));
+    }
+}


### PR DESCRIPTION
  - Failed writes become failures instead of "changed".
  - Edit-conflict skips become unchanged/skipped instead of successful writes.
  - Diff/history links are emitted only for actual writes.
  - Adds tri-state classification tests.