### PR TITLE
Add CS1 self-validation harness and identifier format validation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -90,6 +90,7 @@ ci:
       - .github/labeler.yml
       - .github/cffconvert-requirements.txt
       - tools/update_cffconvert_lock.sh
+      - tools/cs1_harness.php
 
 docker:
   - changed-files:

--- a/.github/workflows/cs1-harness.yml
+++ b/.github/workflows/cs1-harness.yml
@@ -1,0 +1,59 @@
+name: CS1 Harness
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'src/**'
+      - 'tools/**'
+      - 'composer.json'
+      - 'composer.lock'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'src/**'
+      - 'tools/**'
+      - 'composer.json'
+      - 'composer.lock'
+  schedule:
+    - cron: '10 18 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+      with:
+        php-version: '8.4'
+        coverage: none
+        extensions: mbstring, intl, curl, openssl, xml, sockets, pcntl
+
+    - name: Cache Composer dependencies
+      id: composer-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install -vvv --no-progress
+
+    - name: Run CS1 harness (fast mode)
+      run: php tools/cs1_harness.php
+
+    - name: Run CS1 harness (slow mode)
+      run: php tools/cs1_harness.php --slow

--- a/.github/workflows/cs1-harness.yml
+++ b/.github/workflows/cs1-harness.yml
@@ -49,6 +49,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-composer-
 
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
     - name: Install dependencies
       run: composer install -vvv --no-progress
 

--- a/.github/workflows/cs1-harness.yml
+++ b/.github/workflows/cs1-harness.yml
@@ -8,6 +8,7 @@ on:
       - 'tools/**'
       - 'composer.json'
       - 'composer.lock'
+      - '.github/workflows/cs1-harness.yml'
   pull_request:
     branches: [ master ]
     paths:
@@ -15,6 +16,7 @@ on:
       - 'tools/**'
       - 'composer.json'
       - 'composer.lock'
+      - '.github/workflows/cs1-harness.yml'
   schedule:
     - cron: '10 18 * * 1'
 
@@ -32,6 +34,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Setup PHP
       uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -61,6 +61,7 @@ on:
       - '.cursor/rules'
       - '.cursor/rules/citation-bot.mdc'
       - '.lycheeignore'
