### PR TITLE
Fix testDropUrlCode3 CI failure by using a non-free DOI prefix

### DIFF
--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -60,7 +60,7 @@ final class zoteroTest extends testBaseClass {
         $this->assertNotNull($expanded->get2('url'));
     }
 
-    public function testDropUrlCode3(): void { // url is same as one doi points to, except for http vs. https ; DOI prefix is deliberately NOT one that gets doi-access=free
+    public function testDropUrlCode3(): void { // url is same as one doi points to, except for http vs. https
         $text = '{{cite journal |pmc=XYZ| last1 = Watson | first1 = James D. | last2 = Crick | first2 = Francis H. C. | year = 1953 | title = Molecular Structure of Nucleic Acids: A Structure for Deoxyribose Nucleic Acid | url = http://www.nature.com/articles/171737a0 | doi=10.1038/171737a0 }}';
         $expanded = $this->process_citation($text);
         $this->assertNotNull($expanded->get2('url'));

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -60,8 +60,8 @@ final class zoteroTest extends testBaseClass {
         $this->assertNotNull($expanded->get2('url'));
     }
 
-    public function testDropUrlCode3(): void { // url is same as one doi points to, except for http vs. https
-        $text = "{{cite journal |pmc=XYZ| first = Luca | last = D'Auria | year = 2015 | title = Magma injection beneath the urban area of Naples | url = http://www.nature.com/articles/srep13100 | doi=10.1038/srep13100 }}";
+    public function testDropUrlCode3(): void { // url is same as one doi points to, except for http vs. https ; DOI prefix is deliberately NOT one that gets doi-access=free
+        $text = '{{cite journal |pmc=XYZ| last1 = Watson | first1 = James D. | last2 = Crick | first2 = Francis H. C. | year = 1953 | title = Molecular Structure of Nucleic Acids: A Structure for Deoxyribose Nucleic Acid | url = http://www.nature.com/articles/171737a0 | doi=10.1038/171737a0 }}';
         $expanded = $this->process_citation($text);
         $this->assertNotNull($expanded->get2('url'));
     }


### PR DESCRIPTION
Since #5758 added '10.1038/srep' to DOI_FREE_PREFIX, this test's doi=10.1038/srep13100 now receives doi-access=free.  With a healthy network (as in CI), CrossRef adds journal/volume, and drop_urls_that_match_dois() drops the publisher-canonical nature.com URL because has_good_free_copy() is true, so the assertNotNull fails.

Switch to doi=10.1038/171737a0 (Watson and Crick, 1953), which keeps the same publisher host and the same http-vs-https edge case, but whose prefix is  not in the free-DOI list.