### PR TITLE
Fix author suffex

### DIFF
--- a/src/includes/NameTools.php
+++ b/src/includes/NameTools.php
@@ -210,8 +210,10 @@ function author_is_human(string $author): bool {
 function format_author(string $author): string {
     // Requires an author who is formatted as SURNAME, FORENAME or SURNAME FORENAME or FORENAME SURNAME. Substitute initials for forenames if needed
     $surname = '';
+    $author = html_entity_decode($author, ENT_COMPAT | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+    [$author, $junior] = junior_test(mb_trim($author));
     // Google and Zotero sometimes have these (sir) and just sir
-    $author = preg_replace("~ ?\((?i)sir(?-i)\.?\)~", "", html_entity_decode($author, ENT_COMPAT | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8'));
+    $author = preg_replace("~ ?\((?i)sir(?-i)\.?\)~", "", $author);
     $author = preg_replace("~^( ?sir )~", "", $author);
     $author = preg_replace("~^(, sir )~", ", ", $author);
 
@@ -303,6 +305,9 @@ function format_author(string $author): string {
     $full_name = str_replace("..", ".", $full_name);  // Sometimes add period after period
     $full_name = str_replace(".", ". ", $full_name);  // Add spaces after all periods
     $full_name = str_replace(["   ", "  "], [" ", " "], $full_name); // Remove extra spaces
+    if ($junior !== '') {
+        $full_name .= $junior;
+    }
     return mb_trim($full_name);
 }
 

--- a/tests/phpunit/includes/AuthorSuffixTest.php
+++ b/tests/phpunit/includes/AuthorSuffixTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../testBaseClass.php';
+
+final class AuthorSuffixTest extends testBaseClass {
+    public function testCommaSeparatedJuniorSuffixIsPreserved(): void {
+        $this->assertSame(
+            'Smith, John Jr.',
+            format_author('Smith, John, Jr.')
+        );
+    }
+
+    public function testSpaceSeparatedJuniorSuffixIsPreserved(): void {
+        $this->assertSame(
+            'Smith, John Jr.',
+            format_author('John Smith Jr.')
+        );
+    }
+
+    public function testOrdinalSuffixIsPreserved(): void {
+        $this->assertSame(
+            'Smith, John 3rd',
+            format_author('Smith, John, 3rd')
+        );
+    }
+}


### PR DESCRIPTION
  - Reuses junior_test() inside format_author().
  - Preserves Jr., Jr, and ordinal generational suffixes.
  - Adds tests for comma- and space-separated forms.