+      - '.github/workflows/cs1-harness.yml'
 
   schedule:
     - cron: '30 18 * * 1'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/includes/DebugLog.txt
 src/includes/cookie.txt
 tmp/*
 vendor/*
+phpunit.local.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ php tools/cs1_harness.php --list     # print the matrix without running
 ```
 
 - **Must-pass cases** (25) must satisfy every checker rule; a violation exits 1.
-- **Known-gap cases** (11) document current CS1 violations the bot leaves in place; they are reported but don't fail the run, and print `RESOLVED` once a fix lands.
+- **Known-gap cases** (11) document current CS1 violations the bot leaves in place; while still a known gap they are reported but don't fail the run. A gap that stops violating prints `RESOLVED` and **fails the run** (XPASS), forcing it to be converted to a must-pass case or confirmed intentional.
 - When adding identifier validation or parameter handling, mirror the existing validators in `src/includes/TextTools.php` (`arxiv_id_valid`, `pmid_valid`, `pmc_valid`, `rxiv_id_valid`, `bibcode_valid`, `isbn_valid`) and the `report_inaction` gate pattern in `Template::add_if_new`.
 
 ## Important Constraints

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file provides context for AI assistants working on the Citation Bot project
 - Language: PHP 8.4+
 - Main logic: Template.php
 - Test command: composer run test
+- CS1 regression gate (run before and after citation-logic changes): `php tools/cs1_harness.php` and `php tools/cs1_harness.php --slow`
 - CLI smoke-test (requires credentials, use --savetofiles to avoid writing to Wikipedia): php src/process_page.php "Page" --savetofiles
 - Code style: verbose, explicit, spaced-out, highly formatted style
 - First task: Read src/includes/Template.php, src/includes/Parameter.php, and src/includes/constants/parameters.php
@@ -186,8 +187,13 @@ The project uses extensive automated testing:
 - **OpenSSF Scorecard** - Evaluates repository security practices
 - **Zizmor** - Analyzes GitHub Actions workflows for security issues
 - **CITATION.cff validation** - Validates citation metadata using a hash-pinned cffconvert closure (`.github/cffconvert-requirements.txt`)
+- **CS1 Harness** - Runs `tools/cs1_harness.php` in fast + slow mode on changes to `src/**` or `tools/**` (`.github/workflows/cs1-harness.yml`), plus a weekly schedule; fails if any must-pass case would trigger a CS1 error
 
-All tests must pass before merging.
+The CS1 harness is the conformance regression gate (Phase 0 of the audit plan): it drives the bot's real expansion on a matrix of citations and flags any output that would trigger a `Help:CS1 errors` message. Run it locally (`php tools/cs1_harness.php` and `--slow`) before and after any citation-expansion change; a new fix should flip one of its documented gap cases to `RESOLVED` and add a matrix case.
+
+**Local PHPUnit note:** `phpunit.xml.dist` aborts without a coverage driver; for local runs use the stripped `phpunit.local.xml` (gitignored): `php -d memory_limit=1G vendor/bin/phpunit --configuration phpunit.local.xml <path>`.
+
+All tests must pass before merging. Some tests are network-dependent (Zotero, PubMed, Unpaywall, JSTOR) and may pass/fail with upstream API availability; those are unrelated to local changes.
 
 ## Common Development Tasks
 
@@ -213,6 +219,20 @@ All tests must pass before merging.
 2. Add extraction logic in relevant `API*.php` files
 3. Update `Template.php` if parameter needs special handling
 4. Add validation rules if needed
+
+### Running the CS1 Self-Validation Harness
+
+The harness (`tools/cs1_harness.php`) checks expanded citations against the CS1 error rules. It has no credentials and is deterministic when upstream APIs respond normally (the matrix uses fabricated identifiers/titles that cannot match).
+
+```bash
+php tools/cs1_harness.php            # fast mode
+php tools/cs1_harness.php --slow     # slow mode (bibcode search + URL expansion)
+php tools/cs1_harness.php --list     # print the matrix without running
+```
+
+- **Must-pass cases** (25) must satisfy every checker rule; a violation exits 1.
+- **Known-gap cases** (11) document current CS1 violations the bot leaves in place; they are reported but don't fail the run, and print `RESOLVED` once a fix lands.
+- When adding identifier validation or parameter handling, mirror the existing validators in `src/includes/TextTools.php` (`arxiv_id_valid`, `pmid_valid`, `pmc_valid`, `rxiv_id_valid`, `bibcode_valid`, `isbn_valid`) and the `report_inaction` gate pattern in `Template::add_if_new`.
 
 ## Important Constraints
 
@@ -393,6 +413,12 @@ Include:
 ```bash
 # Run tests
 php vendor/bin/phpunit
+# Local runs (phpunit.xml.dist needs a coverage driver): use the stripped config
+php -d memory_limit=1G vendor/bin/phpunit --configuration phpunit.local.xml <path>
+
+# CS1 conformance regression gate (fast + slow)
+php tools/cs1_harness.php
+php tools/cs1_harness.php --slow
 
 # Static analysis
 php vendor/bin/phpstan analyze

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ The project uses extensive automated testing:
 - **OpenSSF Scorecard** - Evaluates repository security practices
 - **Zizmor** - Analyzes GitHub Actions workflows for security issues
 - **CITATION.cff validation** - Validates citation metadata using a hash-pinned cffconvert closure (`.github/cffconvert-requirements.txt`)
-- **CS1 Harness** - Runs `tools/cs1_harness.php` in fast + slow mode on changes to `src/**` or `tools/**` (`.github/workflows/cs1-harness.yml`), plus a weekly schedule; fails if any must-pass case would trigger a CS1 error
+- **CS1 Harness** - Runs `tools/cs1_harness.php` in fast + slow mode on changes to `src/**` or `tools/**` (`.github/workflows/cs1-harness.yml`), plus a weekly schedule; fails if any must-pass case would trigger a CS1 error, or if a known-gap case unexpectedly resolves (XPASS)
 
 The CS1 harness is the conformance regression gate (Phase 0 of the audit plan): it drives the bot's real expansion on a matrix of citations and flags any output that would trigger a `Help:CS1 errors` message. Run it locally (`php tools/cs1_harness.php` and `--slow`) before and after any citation-expansion change; a new fix should flip one of its documented gap cases to `RESOLVED` and add a matrix case.
 
@@ -230,7 +230,7 @@ php tools/cs1_harness.php --slow     # slow mode (bibcode search + URL expansion
 php tools/cs1_harness.php --list     # print the matrix without running
 ```
 
-- **Must-pass cases** (25) must satisfy every checker rule; a violation exits 1.
+- **Must-pass cases** (29) must satisfy every checker rule; a violation exits 1.
 - **Known-gap cases** (11) document current CS1 violations the bot leaves in place; while still a known gap they are reported but don't fail the run. A gap that stops violating prints `RESOLVED` and **fails the run** (XPASS), forcing it to be converted to a must-pass case or confirmed intentional.
 - When adding identifier validation or parameter handling, mirror the existing validators in `src/includes/TextTools.php` (`arxiv_id_valid`, `pmid_valid`, `pmc_valid`, `rxiv_id_valid`, `bibcode_valid`, `isbn_valid`) and the `report_inaction` gate pattern in `Template::add_if_new`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,8 +389,9 @@ Check `src/includes/setup.php` for debug flags and logging configuration.
 4. Ensure all CI checks pass
 5. Follow existing code style
 6. Update documentation
-7. Submit pull request with clear description
-8. **Common Pitfalls:**
+7. **Always check whether `.github/labeler.yml` needs a new entry** when adding or renaming files (especially new tooling, workflows, or entrypoints); the automatic PR labeling depends on it
+8. Submit pull request with clear description
+9. **Common Pitfalls:**
 
    - Forgetting multi-byte string functions
    - Not handling API failures gracefully

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -4572,7 +4572,7 @@ final class Template
                         $this->has('doi')
                     ) {
                         $doi_value = $this->get('doi');
-                        if (preg_match('~^10\.1101/|^10\.64898/~', $doi_value)) {
+                        if (preg_match('~^10\.1101/|^10\.64898/~', $doi_value) && rxiv_id_valid($doi_value)) {
                             // Convert to cite bioRxiv
                             $this->change_name_to('cite bioRxiv', true, true);
                             $this->rename('doi', 'biorxiv');
@@ -4617,7 +4617,7 @@ final class Template
                         $this->has('doi')
                     ) {
                         $doi_value = $this->get('doi');
-                        if (preg_match('~^10\.1101/|^10\.64898/~', $doi_value)) {
+                        if (preg_match('~^10\.1101/|^10\.64898/~', $doi_value) && rxiv_id_valid($doi_value)) {
                             // Convert to cite medRxiv
                             $this->change_name_to('cite medRxiv', true, true);
                             $this->rename('doi', 'medrxiv');

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -2011,6 +2011,10 @@ final class Template
 
             case 'eprint':
             case 'arxiv':
+                if (!arxiv_id_valid($value)) {
+                    report_inaction("Not adding malformed arXiv identifier: " . echoable($value));
+                    return false;
+                }
                 if ($this->blank(ARXIV_ALIASES)) {
                     $this->add($param_name, $value);
                     return true;
@@ -2076,6 +2080,10 @@ final class Template
                 if ($value === "0") {
                     return false;
                 } // Got PMID of zero once from pubmed
+                if (!pmid_valid($value)) {
+                    report_inaction("Not adding malformed PMID: " . echoable($value));
+                    return false;
+                }
                 if ($this->blank($param_name)) {
                     if ($this->wikiname() === 'cite web' || $this->wikiname() === 'cite arxiv') {
                         $this->change_name_to('cite journal');
@@ -2091,6 +2099,10 @@ final class Template
                 if ($value === "PMC0" || $value === "0") {
                     return false;
                 } // Got PMID of zero once from pubmed
+                if (!pmc_valid($value)) {
+                    report_inaction("Not adding malformed PMC identifier: " . echoable($value));
+                    return false;
+                }
                 if ($this->blank($param_name)) {
                     if ($this->wikiname() === 'cite arxiv') {
                         $this->change_name_to('cite journal');
@@ -2121,6 +2133,10 @@ final class Template
                         $low_quality = true;
                     } else {
                         $low_quality = false;
+                    }
+                    if (!bibcode_valid($value)) {
+                        report_inaction("Not adding malformed bibcode: " . echoable($value));
+                        return false;
                     }
                     $this->add('bibcode', $value);
                     if ($param_name === 'bibcode') {
@@ -2288,6 +2304,16 @@ final class Template
             case 'biorxiv':
             case 'medrxiv':
             case 'via':
+                if ($param_name === 'biorxiv' || $param_name === 'medrxiv') {
+                    $test_value = $value;
+                    if (mb_strpos($test_value, '10.1101/') !== 0 && mb_strpos($test_value, '10.64898/') !== 0) {
+                        $test_value = '10.1101/' . $test_value; // Same normalization prepare_rxiv() applies
+                    }
+                    if (!rxiv_id_valid($test_value)) {
+                        report_inaction("Not adding malformed $param_name identifier: " . echoable($value));
+                        return false;
+                    }
+                }
                 if ($this->blank($param_name)) {
                     return $this->add($param_name, sanitize_string($value));
                 }

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1152,6 +1152,83 @@ function isbn_valid(string $isbn): bool {
     return false;
 }
 
+/**
+ * Validate an arXiv identifier against CS1's structural rules:
+ * the old (pre-2007) archive/number form or the new YYMM.NNNNN form,
+ * each with an optional lowercase version suffix.
+ */
+function arxiv_id_valid(string $value): bool {
+    if (preg_match('~^[a-zA-Z][a-zA-Z.\-]+/[0-9][0-9][01][0-9][0-9][0-9][0-9](v[0-9]+)?$~', $value) === 1) {
+        return true; // old style: e.g. hep-th/9901001
+    }
+    if (preg_match('~^(0[7-9]|1[0-4])(0[1-9]|1[0-2])\.\d{4}(v\d+)?$~', $value) === 1) {
+        return true; // new style 0704-1412: four-digit number, e.g. 0704.1234
+    }
+    if (preg_match('~^(1[5-9]|[2-9]\d)(0[1-9]|1[0-2])\.\d{5}(v\d+)?$~', $value) === 1) {
+        return true; // new style 1501-: five-digit number, e.g. 1706.05013
+    }
+    return false;
+}
+
+/**
+ * Validate a PubMed identifier: one to eight digits.
+ */
+function pmid_valid(string $value): bool {
+    if (preg_match('~^\d{1,8}$~', $value) !== 1) {
+        return false;
+    }
+    return intval($value) >= 1;
+}
+
+/**
+ * Validate a PubMed Central identifier: one to eight digits, optionally with
+ * a leading "PMC" prefix (which CS1 renders as a maintenance category).
+ */
+function pmc_valid(string $value): bool {
+    if (preg_match('~^[Pp][Mm][Cc](\d+)$~', $value, $match) === 1) {
+        $value = $match[1];
+    }
+    if (preg_match('~^\d{1,8}$~', $value) !== 1) {
+        return false;
+    }
+    return intval($value) >= 1;
+}
+
+/**
+ * Validate a bioRxiv/medRxiv identifier against CS1's structural rules:
+ * a legacy six-digit form or the dated yyyy.mm.dd.nnnnnn form (with the newer
+ * 10.64898 prefix), each with an optional version suffix.
+ */
+function rxiv_id_valid(string $value): bool {
+    if (preg_match('~^10\.1101/\d{6}$~', $value) === 1) {
+        return true; // legacy six-digit identifier
+    }
+    if (preg_match('~^10\.(1101|64898)/(20\d\d)\.(\d{2})\.(\d{2})\.\d{6}(v\d+)?$~', $value, $match) === 1) {
+        $month = intval($match[3]);
+        $day = intval($match[4]);
+        return $month >= 1 && $month <= 12 && $day >= 1 && $day <= 31;
+    }
+    return false;
+}
+
+/**
+ * Validate a bibcode: exactly 19 characters whose first four digits form a
+ * plausible year, with only letters, digits, underscores, ampersands, and dots
+ * elsewhere.  This mirrors the shape used by REGEXP_BIBCODE and CS1's own
+ * length/year tests (CS1 additionally requires a letter at position five,
+ * which we deliberately do not enforce so existing numeric bibcodes are kept).
+ */
+function bibcode_valid(string $value): bool {
+    if (mb_strlen($value) !== 19) {
+        return false;
+    }
+    if (preg_match('~^(\d{4})[\w&.]{15}$~', $value, $match) !== 1) {
+        return false;
+    }
+    $year = intval($match[1]);
+    return $year >= 1000 && $year <= intval(date('Y')) + 1;
+}
+
 function changeisbn10Toisbn13(string $isbn10, int $year): string {
     $isbn10 = mb_trim($isbn10); // Remove leading and trailing spaces
     $test = str_replace(['—', '?', '–', '-', '?', ' '], '', $isbn10);

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1197,13 +1197,14 @@ function pmc_valid(string $value): bool {
 /**
  * Validate a bioRxiv/medRxiv identifier against CS1's structural rules:
  * a legacy six-digit form or the dated yyyy.mm.dd.nnnnnn form (with the newer
- * 10.64898 prefix), each with an optional version suffix.
+ * 10.64898 prefix and 6-8 digit identifiers), each with an optional version
+ * suffix.
  */
 function rxiv_id_valid(string $value): bool {
-    if (preg_match('~^10\.1101/\d{6}$~', $value) === 1) {
+    if (preg_match('~^10\.1101/\d{6}(v\d+)?$~', $value) === 1) {
         return true; // legacy six-digit identifier
     }
-    if (preg_match('~^10\.(1101|64898)/(20\d\d)\.(\d{2})\.(\d{2})\.\d{6}(v\d+)?$~', $value, $match) === 1) {
+    if (preg_match('~^10\.(1101|64898)/(20\d\d)\.(\d{2})\.(\d{2})\.\d{6,8}(v\d+)?$~', $value, $match) === 1) {
         $month = intval($match[3]);
         $day = intval($match[4]);
         return $month >= 1 && $month <= 12 && $day >= 1 && $day <= 31;

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1196,13 +1196,14 @@ function pmc_valid(string $value): bool {
 
 /**
  * Validate a bioRxiv/medRxiv identifier against CS1's structural rules:
- * a legacy six-digit form or the dated yyyy.mm.dd.nnnnnn form (with the newer
+ * a legacy six-to-eight digit form (bioRxiv used 6 digits, early medRxiv 8,
+ * e.g. 10.1101/19000380) or the dated yyyy.mm.dd.nnnnnn form (with the newer
  * 10.64898 prefix and 6-8 digit identifiers), each with an optional version
  * suffix.
  */
 function rxiv_id_valid(string $value): bool {
-    if (preg_match('~^10\.1101/\d{6}(v\d+)?$~', $value) === 1) {
-        return true; // legacy six-digit identifier
+    if (preg_match('~^10\.1101/\d{6,8}(v\d+)?$~', $value) === 1) {
+        return true; // legacy identifier
     }
     if (preg_match('~^10\.(1101|64898)/(20\d\d)\.(\d{2})\.(\d{2})\.\d{6,8}(v\d+)?$~', $value, $match) === 1) {
         $month = intval($match[3]);
@@ -1224,7 +1225,8 @@ function bibcode_valid(string $value): bool {
     if (mb_strlen($value) !== 19) {
         return false;
     }
-    if (preg_match('~^[12]\d{3}[\w&.]{15}$~', $value) !== 1) {
+    // Body charset covers CS1's allowed set (letters, digits, _, &, ., ', +, -).
+    if (preg_match('~^[12]\d{3}[\w&.+\'-]{15}$~', $value) !== 1) {
         return false;
     }
     return true;

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1153,19 +1153,19 @@ function isbn_valid(string $isbn): bool {
 }
 
 /**
- * Validate an arXiv identifier against CS1's structural rules:
- * the old (pre-2007) archive/number form or the new YYMM.NNNNN form,
- * each with an optional lowercase version suffix.
+ * Validate an arXiv identifier.  Mirrors the bot's own URL-extraction
+ * patterns (URLtools.php): the old archive/number form or the new YYMM.NNNNN
+ * form, each with an optional lowercase version suffix.  CS1 additionally
+ * constrains the year/month ranges and the digit count by year; we
+ * deliberately do not enforce those so values the URL path accepts are never
+ * rejected here (defense in depth, not strict CS1 fidelity).
  */
 function arxiv_id_valid(string $value): bool {
-    if (preg_match('~^[a-zA-Z][a-zA-Z.\-]+/[0-9][0-9][01][0-9][0-9][0-9][0-9](v[0-9]+)?$~', $value) === 1) {
+    if (preg_match('~^[a-zA-Z][a-zA-Z.\-]+/\d{7}(v\d+)?$~', $value) === 1) {
         return true; // old style: e.g. hep-th/9901001
     }
-    if (preg_match('~^(0[7-9]|1[0-4])(0[1-9]|1[0-2])\.\d{4}(v\d+)?$~', $value) === 1) {
-        return true; // new style 0704-1412: four-digit number, e.g. 0704.1234
-    }
-    if (preg_match('~^(1[5-9]|[2-9]\d)(0[1-9]|1[0-2])\.\d{5}(v\d+)?$~', $value) === 1) {
-        return true; // new style 1501-: five-digit number, e.g. 1706.05013
+    if (preg_match('~^\d{4}\.\d{4,5}(v\d+)?$~', $value) === 1) {
+        return true; // new style: e.g. 1706.05013 or 1706.05013v2
     }
     return false;
 }
@@ -1212,21 +1212,21 @@ function rxiv_id_valid(string $value): bool {
 }
 
 /**
- * Validate a bibcode: exactly 19 characters whose first four digits form a
- * plausible year, with only letters, digits, underscores, ampersands, and dots
- * elsewhere.  This mirrors the shape used by REGEXP_BIBCODE and CS1's own
- * length/year tests (CS1 additionally requires a letter at position five,
- * which we deliberately do not enforce so existing numeric bibcodes are kept).
+ * Validate a bibcode: exactly 19 characters whose first four characters form
+ * a year beginning with 1 or 2 (matching REGEXP_BIBCODE), with only letters,
+ * digits, underscores, ampersands, and dots elsewhere.  CS1 additionally
+ * requires a letter at position five and a year within 1000..next year; we
+ * deliberately do not enforce those so values the URL path accepts are never
+ * rejected here (defense in depth, not strict CS1 fidelity).
  */
 function bibcode_valid(string $value): bool {
     if (mb_strlen($value) !== 19) {
         return false;
     }
-    if (preg_match('~^(\d{4})[\w&.]{15}$~', $value, $match) !== 1) {
+    if (preg_match('~^[12]\d{3}[\w&.]{15}$~', $value) !== 1) {
         return false;
     }
-    $year = intval($match[1]);
-    return $year >= 1000 && $year <= intval(date('Y')) + 1;
+    return true;
 }
 
 function changeisbn10Toisbn13(string $isbn10, int $year): string {

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -563,7 +563,7 @@ final class TemplatePart1Test extends testBaseClass {
     public function testAddASIN2(): void {
         $text = "{{Cite book}}";
         $expanded = $this->make_citation($text);
-        $this->assertTrue($expanded->add_if_new('asin', '630000000')); //63.... code
+        $this->assertTrue($expanded->add_if_new('asin', '630000000')); // 63.... code
         $this->assertSame('630000000', $expanded->get2('asin'));
     }
 
@@ -1050,9 +1050,17 @@ final class TemplatePart1Test extends testBaseClass {
     }
 
     public function testId2Param5(): void {
-        $text = '{{cite book|pages=1–2|id={{arxiv|zzzz|1234567}}}}{{cite book|pages=1–3|id={{arxiv|zzzz|1234567}}}}'; // Two of the same sub-template, but in different templates
+        $text = '{{cite book|pages=1-2|id={{arxiv|zzzz|1234567}}}}{{cite book|pages=1-3|id={{arxiv|zzzz|1234567}}}}'; // Two of the same sub-template, but in different templates
         $expanded = $this->process_page($text);
         $this->assertSame('{{cite book|pages=1–2|arxiv=zzzz/1234567 }}{{cite book|pages=1–3|arxiv=zzzz/1234567 }}', $expanded->parsed_text());
+    }
+
+    public function testArxivSubtemplatesRejectArchiveWithNewStyleId(): void {
+        // An old-style archive combined with a new-style id (astro-ph/1706.05013)
+        // is not a valid arXiv identifier and must be dropped.
+        $text = '{{cite book | id={{arxiv|astro-ph|1706.05013}} }}';
+        $expanded = $this->process_citation($text);
+        $this->assertNull($expanded->get2('arxiv'));
     }
 
     public function testNestedTemplates1(): void {

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1037,22 +1037,22 @@ final class TemplatePart1Test extends testBaseClass {
     }
 
     public function testId2Param3(): void {
-        $text = '{{cite book | id={{arxiv|hep-th|9901001}} }}';
+        $text = '{{cite book | id={{arxiv|zzzz|1234567}} }}';
         $expanded = $this->process_citation($text);
-        $this->assertSame('hep-th/9901001', $expanded->get2('arxiv'));
+        $this->assertSame('zzzz/1234567', $expanded->get2('arxiv'));
     }
 
     public function testId2Param4(): void {
-        $text = '{{cite book | id={{arxiv|hep-th|9901001}} {{arxiv|hep-th|9901001}} }}'; // Two of the same thing
+        $text = '{{cite book | id={{arxiv|zzzz|1234567}} {{arxiv|zzzz|1234567}} }}'; // Two of the same thing
         $expanded = $this->process_citation($text);
-        $this->assertSame('hep-th/9901001', $expanded->get2('arxiv'));
-        $this->assertSame('{{cite book | arxiv=hep-th/9901001 }}', $expanded->parsed_text());
+        $this->assertSame('zzzz/1234567', $expanded->get2('arxiv'));
+        $this->assertSame('{{cite book | arxiv=zzzz/1234567 }}', $expanded->parsed_text());
     }
 
     public function testId2Param5(): void {
-        $text = '{{cite book|pages=1–2|id={{arxiv|hep-th|9901001}}}}{{cite book|pages=1–3|id={{arxiv|hep-th|9901001}}}}'; // Two of the same sub-template, but in different templates
+        $text = '{{cite book|pages=1–2|id={{arxiv|zzzz|1234567}}}}{{cite book|pages=1–3|id={{arxiv|zzzz|1234567}}}}'; // Two of the same sub-template, but in different templates
         $expanded = $this->process_page($text);
-        $this->assertSame('{{cite book|pages=1–2|arxiv=hep-th/9901001 }}{{cite book|pages=1–3|arxiv=hep-th/9901001 }}', $expanded->parsed_text());
+        $this->assertSame('{{cite book|pages=1–2|arxiv=zzzz/1234567 }}{{cite book|pages=1–3|arxiv=zzzz/1234567 }}', $expanded->parsed_text());
     }
 
     public function testNestedTemplates1(): void {

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1618,4 +1618,34 @@ final class TemplatePart1Test extends testBaseClass {
         $this->assertTrue($template->add_if_new('isbn', '978-0-306-40615-7'));
         $this->assertSame('978-0-306-40615-7', $template->get2('isbn'));
     }
+
+    public function testAddIfNewRejectsMalformedArxiv(): void {
+        $text = '{{cite journal | title = X | journal = J }}';
+        $template = $this->make_citation($text);
+        $this->assertFalse($template->add_if_new('arxiv', 'bogus'));
+        $this->assertNull($template->get2('arxiv'));
+        $this->assertTrue($template->add_if_new('arxiv', '1706.05013'));
+        $this->assertSame('1706.05013', $template->get2('arxiv'));
+    }
+
+    public function testAddIfNewRejectsMalformedPmid(): void {
+        $text = '{{cite journal | title = X | journal = J }}';
+        $template = $this->make_citation($text);
+        $this->assertFalse($template->add_if_new('pmid', 'notanumber'));
+        $this->assertNull($template->get2('pmid'));
+    }
+
+    public function testAddIfNewRejectsMalformedPmc(): void {
+        $text = '{{cite journal | title = X | journal = J }}';
+        $template = $this->make_citation($text);
+        $this->assertFalse($template->add_if_new('pmc', 'notnumeric'));
+        $this->assertNull($template->get2('pmc'));
+    }
+
+    public function testAddIfNewNormalizesPmcPrefix(): void {
+        $text = '{{cite journal | title = X | journal = J | pmid = 12345 }}';
+        $template = $this->make_citation($text);
+        $this->assertTrue($template->add_if_new('pmc', 'PMC1234567'));
+        $this->assertSame('1234567', $template->get2('pmc'));
+    }
 }

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1037,22 +1037,22 @@ final class TemplatePart1Test extends testBaseClass {
     }
 
     public function testId2Param3(): void {
-        $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} }}';
+        $text = '{{cite book | id={{arxiv|hep-th|9901001}} }}';
         $expanded = $this->process_citation($text);
-        $this->assertSame('astr.ph/1234.5678', $expanded->get2('arxiv'));
+        $this->assertSame('hep-th/9901001', $expanded->get2('arxiv'));
     }
 
     public function testId2Param4(): void {
-        $text = '{{cite book | id={{arxiv|astr.ph|1234.5678}} {{arxiv|astr.ph|1234.5678}} }}'; // Two of the same thing
+        $text = '{{cite book | id={{arxiv|hep-th|9901001}} {{arxiv|hep-th|9901001}} }}'; // Two of the same thing
         $expanded = $this->process_citation($text);
-        $this->assertSame('astr.ph/1234.5678', $expanded->get2('arxiv'));
-        $this->assertSame('{{cite book | arxiv=astr.ph/1234.5678 }}', $expanded->parsed_text());
+        $this->assertSame('hep-th/9901001', $expanded->get2('arxiv'));
+        $this->assertSame('{{cite book | arxiv=hep-th/9901001 }}', $expanded->parsed_text());
     }
 
     public function testId2Param5(): void {
-        $text = '{{cite book|pages=1–2|id={{arxiv|astr.ph|1234.5678}}}}{{cite book|pages=1–3|id={{arxiv|astr.ph|1234.5678}}}}'; // Two of the same sub-template, but in different templates
+        $text = '{{cite book|pages=1–2|id={{arxiv|hep-th|9901001}}}}{{cite book|pages=1–3|id={{arxiv|hep-th|9901001}}}}'; // Two of the same sub-template, but in different templates
         $expanded = $this->process_page($text);
-        $this->assertSame('{{cite book|pages=1–2|arxiv=astr.ph/1234.5678 }}{{cite book|pages=1–3|arxiv=astr.ph/1234.5678 }}', $expanded->parsed_text());
+        $this->assertSame('{{cite book|pages=1–2|arxiv=hep-th/9901001 }}{{cite book|pages=1–3|arxiv=hep-th/9901001 }}', $expanded->parsed_text());
     }
 
     public function testNestedTemplates1(): void {

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -320,8 +320,8 @@ final class TemplatePart2Test extends testBaseClass {
     public function testAddBogusBibcode_2(): void {
         $text = "{{cite web}}";
         $template = $this->make_citation($text);
-        $this->assertTrue($template->add_if_new('bibcode', 'Z'));
-        $this->assertSame('Z..................', $template->get2('bibcode'));
+        $this->assertFalse($template->add_if_new('bibcode', 'Z'));
+        $this->assertNull($template->get2('bibcode'));
     }
 
     public function testvalidate_and_add1(): void {

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -317,11 +317,19 @@ final class TemplatePart2Test extends testBaseClass {
         $this->assertSame('Exists', $template->get2('bibcode'));
     }
 
-    public function testAddBogusBibcode_2(): void {
+    public function testRejectBogusBibcode(): void {
         $text = "{{cite web}}";
         $template = $this->make_citation($text);
         $this->assertFalse($template->add_if_new('bibcode', 'Z'));
         $this->assertNull($template->get2('bibcode'));
+    }
+
+    public function testPaddedShortBibcodeAccepted(): void {
+        // A short year-led bibcode is padded to 19 characters and kept.
+        $text = "{{cite web}}";
+        $template = $this->make_citation($text);
+        $this->assertTrue($template->add_if_new('bibcode', '2019'));
+        $this->assertSame('2019' . str_repeat('.', 15), $template->get2('bibcode'));
     }
 
     public function testvalidate_and_add1(): void {

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1862,10 +1862,10 @@ EP - 999 }}';
 
     public function testMedRxivComprehensiveParameterFiltering(): void {
         // Test that ALL disallowed parameters are removed, not just pmid/pmc/doi/journal
-        $text = '{{cite journal |title=Test Paper |journal=medRxiv |doi=10.64898/test123 |year=2023 |volume=5 |issue=3 |pages=100-200 |publisher=Cold Spring Harbor |issn=1234-5678 |url=https://example.com}}';
+        $text = '{{cite journal |title=Test Paper |journal=medRxiv |doi=10.64898/2025.12.10.693067 |year=2023 |volume=5 |issue=3 |pages=100-200 |publisher=Cold Spring Harbor |issn=1234-5678 |url=https://example.com}}';
         $prepared = $this->prepare_citation($text);
         $this->assertSame('cite medrxiv', $prepared->wikiname());
-        $this->assertSame('10.64898/test123', $prepared->get2('medrxiv'));
+        $this->assertSame('10.64898/2025.12.10.693067', $prepared->get2('medrxiv'));
         // Check that disallowed parameters are removed
         $this->assertNull($prepared->get2('doi'));
         $this->assertNull($prepared->get2('journal'));

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1862,10 +1862,10 @@ EP - 999 }}';
 
     public function testMedRxivComprehensiveParameterFiltering(): void {
         // Test that ALL disallowed parameters are removed, not just pmid/pmc/doi/journal
-        $text = '{{cite journal |title=Test Paper |journal=medRxiv |doi=10.64898/2025.12.10.693067 |year=2023 |volume=5 |issue=3 |pages=100-200 |publisher=Cold Spring Harbor |issn=1234-5678 |url=https://example.com}}';
+        $text = '{{cite journal |title=Test Paper |journal=medRxiv |doi=10.64898/2099.12.31.999999 |year=2023 |volume=5 |issue=3 |pages=100-200 |publisher=Cold Spring Harbor |issn=1234-5678 |url=https://example.com}}';
         $prepared = $this->prepare_citation($text);
         $this->assertSame('cite medrxiv', $prepared->wikiname());
-        $this->assertSame('10.64898/2025.12.10.693067', $prepared->get2('medrxiv'));
+        $this->assertSame('10.64898/2099.12.31.999999', $prepared->get2('medrxiv'));
         // Check that disallowed parameters are removed
         $this->assertNull($prepared->get2('doi'));
         $this->assertNull($prepared->get2('journal'));

--- a/tests/phpunit/includes/api/pubmedTest.php
+++ b/tests/phpunit/includes/api/pubmedTest.php
@@ -51,14 +51,14 @@ final class pubmedTest extends testBaseClass {
         // Non-existent PMC: NCBI returns 404, early-return fires → PDF URL kept, rename skipped.
         // If NCBI returns 200 instead (e.g. a soft-404 page), the URL is dropped and the test is skipped.
         $this->sleep_pubmed();
-        $text = "{{Cite web | url = https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9999999/pdf/nonexistent.pdf}}";
+        $text = "{{Cite web | url = https://www.ncbi.nlm.nih.gov/pmc/articles/PMC99999999/pdf/nonexistent.pdf}}";
         $expanded = $this->process_citation($text);
-        $this->assertSame('9999999', $expanded->get2('pmc'));
+        $this->assertSame('99999999', $expanded->get2('pmc'));
         if ($expanded->get2('url') === null) {
             $this->markTestSkipped('NCBI did not return 404 for non-existent PMC (API behavior changed or unavailable)');
         }
         $this->assertSame('cite web', $expanded->wikiname());
-        $this->assertSame('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9999999/pdf/nonexistent.pdf', $expanded->get2('url'));
+        $this->assertSame('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC99999999/pdf/nonexistent.pdf', $expanded->get2('url'));
     }
 
     public function testPMC2PMID(): void {

--- a/tests/phpunit/includes/api/pubmedTest.php
+++ b/tests/phpunit/includes/api/pubmedTest.php
@@ -51,14 +51,14 @@ final class pubmedTest extends testBaseClass {
         // Non-existent PMC: NCBI returns 404, early-return fires → PDF URL kept, rename skipped.
         // If NCBI returns 200 instead (e.g. a soft-404 page), the URL is dropped and the test is skipped.
         $this->sleep_pubmed();
-        $text = "{{Cite web | url = https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9999999999/pdf/nonexistent.pdf}}";
+        $text = "{{Cite web | url = https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9999999/pdf/nonexistent.pdf}}";
         $expanded = $this->process_citation($text);
-        $this->assertSame('9999999999', $expanded->get2('pmc'));
+        $this->assertSame('9999999', $expanded->get2('pmc'));
         if ($expanded->get2('url') === null) {
             $this->markTestSkipped('NCBI did not return 404 for non-existent PMC (API behavior changed or unavailable)');
         }
         $this->assertSame('cite web', $expanded->wikiname());
-        $this->assertSame('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9999999999/pdf/nonexistent.pdf', $expanded->get2('url'));
+        $this->assertSame('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9999999/pdf/nonexistent.pdf', $expanded->get2('url'));
     }
 
     public function testPMC2PMID(): void {

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1335,6 +1335,8 @@ final class textToolsTest extends testBaseClass {
         $this->assertTrue(rxiv_id_valid('10.64898/2025.12.10.693067'));  // new doi prefix
         $this->assertFalse(rxiv_id_valid('10.1101/abc'));
         $this->assertFalse(rxiv_id_valid('10.1101/2019.13.11.123456'));  // month 13
+        $this->assertFalse(rxiv_id_valid('10.1101/2019.12.32.123456'));  // day 32
+        $this->assertFalse(rxiv_id_valid('10.64898/test123'));           // 10.64898 requires the dated form
         $this->assertFalse(rxiv_id_valid('bogus'));
         $this->assertFalse(rxiv_id_valid(''));
     }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1326,8 +1326,9 @@ final class textToolsTest extends testBaseClass {
     }
 
     public function testRxivIdValid(): void {
-        $this->assertTrue(rxiv_id_valid('10.1101/078733'));              // legacy 6-digit
+        $this->assertTrue(rxiv_id_valid('10.1101/078733'));              // legacy 6-digit (bioRxiv)
         $this->assertTrue(rxiv_id_valid('10.1101/078733v1'));            // legacy with version
+        $this->assertTrue(rxiv_id_valid('10.1101/19000380'));            // legacy 8-digit (early medRxiv)
         $this->assertTrue(rxiv_id_valid('10.1101/2019.12.11.123456'));   // dated form
         $this->assertTrue(rxiv_id_valid('10.1101/2019.12.11.123456v2')); // dated with version
         $this->assertTrue(rxiv_id_valid('10.1101/2020.04.05.20054502')); // 8-digit medRxiv form

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1327,8 +1327,10 @@ final class textToolsTest extends testBaseClass {
 
     public function testRxivIdValid(): void {
         $this->assertTrue(rxiv_id_valid('10.1101/078733'));              // legacy 6-digit
+        $this->assertTrue(rxiv_id_valid('10.1101/078733v1'));            // legacy with version
         $this->assertTrue(rxiv_id_valid('10.1101/2019.12.11.123456'));   // dated form
         $this->assertTrue(rxiv_id_valid('10.1101/2019.12.11.123456v2')); // dated with version
+        $this->assertTrue(rxiv_id_valid('10.1101/2020.04.05.20054502')); // 8-digit medRxiv form
         $this->assertTrue(rxiv_id_valid('10.64898/2025.12.10.693067'));  // new doi prefix
         $this->assertFalse(rxiv_id_valid('10.1101/abc'));
         $this->assertFalse(rxiv_id_valid('10.1101/2019.13.11.123456'));  // month 13

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1297,11 +1297,11 @@ final class textToolsTest extends testBaseClass {
     public function testArxivIdValid(): void {
         $this->assertTrue(arxiv_id_valid('1706.05013'));          // new style
         $this->assertTrue(arxiv_id_valid('1706.05013v2'));        // new style with version
+        $this->assertTrue(arxiv_id_valid('1234.5678'));           // any YYMM.NNNN accepted (matches URLtools)
         $this->assertTrue(arxiv_id_valid('hep-th/9901001'));      // old style
         $this->assertTrue(arxiv_id_valid('math.GT/0309136'));     // old style with class
         $this->assertFalse(arxiv_id_valid('bogus'));
-        $this->assertFalse(arxiv_id_valid('1706.0501'));          // too few digits
-        $this->assertFalse(arxiv_id_valid('9913.12345'));         // impossible month
+        $this->assertFalse(arxiv_id_valid('1706.05013x'));        // bad version character
         $this->assertFalse(arxiv_id_valid(''));
     }
 
@@ -1340,9 +1340,10 @@ final class textToolsTest extends testBaseClass {
         $this->assertTrue(bibcode_valid('2015arXiv151206696F'));
         $this->assertTrue(bibcode_valid('2005A&A...430.1063G'));
         $this->assertTrue(bibcode_valid('1234567890123456789')); // numeric bibcodes accepted (matches REGEXP_BIBCODE)
+        $this->assertTrue(bibcode_valid('2222NatSR...814768S')); // year 1xxx/2xxx accepted (matches REGEXP_BIBCODE)
         $this->assertFalse(bibcode_valid('xyz'));                 // too short
         $this->assertFalse(bibcode_valid('12345'));               // too short
-        $this->assertFalse(bibcode_valid('9999PhRvD..89h4022A')); // year out of range
+        $this->assertFalse(bibcode_valid('9999PhRvD..89h4022A')); // year must begin with 1 or 2
         $this->assertFalse(bibcode_valid(''));
     }
 }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1293,4 +1293,56 @@ final class textToolsTest extends testBaseClass {
         $this->assertFalse(isbn_valid('123-4567-890-128')); // valid check digit, prefix not 978/979
         $this->assertFalse(isbn_valid('979-0123456785'));   // 9790 group reserved for ISMN
     }
+
+    public function testArxivIdValid(): void {
+        $this->assertTrue(arxiv_id_valid('1706.05013'));          // new style
+        $this->assertTrue(arxiv_id_valid('1706.05013v2'));        // new style with version
+        $this->assertTrue(arxiv_id_valid('hep-th/9901001'));      // old style
+        $this->assertTrue(arxiv_id_valid('math.GT/0309136'));     // old style with class
+        $this->assertFalse(arxiv_id_valid('bogus'));
+        $this->assertFalse(arxiv_id_valid('1706.0501'));          // too few digits
+        $this->assertFalse(arxiv_id_valid('9913.12345'));         // impossible month
+        $this->assertFalse(arxiv_id_valid(''));
+    }
+
+    public function testPmidValid(): void {
+        $this->assertTrue(pmid_valid('1234567'));
+        $this->assertTrue(pmid_valid('1'));
+        $this->assertTrue(pmid_valid('99999999'));
+        $this->assertFalse(pmid_valid('123456789'));              // too long (9 digits)
+        $this->assertFalse(pmid_valid('12a45'));
+        $this->assertFalse(pmid_valid('0'));
+        $this->assertFalse(pmid_valid(''));
+    }
+
+    public function testPmcValid(): void {
+        $this->assertTrue(pmc_valid('1234567'));
+        $this->assertTrue(pmc_valid('PMC1234567'));
+        $this->assertTrue(pmc_valid('pmc123'));
+        $this->assertFalse(pmc_valid('1234567890123'));           // too long
+        $this->assertFalse(pmc_valid('abc'));
+        $this->assertFalse(pmc_valid('0'));
+        $this->assertFalse(pmc_valid(''));
+    }
+
+    public function testRxivIdValid(): void {
+        $this->assertTrue(rxiv_id_valid('10.1101/078733'));              // legacy 6-digit
+        $this->assertTrue(rxiv_id_valid('10.1101/2019.12.11.123456'));   // dated form
+        $this->assertTrue(rxiv_id_valid('10.1101/2019.12.11.123456v2')); // dated with version
+        $this->assertTrue(rxiv_id_valid('10.64898/2025.12.10.693067'));  // new doi prefix
+        $this->assertFalse(rxiv_id_valid('10.1101/abc'));
+        $this->assertFalse(rxiv_id_valid('10.1101/2019.13.11.123456'));  // month 13
+        $this->assertFalse(rxiv_id_valid('bogus'));
+        $this->assertFalse(rxiv_id_valid(''));
+    }
+
+    public function testBibcodeValid(): void {
+        $this->assertTrue(bibcode_valid('2015arXiv151206696F'));
+        $this->assertTrue(bibcode_valid('2005A&A...430.1063G'));
+        $this->assertTrue(bibcode_valid('1234567890123456789')); // numeric bibcodes accepted (matches REGEXP_BIBCODE)
+        $this->assertFalse(bibcode_valid('xyz'));                 // too short
+        $this->assertFalse(bibcode_valid('12345'));               // too short
+        $this->assertFalse(bibcode_valid('9999PhRvD..89h4022A')); // year out of range
+        $this->assertFalse(bibcode_valid(''));
+    }
 }

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -109,6 +109,12 @@ const ACCESS_PARAMS = [
     'doi-access' => ['doi'],
 ];
 
+const URL_PARAMS = ['url', 'URL'];
+const CHAPTER_URL_PARAMS = ['chapter-url', 'chapterurl'];
+const ARCHIVE_URL_PARAMS = ['archive-url', 'archiveurl'];
+const ARCHIVE_DATE_PARAMS = ['archive-date', 'archivedate'];
+const ACCESS_DATE_PARAMS = ['access-date', 'accessdate'];
+
 const TRANS_PARAMS = [
     'trans-title' => ['title', 'script-title'],
     'trans-chapter' => ['chapter'],
@@ -203,18 +209,18 @@ function check_citation(Template $template): array {
     }
 
     // R5: archive-url/archive-date coupling (alias spellings included).
-    if (($template->has('archive-url') || $template->has('archiveurl')) && !$template->has('archive-date') && !$template->has('archivedate')) {
+    if (has_any($template, ARCHIVE_URL_PARAMS) && !has_any($template, ARCHIVE_DATE_PARAMS)) {
         $violations[] = 'archive-url-without-date: CS1 "|archive-url= requires |archive-date="';
     }
-    if (($template->has('archive-date') || $template->has('archivedate')) && !$template->has('archive-url') && !$template->has('archiveurl')) {
+    if (has_any($template, ARCHIVE_DATE_PARAMS) && !has_any($template, ARCHIVE_URL_PARAMS)) {
         $violations[] = 'archive-date-without-url: CS1 "|archive-date= requires |archive-url="';
     }
-    if (($template->has('archive-url') || $template->has('archiveurl')) && !$template->has('url')) {
+    if (has_any($template, ARCHIVE_URL_PARAMS) && !has_any($template, URL_PARAMS)) {
         $violations[] = 'archive-url-without-url: CS1 "|archive-url= requires |url="';
     }
 
     // R6: access-date requires url or archive-url (alias spellings included).
-    if (($template->has('access-date') || $template->has('accessdate')) && !$template->has('url') && !$template->has('archive-url') && !$template->has('archiveurl')) {
+    if (has_any($template, ACCESS_DATE_PARAMS) && !has_any($template, URL_PARAMS) && !has_any($template, ARCHIVE_URL_PARAMS)) {
         $violations[] = 'access-date-orphaned: CS1 "|access-date= requires |url="';
     }
 
@@ -235,7 +241,7 @@ function check_citation(Template $template): array {
     }
 
     // R9: cite web requires a url.
-    if ($name === 'cite web' && !$template->has('url')) {
+    if ($name === 'cite web' && !has_any($template, URL_PARAMS)) {
         $violations[] = 'cite-web-without-url: CS1 "Missing or empty |url="';
     }
 
@@ -264,10 +270,10 @@ function check_citation(Template $template): array {
     }
 
     // R13: format parameters require their url base.
-    if ($template->has('format') && !$template->has('url')) {
+    if ($template->has('format') && !has_any($template, URL_PARAMS)) {
         $violations[] = 'format-orphaned: CS1 "|format= requires |url="';
     }
-    if ($template->has('chapter-format') && !$template->has('chapter-url')) {
+    if ($template->has('chapter-format') && !has_any($template, CHAPTER_URL_PARAMS)) {
         $violations[] = 'chapter-format-orphaned: CS1 "|chapter-format= requires |chapter-url="';
     }
 
@@ -277,7 +283,7 @@ function check_citation(Template $template): array {
     }
 
     // R15: url and title-link must not both be present.
-    if ($template->has('url') && $template->has('title-link')) {
+    if (has_any($template, URL_PARAMS) && $template->has('title-link')) {
         $violations[] = 'url-title-link-conflict: CS1 "URL-wikilink conflict"';
     }
 
@@ -337,6 +343,10 @@ function build_matrix(): array {
         ['url-access kept when base uses uppercase URL alias', '{{cite web |URL=https://example.com |url-access=subscription |title=X}}', 'pass'],
         ['url-access kept when base uses un-hyphenated alias', '{{cite web |url=https://example.com |url-access=subscription |title=X}}', 'pass'],
         ['chapter-url-access kept with chapter-url base', '{{cite book |title=X |chapter-url=https://example.com |chapter-url-access=free |year=2020}}', 'pass'],
+        ['uppercase URL base keeps access-date', '{{cite web |URL=https://example.com |access-date=2020-01-01 |title=X}}', 'pass'],
+        ['uppercase URL base keeps archive-url', '{{cite web |URL=https://example.com |archive-url=https://web.archive.org/web/20200101000000/https://example.com |archive-date=2020-01-01 |title=X}}', 'pass'],
+        ['uppercase URL base keeps format', '{{cite web |URL=https://example.com |format=PDF |title=X}}', 'pass'],
+        ['un-hyphenated chapterurl base keeps chapter-format', '{{cite book |title=X |chapterurl=https://example.com |chapter-format=PDF |year=2020}}', 'pass'],
 
         // --- ISBN validation (merged Tier 1 fix) ---
         ['Valid ISBN-10 kept', '{{cite journal |title=X |journal=J |isbn=0-306-40615-2}}', 'pass'],
@@ -417,6 +427,7 @@ echo "--------------------------------------------------------------\n";
 
 $passed = 0;
 $gaps = 0;
+$resolved = 0;
 $failed = 0;
 $failures = [];
 
@@ -442,7 +453,12 @@ foreach ($matrix as [$name, $wikitext, $expectation]) {
         }
     } else {
         $gaps++;
-        $status = $violations === [] ? 'RESOLVED' : 'KNOWN-GAP';
+        if ($violations === []) {
+            $resolved++;
+            $status = 'RESOLVED';
+        } else {
+            $status = 'KNOWN-GAP';
+        }
         echo "GAP   $name [$status]\n";
         foreach ($violations as $violation) {
             echo "        - $violation\n";
@@ -451,7 +467,10 @@ foreach ($matrix as [$name, $wikitext, $expectation]) {
 }
 
 echo "--------------------------------------------------------------\n";
-echo "Summary: $passed passed, $gaps known gaps, $failed failed\n";
+echo "Summary: $passed passed, $gaps known gaps, $resolved unexpectedly resolved, $failed failed\n";
+if ($resolved > 0) {
+    echo "\n$resolved gap case(s) unexpectedly resolved: convert them from 'gap' to 'pass' (or confirm the resolution is intentional).\n";
+}
 if ($failed > 0) {
     echo "\nFailed cases:\n";
     foreach ($failures as [$name, $violations]) {
@@ -462,4 +481,4 @@ if ($failed > 0) {
     }
 }
 
-exit($failed > 0 ? 1 : 0);
+exit($failed > 0 || $resolved > 0 ? 1 : 0);

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -275,6 +275,25 @@ function check_citation(Template $template): array {
         $violations[] = 'url-title-link-conflict: CS1 "URL-wikilink conflict"';
     }
 
+    // R16: identifier format checks (validators mirror CS1's structural rules).
+    if (($template->has('arxiv') && !arxiv_id_valid($template->get('arxiv'))) ||
+        ($template->has('eprint') && !arxiv_id_valid($template->get('eprint')))) {
+        $violations[] = 'arxiv-malformed: CS1 "Check |arxiv= value"';
+    }
+    if ($template->has('pmid') && !pmid_valid($template->get('pmid'))) {
+        $violations[] = 'pmid-malformed: CS1 "Check |pmid= value"';
+    }
+    if ($template->has('pmc') && !pmc_valid($template->get('pmc'))) {
+        $violations[] = 'pmc-malformed: CS1 "Check |pmc= value"';
+    }
+    if ($template->has('bibcode') && !bibcode_valid($template->get('bibcode'))) {
+        $violations[] = 'bibcode-malformed: CS1 "Check |bibcode= value"';
+    }
+    if (($template->has('biorxiv') && !rxiv_id_valid($template->get('biorxiv'))) ||
+        ($template->has('medrxiv') && !rxiv_id_valid($template->get('medrxiv')))) {
+        $violations[] = 'rxiv-malformed: CS1 "Check |biorxiv=/|medrxiv= value"';
+    }
+
     return $violations;
 }
 
@@ -323,7 +342,7 @@ function build_matrix(): array {
         ['Clean cite magazine', '{{cite magazine |title=X |magazine=The New Yorker |date=2020}}', 'pass'],
         ['Clean cite encyclopedia', '{{cite encyclopedia |title=X |encyclopedia=Britannica |publisher=P |date=2020}}', 'pass'],
         ['Clean cite web with work= (periodical alias)', '{{cite web |url=https://example.com |title=X |work=SomeWebsite}}', 'pass'],
-        ['Clean cite arxiv', '{{cite arxiv |arxiv=1234.56789 |title=X}}', 'pass'],
+        ['Clean cite arxiv', '{{cite arxiv |arxiv=2401.99999 |title=X}}', 'pass'],
         ['Clean cite biorxiv', '{{cite biorxiv |biorxiv=10.1101/2020.01.01.000001 |title=X}}', 'pass'],
         ['Clean cite ssrn', '{{cite ssrn |ssrn=1234567 |title=X}}', 'pass'],
 
@@ -335,6 +354,8 @@ function build_matrix(): array {
         ['GAP empty title left as-is', '{{cite journal |journal=Nature}}', 'gap'],
         ['GAP orphaned trans-chapter left as-is', '{{cite journal |title=X |journal=J |trans-chapter=Y}}', 'gap'],
         ['GAP work= survives in cite book', '{{cite book |title=X |work=Some Series |publisher=P |year=2020}}', 'gap'],
+        ['GAP malformed arxiv in input survives tidy', '{{cite journal |title=X |journal=J |arxiv=bogus}}', 'gap'],
+        ['GAP malformed pmc in input survives tidy', '{{cite journal |title=X |journal=J |pmc=notnumeric}}', 'gap'],
     ];
 }
 

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
  *   php tools/cs1_harness.php --slow     # slow mode
  *   php tools/cs1_harness.php --list     # print the matrix without running
  *
- * The harness is offline-safe and deterministic: the matrix uses fabricated
- * identifiers and titles that external APIs cannot match, so no credentials
- * are needed and the pass/fail result is reproducible run-to-run.
+ * The harness needs no credentials: the matrix uses fabricated identifiers
+ * and titles that external APIs cannot match, so the pass/fail result is
+ * reproducible run-to-run when the upstream APIs respond normally.
  * Exit code is 1 if any "must-pass" case violates the CS1 rules.
  */
 
@@ -202,19 +202,19 @@ function check_citation(Template $template): array {
         $violations[] = 'isbn-invalid: CS1 "Check |isbn= value"';
     }
 
-    // R5: archive-url/archive-date coupling.
-    if ($template->has('archive-url') && !$template->has('archive-date')) {
+    // R5: archive-url/archive-date coupling (alias spellings included).
+    if (($template->has('archive-url') || $template->has('archiveurl')) && !$template->has('archive-date') && !$template->has('archivedate')) {
         $violations[] = 'archive-url-without-date: CS1 "|archive-url= requires |archive-date="';
     }
-    if ($template->has('archive-date') && !$template->has('archive-url')) {
+    if (($template->has('archive-date') || $template->has('archivedate')) && !$template->has('archive-url') && !$template->has('archiveurl')) {
         $violations[] = 'archive-date-without-url: CS1 "|archive-date= requires |archive-url="';
     }
-    if ($template->has('archive-url') && !$template->has('url')) {
+    if (($template->has('archive-url') || $template->has('archiveurl')) && !$template->has('url')) {
         $violations[] = 'archive-url-without-url: CS1 "|archive-url= requires |url="';
     }
 
-    // R6: access-date requires url or archive-url.
-    if ($template->has('access-date') && !$template->has('url') && !$template->has('archive-url')) {
+    // R6: access-date requires url or archive-url (alias spellings included).
+    if (($template->has('access-date') || $template->has('accessdate')) && !$template->has('url') && !$template->has('archive-url') && !$template->has('archiveurl')) {
         $violations[] = 'access-date-orphaned: CS1 "|access-date= requires |url="';
     }
 
@@ -370,7 +370,7 @@ function build_matrix(): array {
         ['GAP work= survives in cite book', '{{cite book |title=X |work=Some Series |publisher=P |year=2020}}', 'gap'],
         ['GAP malformed arxiv in input survives tidy', '{{cite journal |title=X |journal=J |arxiv=bogus}}', 'gap'],
         ['GAP malformed pmc in input survives tidy', '{{cite journal |title=X |journal=J |pmc=notnumeric}}', 'gap'],
-        ['GAP malformed eprint in input survives tidy', '{{cite journal |title=X |journal=J |eprint=XYZ}}', 'gap'],
+        ['GAP malformed arxiv/eprint in input survives tidy', '{{cite journal |title=X |journal=J |eprint=XYZ}}', 'gap'],
         ['GAP malformed bibcode in input survives tidy', '{{cite journal |title=X |journal=J |bibcode=Z}}', 'gap'],
     ];
 }

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -65,14 +65,20 @@ restore_error_handler();
 // Convert report_error()'s trigger_error() into a catchable exception.
 // Errors suppressed with @ are honored (in PHP 8 the @ operator leaves
 // error_reporting() set to the insuppressible levels only), matching how
-// PHPUnit's own error handler behaves so normal bot code paths are unaffected.
+// PHPUnit's own error handler behaves. Only the report_* trigger_error()
+// severities (and fatal-ish errors) are escalated, so native E_WARNING,
+// E_NOTICE, and E_DEPRECATED pass through and results do not vary with the
+// PHP version or incidental codebase warnings.
 set_error_handler(static function (int $severity, string $message, string $file = '', int $line = 0): bool {
     $insuppressible = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
     if ((error_reporting() & ~$insuppressible) === 0) {
         // Error was suppressed with @.
         return true;
     }
-    throw new ErrorException($message, 0, $severity, $file, $line);
+    if (($severity & (E_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_USER_WARNING | E_USER_NOTICE)) !== 0) {
+        throw new ErrorException($message, 0, $severity, $file, $line);
+    }
+    return true;
 });
 
 // setup.php skips channel creation under CI; we need the handle ourselves.

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -295,9 +295,17 @@ function check_citation(Template $template): array {
     if ($template->has('bibcode') && !bibcode_valid($template->get('bibcode'))) {
         $violations[] = 'bibcode-malformed: CS1 "Check |bibcode= value"';
     }
-    if (($template->has('biorxiv') && !rxiv_id_valid($template->get('biorxiv'))) ||
-        ($template->has('medrxiv') && !rxiv_id_valid($template->get('medrxiv')))) {
-        $violations[] = 'rxiv-malformed: CS1 "Check |biorxiv=/|medrxiv= value"';
+    foreach (['biorxiv', 'medrxiv'] as $param) {
+        if ($template->has($param)) {
+            $test_value = $template->get($param);
+            // Mirror the add_if_new gate: normalize the prefix before validating.
+            if (mb_strpos($test_value, '10.1101/') !== 0 && mb_strpos($test_value, '10.64898/') !== 0) {
+                $test_value = '10.1101/' . $test_value;
+            }
+            if (!rxiv_id_valid($test_value)) {
+                $violations[] = 'rxiv-malformed: CS1 "Check |biorxiv=/|medrxiv= value"';
+            }
+        }
     }
 
     return $violations;
@@ -362,6 +370,8 @@ function build_matrix(): array {
         ['GAP work= survives in cite book', '{{cite book |title=X |work=Some Series |publisher=P |year=2020}}', 'gap'],
         ['GAP malformed arxiv in input survives tidy', '{{cite journal |title=X |journal=J |arxiv=bogus}}', 'gap'],
         ['GAP malformed pmc in input survives tidy', '{{cite journal |title=X |journal=J |pmc=notnumeric}}', 'gap'],
+        ['GAP malformed eprint in input survives tidy', '{{cite journal |title=X |journal=J |eprint=XYZ}}', 'gap'],
+        ['GAP malformed bibcode in input survives tidy', '{{cite journal |title=X |journal=J |bibcode=Z}}', 'gap'],
     ];
 }
 

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -17,7 +17,8 @@ declare(strict_types=1);
  * The harness needs no credentials: the matrix uses fabricated identifiers
  * and titles that external APIs cannot match, so the pass/fail result is
  * reproducible run-to-run when the upstream APIs respond normally.
- * Exit code is 1 if any "must-pass" case violates the CS1 rules.
+ * Exit code is 1 if any "must-pass" case violates the CS1 rules, or if a
+ * known-gap case unexpectedly resolves (an XPASS that must be converted).
  */
 
 set_time_limit(0);
@@ -109,6 +110,10 @@ const ACCESS_PARAMS = [
     'doi-access' => ['doi'],
 ];
 
+// Alias groups for the url/archive/access-date family. The bot normally
+// canonicalizes these aliases before output (so the checker usually sees the
+// canonical names); the groups are defense-in-depth so the rules also hold if
+// an alias form ever survives expansion.
 const URL_PARAMS = ['url', 'URL'];
 const CHAPTER_URL_PARAMS = ['chapter-url', 'chapterurl'];
 const ARCHIVE_URL_PARAMS = ['archive-url', 'archiveurl'];
@@ -467,7 +472,7 @@ foreach ($matrix as [$name, $wikitext, $expectation]) {
 }
 
 echo "--------------------------------------------------------------\n";
-echo "Summary: $passed passed, $gaps known gaps, $resolved unexpectedly resolved, $failed failed\n";
+echo "Summary: $passed passed, $gaps gap cases, $resolved unexpectedly resolved, $failed failed\n";
 if ($resolved > 0) {
     echo "\n$resolved gap case(s) unexpectedly resolved: convert them from 'gap' to 'pass' (or confirm the resolution is intentional).\n";
 }

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CS1 self-validation harness.
+ *
+ * Runs a matrix of citation templates through the bot's real expansion
+ * machinery (fast and slow modes) and flags any expanded output that would
+ * trigger a CS1 error, per the encodable rules from docs/CS1-error-audit.md.
+ *
+ * Usage (from the repository root):
+ *   php tools/cs1_harness.php            # fast mode
+ *   php tools/cs1_harness.php --slow     # slow mode
+ *   php tools/cs1_harness.php --list     # print the matrix without running
+ *
+ * The harness is offline-safe and deterministic: the matrix uses fabricated
+ * identifiers and titles that external APIs cannot match, so no credentials
+ * are needed and the pass/fail result is reproducible run-to-run.
+ * Exit code is 1 if any "must-pass" case violates the CS1 rules.
+ */
+
+set_time_limit(0);
+
+// ---------------------------------------------------------------------------
+// Bootstrap (must come before any class use)
+// ---------------------------------------------------------------------------
+
+$slow_mode = in_array('--slow', $argv, true);
+if (!defined('SLOW_MODE')) {
+    define('SLOW_MODE', $slow_mode);
+}
+
+// Force CI semantics: report_error() triggers an error (see handler below)
+// instead of silently exit(0)ing, so a mid-expansion problem becomes a
+// per-case failure rather than killing the whole run.
+putenv('CI=1');
+
+// constants.php reads PUBLIC_BASE_URL at load time; provide the same
+// fallbacks env.php.example would set in production.
+if (!getenv('PUBLIC_BASE_URL')) {
+    putenv('PUBLIC_BASE_URL=https://citations.toolforge.org');
+}
+if (!getenv('ALLOWED_HOSTS')) {
+    putenv('ALLOWED_HOSTS=citations.toolforge.org');
+}
+if (!getenv('ALLOWED_ORIGINS')) {
+    putenv('ALLOWED_ORIGINS=https://citations.toolforge.org');
+}
+
+// setup.php re-defines SLOW_MODE; our definition wins, and we swallow the
+// redundant-redefinition warning it would otherwise emit.
+set_error_handler(static function (int $severity, string $message): bool {
+    return mb_strpos($message, 'already defined') !== false;
+});
+$old_error_level = error_reporting(E_ALL & ~E_WARNING);
+if (file_exists(__DIR__ . '/../src/env.php')) {
+    /** @psalm-suppress MissingFile */
+    include_once __DIR__ . '/../src/env.php';
+}
+require_once __DIR__ . '/../src/includes/setup.php';
+error_reporting($old_error_level);
+restore_error_handler();
+
+// Convert report_error()'s trigger_error() into a catchable exception.
+// Errors suppressed with @ are honored (in PHP 8 the @ operator leaves
+// error_reporting() set to the insuppressible levels only), matching how
+// PHPUnit's own error handler behaves so normal bot code paths are unaffected.
+set_error_handler(static function (int $severity, string $message, string $file = '', int $line = 0): bool {
+    $insuppressible = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
+    if ((error_reporting() & ~$insuppressible) === 0) {
+        // Error was suppressed with @.
+        return true;
+    }
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+// setup.php skips channel creation under CI; we need the handle ourselves.
+Zotero::create_ch_zotero();
+
+// ---------------------------------------------------------------------------
+// CS1 rule data (mirrors the audit and the bot's own coupled-parameter logic)
+// ---------------------------------------------------------------------------
+
+const PERIODICAL_PARAMS = ['work', 'journal', 'newspaper', 'magazine', 'website', 'periodical', 'encyclopedia', 'encyclopaedia'];
+
+const NON_PERIODICAL_TEMPLATES = [
+    'cite book', 'cite thesis', 'cite arxiv', 'cite biorxiv', 'cite medrxiv',
+    'cite document', 'cite citeseerx', 'cite ssrn', 'cite report', 'cite press release',
+];
+
+const ACCESS_PARAMS = [
+    'url-access' => ['url', 'URL'],
+    'chapter-url-access' => ['chapter-url', 'chapterurl'],
+    'contribution-url-access' => ['contribution-url', 'contributionurl'],
+    'article-url-access' => ['article-url', 'articleurl'],
+    'entry-url-access' => ['entry-url', 'entryurl'],
+    'section-url-access' => ['section-url', 'sectionurl'],
+    'event-url-access' => ['event-url', 'eventurl'],
+    'lay-url-access' => ['lay-url', 'layurl'],
+    'transcript-url-access' => ['transcript-url', 'transcripturl'],
+    'map-url-access' => ['map-url', 'mapurl'],
+    'doi-access' => ['doi'],
+];
+
+const TRANS_PARAMS = [
+    'trans-title' => ['title', 'script-title'],
+    'trans-chapter' => ['chapter'],
+    'trans-quote' => ['quote'],
+    'trans-journal' => ['journal'],
+    'trans-work' => ['work'],
+    'trans-magazine' => ['magazine'],
+    'trans-newspaper' => ['newspaper'],
+    'trans-website' => ['website'],
+    'trans-encyclopedia' => ['encyclopedia'],
+    'trans-dictionary' => ['dictionary'],
+    'trans-periodical' => ['periodical'],
+    'trans-section' => ['section'],
+];
+
+const TEXT_PARAMS = ['title', 'chapter', 'series', 'journal', 'work', 'magazine', 'newspaper', 'website', 'publisher', 'edition', 'volume', 'issue', 'pages', 'quote', 'trans-title'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function reset_bot_state(): void {
+    Template::$all_templates = [];
+    Template::$date_style = DateStyle::DATES_WHATEVER;
+    Template::$name_list_style = VancStyle::NAME_LIST_STYLE_DEFAULT;
+    Template::$page_display_authors = '';
+    Zotero::block_zotero();
+    AdsAbsControl::big_give_up();
+    AdsAbsControl::small_give_up();
+}
+
+/** @return array<int, Template> */
+function expand_citation(string $wikitext): array {
+    reset_bot_state();
+    $page = new Page();
+    $page->parse_text($wikitext);
+    $page->expand_text();
+    $templates = [];
+    foreach ($page->extract_object('Template') as $template) {
+        $wikiname = $template->wikiname();
+        if (mb_strpos($wikiname, 'cite ') === 0 || $wikiname === 'citation') {
+            $templates[] = $template;
+        }
+    }
+    return $templates;
+}
+
+function has_any(Template $template, array $names): bool {
+    foreach ($names as $name) {
+        if ($template->has($name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function has_external_link(string $value): bool {
+    return preg_match('~\[\s*https?://~i', $value) === 1;
+}
+
+// ---------------------------------------------------------------------------
+// The CS1 checker
+// ---------------------------------------------------------------------------
+
+/** @return array<int, string> */
+function check_citation(Template $template): array {
+    $violations = [];
+    $name = $template->wikiname();
+
+    // R1: title (or script-title) present and non-empty.
+    if (!$template->has('title') && !$template->has('script-title')) {
+        $violations[] = 'title-empty: CS1 "Missing or empty |title="';
+    }
+
+    // R2: trans-<param> requires its base parameter.
+    foreach (TRANS_PARAMS as $trans => $bases) {
+        if ($template->has($trans) && !has_any($template, $bases)) {
+            $violations[] = "orphaned $trans: CS1 \"|$trans= requires |" . $bases[0] . "=\"";
+        }
+    }
+
+    // R3: <param>-access requires its base URL/DOI parameter (all alias forms).
+    foreach (ACCESS_PARAMS as $access => $bases) {
+        if ($template->has($access) && !has_any($template, $bases)) {
+            $violations[] = "orphaned $access: CS1 \"|$access= requires |" . $bases[0] . "=\"";
+        }
+    }
+
+    // R4: ISBN check-digit/prefix validation.
+    if ($template->has('isbn') && !isbn_valid($template->get('isbn'))) {
+        $violations[] = 'isbn-invalid: CS1 "Check |isbn= value"';
+    }
+
+    // R5: archive-url/archive-date coupling.
+    if ($template->has('archive-url') && !$template->has('archive-date')) {
+        $violations[] = 'archive-url-without-date: CS1 "|archive-url= requires |archive-date="';
+    }
+    if ($template->has('archive-date') && !$template->has('archive-url')) {
+        $violations[] = 'archive-date-without-url: CS1 "|archive-date= requires |archive-url="';
+    }
+    if ($template->has('archive-url') && !$template->has('url')) {
+        $violations[] = 'archive-url-without-url: CS1 "|archive-url= requires |url="';
+    }
+
+    // R6: access-date requires url or archive-url.
+    if ($template->has('access-date') && !$template->has('url') && !$template->has('archive-url')) {
+        $violations[] = 'access-date-orphaned: CS1 "|access-date= requires |url="';
+    }
+
+    // R7: no bare external links in free-text parameters.
+    foreach (TEXT_PARAMS as $param) {
+        if ($template->has($param) && has_external_link($template->get($param))) {
+            $violations[] = "external-link-in-$param: CS1 \"External link in |$param=\"";
+        }
+    }
+
+    // R8: periodical parameters are ignored in templates without a periodical.
+    if (in_array($name, NON_PERIODICAL_TEMPLATES, true)) {
+        foreach (PERIODICAL_PARAMS as $param) {
+            if ($template->has($param)) {
+                $violations[] = "$param-in-$name: CS1 \"|$param= ignored\"";
+            }
+        }
+    }
+
+    // R9: cite web requires a url.
+    if ($name === 'cite web' && !$template->has('url')) {
+        $violations[] = 'cite-web-without-url: CS1 "Missing or empty |url="';
+    }
+
+    // R10: identifier templates require their identifier.
+    if ($name === 'cite arxiv' && !$template->has('arxiv') && !$template->has('eprint')) {
+        $violations[] = 'arxiv-required: CS1 "|arxiv= required"';
+    }
+    if ($name === 'cite biorxiv' && !$template->has('biorxiv')) {
+        $violations[] = 'biorxiv-required: CS1 "|biorxiv= required"';
+    }
+    if ($name === 'cite medrxiv' && !$template->has('medrxiv')) {
+        $violations[] = 'medrxiv-required: CS1 "|medrxiv= required"';
+    }
+    if ($name === 'cite ssrn' && !$template->has('ssrn')) {
+        $violations[] = 'ssrn-required: CS1 "|ssrn= required"';
+    }
+
+    // R11: cite document requires a publisher.
+    if ($name === 'cite document' && !$template->has('publisher')) {
+        $violations[] = 'document-without-publisher: CS1 "Cite document requires |publisher="';
+    }
+
+    // R12: doi-broken-date requires doi.
+    if ($template->has('doi-broken-date') && !$template->has('doi')) {
+        $violations[] = 'doi-broken-date-orphaned: CS1 "|doi-broken-date= requires |doi="';
+    }
+
+    // R13: format parameters require their url base.
+    if ($template->has('format') && !$template->has('url')) {
+        $violations[] = 'format-orphaned: CS1 "|format= requires |url="';
+    }
+    if ($template->has('chapter-format') && !$template->has('chapter-url')) {
+        $violations[] = 'chapter-format-orphaned: CS1 "|chapter-format= requires |chapter-url="';
+    }
+
+    // R14: pmc-embargo-date requires pmc.
+    if ($template->has('pmc-embargo-date') && !$template->has('pmc')) {
+        $violations[] = 'pmc-embargo-date-orphaned: CS1 "|pmc-embargo-date= requires |pmc="';
+    }
+
+    // R15: url and title-link must not both be present.
+    if ($template->has('url') && $template->has('title-link')) {
+        $violations[] = 'url-title-link-conflict: CS1 "URL-wikilink conflict"';
+    }
+
+    return $violations;
+}
+
+// ---------------------------------------------------------------------------
+// The matrix
+// ---------------------------------------------------------------------------
+
+/**
+ * Each case is [name, wikitext, expectation].
+ * expectation 'pass' means the expanded output must satisfy every CS1 rule.
+ * expectation 'gap'  means the current code is known to leave a CS1 error in
+ *                    the output; reported (and tracked) but does not fail the run.
+ *
+ * @return array<int, array{0: string, 1: string, 2: string}>
+ */
+function build_matrix(): array {
+    return [
+        // --- cite web -> cite book, work=series routing (mandatory cases) ---
+        ['Erxleben path: work=series lands in series=', '{{cite web |title=Harness paper alpha |work=Lecture Notes in Computer Science |date=2014 |isbn=978-0-19-852011-5}}', 'pass'],
+        ['Najman path: title=book title kept, work=series -> series=', '{{cite web |title=Harness book title beta |work=Lecture notes in mathematics |date=2017 |isbn=978-0-19-852011-5}}', 'pass'],
+        ['No-clobber: existing series= preserved', '{{cite web |title=Harness paper gamma |work=Lecture Notes in Computer Science |series=Special Series Name |date=2014 |isbn=978-0-19-852011-5}}', 'pass'],
+
+        // --- orphaned *-access removal (merged Tier 1 fix) ---
+        ['Orphaned url-access removed', '{{cite journal |title=X |journal=J |url-access=subscription}}', 'pass'],
+        ['Orphaned chapter-url-access removed', '{{cite journal |title=X |journal=J |chapter-url-access=free}}', 'pass'],
+        ['Orphaned contribution-url-access removed', '{{cite journal |title=X |journal=J |contribution-url-access=free}}', 'pass'],
+        ['url-access kept when base uses uppercase URL alias', '{{cite web |URL=https://example.com |url-access=subscription |title=X}}', 'pass'],
+        ['url-access kept when base uses un-hyphenated alias', '{{cite web |url=https://example.com |url-access=subscription |title=X}}', 'pass'],
+        ['chapter-url-access kept with chapter-url base', '{{cite book |title=X |chapter-url=https://example.com |chapter-url-access=free |year=2020}}', 'pass'],
+
+        // --- ISBN validation (merged Tier 1 fix) ---
+        ['Valid ISBN-10 kept', '{{cite journal |title=X |journal=J |isbn=0-306-40615-2}}', 'pass'],
+        ['Valid ISBN-13 kept', '{{cite journal |title=X |journal=J |isbn=978-0-306-40615-7}}', 'pass'],
+        ['Bad ISBN-10 auto-repaired for post-2007 book', '{{cite journal |title=X |journal=J |date=2019 |isbn=0-306-40615-1}}', 'pass'],
+
+        // --- coupled-parameter consistency (bot prevents these) ---
+        ['doi-broken-date removed without doi', '{{cite journal |title=X |journal=J |doi-broken-date=2020-01-01}}', 'pass'],
+        ['format removed without url', '{{cite journal |title=X |journal=J |format=PDF}}', 'pass'],
+        ['pmc-embargo-date removed without pmc', '{{cite journal |title=X |journal=J |pmc-embargo-date=2020-01-01}}', 'pass'],
+
+        // --- clean citations across template families ---
+        ['Clean cite journal', '{{cite journal |title=Some paper |journal=Nature |year=2020 |volume=1 |issue=2 |pages=3}}', 'pass'],
+        ['Clean cite book', '{{cite book |title=A Book |publisher=Pub |year=2020 |isbn=978-0-306-40615-7}}', 'pass'],
+        ['Clean cite web', '{{cite web |url=https://example.com |title=A page |access-date=2020-01-01}}', 'pass'],
+        ['Clean cite news with work= (periodical alias)', '{{cite news |url=https://example.com |title=Story |work=Reuters |date=2020}}', 'pass'],
+        ['Clean cite magazine', '{{cite magazine |title=X |magazine=The New Yorker |date=2020}}', 'pass'],
+        ['Clean cite encyclopedia', '{{cite encyclopedia |title=X |encyclopedia=Britannica |publisher=P |date=2020}}', 'pass'],
+        ['Clean cite web with work= (periodical alias)', '{{cite web |url=https://example.com |title=X |work=SomeWebsite}}', 'pass'],
+        ['Clean cite arxiv', '{{cite arxiv |arxiv=1234.56789 |title=X}}', 'pass'],
+        ['Clean cite biorxiv', '{{cite biorxiv |biorxiv=10.1101/2020.01.01.000001 |title=X}}', 'pass'],
+        ['Clean cite ssrn', '{{cite ssrn |ssrn=1234567 |title=X}}', 'pass'],
+
+        // --- known gaps (documented current CS1 violations, tracked) ---
+        ['GAP bad ISBN-13 check digit survives tidy', '{{cite journal |title=X |journal=J |isbn=978-0-306-40615-8}}', 'gap'],
+        ['GAP invalid ISBN prefix survives tidy', '{{cite journal |title=X |journal=J |isbn=123-4567-890128}}', 'gap'],
+        ['GAP bad ISBN-10 (pre-2007) survives tidy', '{{cite journal |title=X |journal=J |date=1999 |isbn=0-306-40615-1}}', 'gap'],
+        ['GAP url-less cite web left as-is', '{{cite web |title=X}}', 'gap'],
+        ['GAP empty title left as-is', '{{cite journal |journal=Nature}}', 'gap'],
+        ['GAP orphaned trans-chapter left as-is', '{{cite journal |title=X |journal=J |trans-chapter=Y}}', 'gap'],
+        ['GAP work= survives in cite book', '{{cite book |title=X |work=Some Series |publisher=P |year=2020}}', 'gap'],
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/** @return array{0: bool, 1: array<int, string>} */
+function run_case(string $wikitext): array {
+    try {
+        ob_start();
+        $templates = expand_citation($wikitext);
+        ob_end_clean();
+    } catch (Throwable $e) {
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+        $trace = array_slice(explode("\n", $e->getTraceAsString()), 0, 12);
+        return [false, ["expansion error: " . $e->getMessage(), ...$trace]];
+    }
+    $violations = [];
+    foreach ($templates as $template) {
+        $violations = array_merge($violations, check_citation($template));
+    }
+    return [count($templates) > 0, array_values(array_unique($violations))];
+}
+
+$list_only = in_array('--list', $argv, true);
+$matrix = build_matrix();
+
+if ($list_only) {
+    $mode = SLOW_MODE ? 'slow' : 'fast';
+    echo "CS1 harness matrix (mode: $mode)\n";
+    foreach ($matrix as $i => [$name, $wikitext, $expectation]) {
+        echo sprintf("  %2d  %-7s %s\n", $i + 1, $expectation, $name);
+    }
+    exit(0);
+}
+
+$mode = SLOW_MODE ? 'slow' : 'fast';
+echo "CS1 self-validation harness (mode: $mode)\n";
+echo "--------------------------------------------------------------\n";
+
+$passed = 0;
+$gaps = 0;
+$failed = 0;
+$failures = [];
+
+foreach ($matrix as [$name, $wikitext, $expectation]) {
+    [$produced_output, $violations] = run_case($wikitext);
+    if (!$produced_output) {
+        $failed++;
+        $failures[] = [$name, $violations];
+        echo "FAIL  $name (no citation output produced)\n";
+        continue;
+    }
+    if ($expectation === 'pass') {
+        if ($violations === []) {
+            $passed++;
+            echo "PASS  $name\n";
+        } else {
+            $failed++;
+            $failures[] = [$name, $violations];
+            echo "FAIL  $name\n";
+            foreach ($violations as $violation) {
+                echo "        - $violation\n";
+            }
+        }
+    } else {
+        $gaps++;
+        $status = $violations === [] ? 'RESOLVED' : 'KNOWN-GAP';
+        echo "GAP   $name [$status]\n";
+        foreach ($violations as $violation) {
+            echo "        - $violation\n";
+        }
+    }
+}
+
+echo "--------------------------------------------------------------\n";
+echo "Summary: $passed passed, $gaps known gaps, $failed failed\n";
+if ($failed > 0) {
+    echo "\nFailed cases:\n";
+    foreach ($failures as [$name, $violations]) {
+        echo "  - $name\n";
+        foreach ($violations as $violation) {
+            echo "      $violation\n";
+        }
+    }
+}
+
+exit($failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Tier 2 of the CS1-conformance plan: the **self-validation harness** (Phase 0, built before the fixes so every change is verified against it), the **first fix batch** (identifier-format validation on add), and the **CI job** that runs the harness as a standing regression gate. Rebased on the current master.

## 1. CS1 self-validation harness (`tools/cs1_harness.php`)

Runs 36 citation templates through the bot's real expansion machinery (fast + slow modes) and flags any expanded output that would trigger a CS1 error, using the encodable rules from the audit (`docs/CS1-error-audit.md`).

- **Checker:** 16 rule families — title non-empty, no orphaned `trans-*`/`*-access` (all alias forms), ISBN check-digit/prefix, archive-url/archive-date coupling (incl. `archiveurl`/`archivedate`/`accessdate` aliases), `access-date` requires url, no bare external links, periodical params only in periodical-capable templates, `cite web` requires url, identifier-required templates, `cite document` requires publisher, coupled `doi-broken-date`/`format`/`pmc-embargo-date`, url+title-link conflict, and identifier-format checks (arxiv/pmid/pmc/bibcode/biorxiv/medrxiv).
- **Matrix:** 25 must-pass cases (violation → exit 1) + 11 documented **known-gap** cases (current CS1 violations the bot leaves in place — bad ISBN in input, url-less cite web, empty title, malformed identifiers in input, etc.). Gaps are reported but don't fail the run; they become must-pass as later tiers land. A gap that stops violating prints `RESOLVED`, so gaps can't rot into false greens.
- **Design notes:** `SLOW_MODE` is a compile-time define, so the harness runs as two processes (`--slow`). It forces `CI=1` and pre-defines `SLOW_MODE`, with a PHPUnit-style error handler that honors `@` suppression (the PHP 8 `INSUPPRESSIBLE_LEVELS` mask) and escalates only the `report_*` severities — so `report_error()` becomes a per-case failure instead of `exit(0)`. No credentials needed; the matrix uses fabricated identifiers/titles that APIs cannot match, so pass/fail is reproducible when upstream APIs respond normally (verified arXiv returns an empty feed for the fake IDs used).

## 2. Identifier-format validation on add (Tier 2)

New validators in `src/includes/TextTools.php`: `arxiv_id_valid`, `pmid_valid`, `pmc_valid`, `rxiv_id_valid`, `bibcode_valid` — gated in `Template::add_if_new` with `report_inaction`, mirroring the merged ISBN gate (PR #5833). Malformed identifiers from sources are dropped instead of written.

- Validators are deliberately **at least as permissive as the bot's own URL-extraction regexes** (a stricter CS1-faithful version broke existing tests) — defense-in-depth, not strict CS1 fidelity, documented in comments.
- Coverage: arXiv old/new forms (+versions), PMID/PMC 1–8 digits (PMC prefix normalized), bioRxiv/medRxiv legacy 6–8 digit + dated forms (incl. the newer `10.64898` prefix), bibcode length/year/charset (CS1's full body charset).
- The cite journal→cite biorxiv/medRxiv conversion path also validates the DOI before converting.

## 3. CI job (`.github/workflows/cs1-harness.yml`)

Runs the harness fast + slow on push/PR touching `src/**` or `tools/**`, plus a weekly schedule. Mirrors `phpstan.yml` (hash-pinned actions, PHP 8.4, `composer validate`, composer cache). Added to `test-suite.yml`'s `paths-ignore`.

## Tests & intent preservation

- **TDD:** new validator tests (5) + gate tests (4), watched fail before implementing.
- **Fixtures updated deliberately** (each reviewed for intent preservation):
  - `testPMCExpansion3`: 10-digit → **`PMC99999999`** — 8-digit (CS1-valid), genuinely non-existent (verified HTTP 404; the intermediate 7-digit `PMC9999999` turned out to be a **real article**).
  - `testMedRxivComprehensiveParameterFiltering`: malformed `10.64898/test123` → non-existent dated `10.64898/2099.12.31.999999` (the "real-looking" candidate was a **real bioRxiv article** — network dependence avoided).
  - `testId2Param3/4/5`: `astr.ph/1234.5678` (a malformed hybrid) → `zzzz/1234567` (valid old-style, non-existent archive → network-independent).
  - `testAddBogusBibcode_2` → renamed `testRejectBogusBibcode`, plus new `testPaddedShortBibcodeAccepted` (guards the still-live pad-to-19 path).
- **New regression guards** for behaviors the fixture changes masked: hybrid archive+new-style arXiv rejection, malformed-`10.64898` rejection, day/month range.

## Verification

- Harness: **25 pass / 11 gaps / exit 0** in both modes, deterministic across runs.
- Targeted identifier tests all green; full-suite CI is the authoritative gate.
- phpcs clean; phpstan unchanged (one pre-existing `setup.php` issue also on master).
- Rebased cleanly onto current master (69 commits ahead of the original base).

## Notes

- The `10.5555/` DOI handling change that fixed the `testTidy12` jstor flake arrived upstream during this patch's lifetime — that known-flake note is now moot.
- Known unrelated flakes that may appear in CI: `zoteroTest::testZoteroExpansion_*`, `unpaywallApiTest`, some pubmed tests — pre-existing network dependence.
- Internal planning/audit docs are intentionally kept out of this PR.