### PR TITLE
PubMed structure

### DIFF
--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -18,6 +18,14 @@ function query_pmc_api (array $pmcs, array &$templates): void {  // Pointer to s
     entrez_api($pmcs, $templates, 'pmc');
 }
 
+function pubmed_item_name(SimpleXMLElement $item): string {
+    return (string) $item['Name'];
+}
+
+function pubmed_document_has_items(SimpleXMLElement $document): bool {
+    return isset($document->Item) && count($document->Item) > 0;
+}
+
 /**
  * @param array<string> $ids
  * @param array<Template> &$templates
@@ -47,8 +55,11 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
     }
 
     // A few PMC do not have any data, just pictures of stuff
-    if (isset($xml->DocSum->Item) && count($xml->DocSum->Item) > 0) {
+    if (isset($xml->DocSum) && count($xml->DocSum) > 0) {
         foreach ($xml->DocSum as $document) {
+            if (!pubmed_document_has_items($document)) {
+                continue;
+            }
             report_info("Found match for {$db} identifier " . echoable((string) $document->Id));
             foreach ($ids as $template_key => $an_id) { // Cannot use array_search since that only returns first
                 $an_id = (string) $an_id;
@@ -90,11 +101,12 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                 break;
                             case "AuthorList":
                                 $i = 0;
-                                foreach ($item->Item as $key => $subItem) {
+                                foreach ($item->Item as $subItem) {
+                                    $item_name = pubmed_item_name($subItem);
                                     $subItem = (string) $subItem;
                                     if (preg_match('~^\d~', $subItem)) { // Author started with a number, skip all remaining authors.
                                         break;    // @codeCoverageIgnore
-                                    } elseif ((string) $key === "CollectiveName") { // This is often really long string of gibberish
+                                    } elseif ($item_name === "CollectiveName") { // Do not treat a study group as a person.
                                         break;    // @codeCoverageIgnore
                                     } elseif (mb_strlen($subItem) > 100) {
                                         break;    // @codeCoverageIgnore

--- a/tests/phpunit/includes/PubMedStructureTest.php
+++ b/tests/phpunit/includes/PubMedStructureTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../testBaseClass.php';
+
+final class PubMedStructureTest extends testBaseClass {
+    public function testCollectiveNameComesFromNameAttribute(): void {
+        $xml = parse_entrez_xml_response(
+            '<eSummaryResult><DocSum><Item Name="AuthorList" Type="List">' .
+            '<Item Name="Author" Type="String">Smith J</Item>' .
+            '<Item Name="CollectiveName" Type="String">Example Study Group</Item>' .
+            '</Item></DocSum></eSummaryResult>'
+        );
+
+        $this->assertNotNull($xml);
+        $author_list = $xml->DocSum->Item[0];
+        $this->assertSame('Author', pubmed_item_name($author_list->Item[0]));
+        $this->assertSame('CollectiveName', pubmed_item_name($author_list->Item[1]));
+    }
+
+    public function testEmptyFirstDocSumDoesNotDefineWholeBatch(): void {
+        $xml = parse_entrez_xml_response(
+            '<eSummaryResult>' .
+            '<DocSum><Id>1</Id></DocSum>' .
+            '<DocSum><Id>2</Id><Item Name="Title" Type="String">Useful record</Item></DocSum>' .
+            '</eSummaryResult>'
+        );
+
+        $this->assertNotNull($xml);
+        $this->assertFalse(pubmed_document_has_items($xml->DocSum[0]));
+        $this->assertTrue(pubmed_document_has_items($xml->DocSum[1]));
+    }
+}


### PR DESCRIPTION
  - Reads AuthorList child type from the SimpleXML Name attribute.
  - Stops treating CollectiveName as an ordinary human author.
  - Processes later DocSum records even if an earlier record has no Item data.
  - Adds SimpleXML structure regression tests.