### PR TITLE
Tier 2 Batch B: generic name/title guards + URL-format validation on add

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ php tools/cs1_harness.php --list     # print the matrix without running
 ```
 
 - **Must-pass cases** (29) must satisfy every checker rule; a violation exits 1.
-- **Known-gap cases** (11) document current CS1 violations the bot leaves in place; while still a known gap they are reported but don't fail the run. A gap that stops violating prints `RESOLVED` and **fails the run** (XPASS), forcing it to be converted to a must-pass case or confirmed intentional.
+- **Known-gap cases** (14) document current CS1 violations the bot leaves in place; while still a known gap they are reported but don't fail the run. A gap that stops violating prints `RESOLVED` and **fails the run** (XPASS), forcing it to be converted to a must-pass case or confirmed intentional.
 - When adding identifier validation or parameter handling, mirror the existing validators in `src/includes/TextTools.php` (`arxiv_id_valid`, `pmid_valid`, `pmc_valid`, `rxiv_id_valid`, `bibcode_valid`, `isbn_valid`) and the `report_inaction` gate pattern in `Template::add_if_new`.
 
 ## Important Constraints

--- a/src/includes/NameTools.php
+++ b/src/includes/NameTools.php
@@ -192,6 +192,7 @@ function author_is_human(string $author): bool {
         || mb_substr(mb_strtolower($author), 0, 4) === "the "
         || (str_ireplace(NON_HUMAN_AUTHORS, '', $author) !== $author)  // This is the use a replace to see if a substring is present trick
         || preg_match("~[A-Z]{3}~", $author)
+        || is_generic_name($author) // CS1 "Cite uses generic name" triggers
         || mb_substr(mb_strtolower($author), -4) === " inc"
         || mb_substr(mb_strtolower($author), -5) === " inc."
         || mb_substr(mb_strtolower($author), -4) === " llc"

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -2719,12 +2719,15 @@ final class Template
                 // Takes priority over more tentative matches
                 report_add("Found URL floating in template; setting url");
                 $url = $match[0];
+                if (mb_stripos($url, 'www.') === 0) {
+                    $url = 'https://' . $url; // Give scheme-less floating URLs a scheme
+                }
                 if ($this->blank('url')) {
                     $this->add_if_new('url', $url);
                 } elseif ($this->blank(['archive-url', 'archiveurl']) && mb_stripos($url, 'archive') !== false) {
                     $this->add_if_new('archive-url', $url);
                 }
-                $dat = str_replace($url, '', $dat);
+                $dat = str_replace($match[0], '', $dat);
             }
 
             $shortest = -1;

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -1610,6 +1610,10 @@ final class Template
                 if (in_array(mb_strtolower(sanitize_string($value)), BAD_TITLES, true)) {
                     return false;
                 }
+                if (is_generic_title($value)) {
+                    report_inaction("Not adding generic title: " . echoable($value));
+                    return false;
+                }
                 if (
                     $this->blank($param_name) ||
                     in_array($this->get($param_name), GOOFY_TITLES, true) ||
@@ -1892,6 +1896,10 @@ final class Template
             case 'url':
                 // look for identifiers in URL - might be better to add a PMC parameter, say
                 if ($this->get_identifiers_from_url($value)) {
+                    return false;
+                }
+                if (!url_valid($value)) {
+                    report_inaction("Not adding malformed URL: " . echoable($value));
                     return false;
                 }
                 if (!$this->blank([$param_name, ...TITLE_LINK_ALIASES])) {

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1282,10 +1282,10 @@ function url_valid(string $value): bool {
     if (preg_match('~\s|[[:cntrl:]]~u', $value) === 1) {
         return false; // CS1 rejects URLs containing whitespace or control characters
     }
-    if (preg_match('~^[a-zA-Z][a-zA-Z0-9+.\-]*:~', $value) !== 1) {
+    if (preg_match('~^[a-zA-Z][a-zA-Z0-9+.\-]*:~', $value, $scheme_match) !== 1) {
         return false; // must begin with a scheme
     }
-    $rest = mb_substr($value, mb_strpos($value, ':') + 1);
+    $rest = mb_substr($value, mb_strlen($scheme_match[0]));
     if ($rest === '' || preg_match('~^/+$~', $rest) === 1) {
         return false; // scheme must be followed by an authority/path
     }

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1232,6 +1232,65 @@ function bibcode_valid(string $value): bool {
     return true;
 }
 
+/**
+ * True when a value matches CS1's "Cite uses generic name" triggers
+ * (role labels, site names, and generic phrases from the Configuration
+ * module's generic_names reject list).
+ */
+function is_generic_name(string $value): bool {
+    $lower = mb_strtolower($value);
+    foreach (GENERIC_NAMES as $phrase) {
+        if (mb_strpos($lower, $phrase) !== false) {
+            return true;
+        }
+    }
+    foreach (GENERIC_NAME_PATTERNS as $pattern) {
+        if (preg_match($pattern, $value) === 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * True when a value matches CS1's "Cite uses generic title" triggers
+ * (bot-created placeholder titles and generic phrases from the
+ * Configuration module's generic_titles reject list).
+ */
+function is_generic_title(string $value): bool {
+    $lower = mb_strtolower($value);
+    foreach (GENERIC_TITLES as $phrase) {
+        if (mb_strpos($lower, $phrase) !== false) {
+            return true;
+        }
+    }
+    foreach (GENERIC_TITLE_PATTERNS as $pattern) {
+        if (preg_match($pattern, $value) === 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * True when a value is a structurally valid URL for CS1 (error 40,
+ * "Check |url= value"): no whitespace/control characters, a proper scheme
+ * (RFC 3986 scheme syntax), and non-empty content after the scheme.
+ */
+function url_valid(string $value): bool {
+    if (preg_match('~\s|[[:cntrl:]]~u', $value) === 1) {
+        return false; // CS1 rejects URLs containing whitespace or control characters
+    }
+    if (preg_match('~^[a-zA-Z][a-zA-Z0-9+.\-]*:~', $value) !== 1) {
+        return false; // must begin with a scheme
+    }
+    $rest = mb_substr($value, mb_strpos($value, ':') + 1);
+    if ($rest === '' || preg_match('~^/+$~', $rest) === 1) {
+        return false; // scheme must be followed by an authority/path
+    }
+    return true;
+}
+
 function changeisbn10Toisbn13(string $isbn10, int $year): string {
     $isbn10 = mb_trim($isbn10); // Remove leading and trailing spaces
     $test = str_replace(['—', '?', '–', '-', '?', ' '], '', $isbn10);

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1253,11 +1253,18 @@ function is_generic_name(string $value): bool {
 }
 
 /**
- * True when a value matches CS1's "Cite uses generic title" pattern triggers
- * (the plain-text phrases are already handled by BAD_TITLES and
- * ZOTERO_BAD_TITLES).
+ * True when a value matches CS1's "Cite uses generic title" triggers.
+ * The plain-text phrases here are those not already covered by BAD_TITLES /
+ * ZOTERO_BAD_TITLES; the patterns cover the bracket/404 forms those exact
+ * lists cannot express.
  */
 function is_generic_title(string $value): bool {
+    $lower = mb_strtolower($value);
+    foreach (GENERIC_TITLES as $phrase) {
+        if (mb_strpos($lower, $phrase) !== false) {
+            return true;
+        }
+    }
     foreach (GENERIC_TITLE_PATTERNS as $pattern) {
         if (preg_match($pattern, $value) === 1) {
             return true;

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1253,17 +1253,11 @@ function is_generic_name(string $value): bool {
 }
 
 /**
- * True when a value matches CS1's "Cite uses generic title" triggers
- * (bot-created placeholder titles and generic phrases from the
- * Configuration module's generic_titles reject list).
+ * True when a value matches CS1's "Cite uses generic title" pattern triggers
+ * (the plain-text phrases are already handled by BAD_TITLES and
+ * ZOTERO_BAD_TITLES).
  */
 function is_generic_title(string $value): bool {
-    $lower = mb_strtolower($value);
-    foreach (GENERIC_TITLES as $phrase) {
-        if (mb_strpos($lower, $phrase) !== false) {
-            return true;
-        }
-    }
     foreach (GENERIC_TITLE_PATTERNS as $pattern) {
         if (preg_match($pattern, $value) === 1) {
             return true;

--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -13331,6 +13331,100 @@ const ALWAYS_BAD_TITLES = [
     'request rejected',
 ];
 
+/**
+ * CS1 "Cite uses generic name" triggers (Module:Citation/CS1/Configuration,
+ * special_case_translation['generic_names']['reject']). Plain-text phrases,
+ * matched case-insensitively as substrings; the pattern triggers are in
+ * GENERIC_NAME_PATTERNS.
+ */
+const GENERIC_NAMES = [
+    'about us',
+    'allmusic',
+    'business',
+    'cnn',
+    'collaborator',
+    'contact us',
+    'contributor',
+    'correspondent',
+    'directory',
+    'facebook',
+    'google',
+    'home page',
+    'instagram',
+    'interviewer',
+    'linkedin',
+    'pinterest',
+    'policy',
+    'privacy',
+    'reuters',
+    'site name',
+    'statement',
+    'submitted',
+    'translator',
+    'tumblr',
+    'twitter',
+    'updated',
+    'verfasser',
+];
+
+/**
+ * CS1 generic-name pattern triggers (word-boundary role labels and
+ * organizational suffixes), mirroring the Lua patterns.
+ */
+const GENERIC_NAME_PATTERNS = [
+    '~\badvisors?\b~i',
+    '~\bauthor\b~i',
+    '~^bureau$~i',
+    '~^company$~i',
+    '~^desk$~i',
+    '~^\s*ed\.?\s*$~i',
+    '~^\s*eds\.?\s*$~i',
+    '~\bedited\b~i',
+    '~\beditor\b~i',
+    '~\beditors\b~i',
+    '~\bemail\b~i',
+    '~^group$~i',
+    '~^inc\.?$~i',
+    '~^limited$~i',
+    '~^news$~i',
+    '~news\s?[ -]?room~i',
+    '~super\.?\s?user~i',
+    '~\buser\b~i',
+];
+
+/**
+ * CS1 "Cite uses generic title" triggers (special_case_translation
+ * ['generic_titles']['reject']), plain-text phrases matched
+ * case-insensitively as substrings; the pattern triggers are in
+ * GENERIC_TITLE_PATTERNS.
+ */
+const GENERIC_TITLES = [
+    'are you a robot',
+    'bot verification',
+    'hugedomains',
+    'internet archive wayback machine',
+    'log into facebook',
+    'login • instagram',
+    'page not found',
+    'redirecting...',
+    'subscribe to read',
+    'usurped title',
+    'wayback machine',
+    'webcite query result',
+    'website is for sale',
+    "wikiwix's cache",
+];
+
+/**
+ * CS1 generic-title pattern triggers.
+ */
+const GENERIC_TITLE_PATTERNS = [
+    '~^[(\[{<]?no +title[>}\])]?$~i',
+    '~^[(\[{<]?unknown[>}\])]?$~i',
+    '~^404~',
+    '~error[ -]404~i',
+];
+
 /** These are case-insensitive strings used to reject new data */
 const BAD_TITLES = [
     ...ALWAYS_BAD_TITLES,

--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -13369,13 +13369,13 @@ const GENERIC_NAMES = [
  * organizational suffixes), mirroring the Lua patterns.
  */
 const GENERIC_NAME_PATTERNS = [
-    '~\badvisors?\b~i',
+    '~\badvisor\b~i',
     '~\bauthor\b~i',
     '~^bureau$~i',
     '~^company$~i',
     '~^desk$~i',
-    '~^\s*ed\.?\s*$~i',
-    '~^\s*eds\.?\s*$~i',
+    '~^eds?[.,;]~i',
+    '~[.,;\s]eds?\.?$~i',
     '~\bedited\b~i',
     '~\beditor\b~i',
     '~\beditors\b~i',
@@ -13390,11 +13390,24 @@ const GENERIC_NAME_PATTERNS = [
 ];
 
 /**
+ * CS1 generic-title plain-text triggers (special_case_translation
+ * ['generic_titles']['reject']) NOT already covered by BAD_TITLES /
+ * ZOTERO_BAD_TITLES, matched case-insensitively as substrings. The remaining
+ * CS1 phrases are covered by those lists and are not duplicated here.
+ */
+const GENERIC_TITLES = [
+    'hugedomains',
+    'log into facebook',
+    'redirecting...',
+    'usurped title',
+    'webcite query result',
+    "wikiwix's cache",
+];
+
+/**
  * CS1 generic-title pattern triggers (special_case_translation
- * ['generic_titles']['reject']). The plain-text phrases are already covered
- * by BAD_TITLES (exact match) and ZOTERO_BAD_TITLES (Zotero/archive paths),
- * so only the pattern triggers that the exact-match lists cannot express are
- * duplicated here.
+ * ['generic_titles']['reject']), which the exact-match BAD_TITLES list cannot
+ * express.
  */
 const GENERIC_TITLE_PATTERNS = [
     '~^[(\[{<]?no +title[>}\])]?$~i',

--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -13374,8 +13374,6 @@ const GENERIC_NAME_PATTERNS = [
     '~^bureau$~i',
     '~^company$~i',
     '~^desk$~i',
-    '~^eds?[.,;]~i',
-    '~[.,;\s]eds?\.?$~i',
     '~\bedited\b~i',
     '~\beditor\b~i',
     '~\beditors\b~i',

--- a/src/includes/constants/bad_data.php
+++ b/src/includes/constants/bad_data.php
@@ -13340,12 +13340,9 @@ const ALWAYS_BAD_TITLES = [
 const GENERIC_NAMES = [
     'about us',
     'allmusic',
-    'business',
     'cnn',
-    'collaborator',
     'contact us',
     'contributor',
-    'correspondent',
     'directory',
     'facebook',
     'google',
@@ -13393,30 +13390,11 @@ const GENERIC_NAME_PATTERNS = [
 ];
 
 /**
- * CS1 "Cite uses generic title" triggers (special_case_translation
- * ['generic_titles']['reject']), plain-text phrases matched
- * case-insensitively as substrings; the pattern triggers are in
- * GENERIC_TITLE_PATTERNS.
- */
-const GENERIC_TITLES = [
-    'are you a robot',
-    'bot verification',
-    'hugedomains',
-    'internet archive wayback machine',
-    'log into facebook',
-    'login • instagram',
-    'page not found',
-    'redirecting...',
-    'subscribe to read',
-    'usurped title',
-    'wayback machine',
-    'webcite query result',
-    'website is for sale',
-    "wikiwix's cache",
-];
-
-/**
- * CS1 generic-title pattern triggers.
+ * CS1 generic-title pattern triggers (special_case_translation
+ * ['generic_titles']['reject']). The plain-text phrases are already covered
+ * by BAD_TITLES (exact match) and ZOTERO_BAD_TITLES (Zotero/archive paths),
+ * so only the pattern triggers that the exact-match lists cannot express are
+ * duplicated here.
  */
 const GENERIC_TITLE_PATTERNS = [
     '~^[(\[{<]?no +title[>}\])]?$~i',

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1673,6 +1673,14 @@ final class TemplatePart1Test extends testBaseClass {
         $this->assertNotNull($template->get2('last1'));
     }
 
+    public function testValidateAndAddKeepsGivenNameEd(): void {
+        // The common given name "Ed" must not be rejected as a generic name.
+        $text = '{{cite journal | title = X | journal = J }}';
+        $template = $this->make_citation($text);
+        $template->validate_and_add('last1', 'Sheeran', 'Ed', '', false);
+        $this->assertNotNull($template->get2('last1'));
+    }
+
     public function testAddIfNewRejectsMalformedUrl(): void {
         $text = '{{cite journal | title = X | journal = J }}';
         $template = $this->make_citation($text);
@@ -1680,5 +1688,11 @@ final class TemplatePart1Test extends testBaseClass {
         $this->assertNull($template->get2('url'));
         $this->assertTrue($template->add_if_new('url', 'https://example.com'));
         $this->assertSame('https://example.com', $template->get2('url'));
+    }
+
+    public function testFloatingWwwUrlGetsScheme(): void {
+        $text = '{{cite journal | title = X | journal = J |  www.example.com/article }}';
+        $expanded = $this->process_citation($text);
+        $this->assertSame('https://www.example.com/article', $expanded->get2('url'));
     }
 }

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1667,7 +1667,7 @@ final class TemplatePart1Test extends testBaseClass {
     public function testValidateAndAddRejectsGenericName(): void {
         $text = '{{cite journal | title = X | journal = J }}';
         $template = $this->make_citation($text);
-        $template->validate_and_add('last1', 'CNN', '', '', false);
+        $template->validate_and_add('last1', 'google', '', '', false); // lowercase: only the generic-name gate catches it
         $this->assertNull($template->get2('last1'));
         $template->validate_and_add('last1', 'Smith', 'John', '', false);
         $this->assertNotNull($template->get2('last1'));
@@ -1679,6 +1679,13 @@ final class TemplatePart1Test extends testBaseClass {
         $template = $this->make_citation($text);
         $template->validate_and_add('last1', 'Sheeran', 'Ed', '', false);
         $this->assertNotNull($template->get2('last1'));
+    }
+
+    public function testAuthorIsHumanKeepsCombinedEdName(): void {
+        // Combined "Last, First" strings (as produced by first_author()) must
+        // not be rejected just because the first name is the common "Ed".
+        $this->assertTrue(author_is_human('Sheeran, Ed'));
+        $this->assertTrue(author_is_human('Sheeran, John'));
     }
 
     public function testAddIfNewRejectsMalformedUrl(): void {

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1656,4 +1656,29 @@ final class TemplatePart1Test extends testBaseClass {
         $this->assertTrue($template->add_if_new('pmc', 'PMC1234567'));
         $this->assertSame('1234567', $template->get2('pmc'));
     }
+
+    public function testAddIfNewRejectsGenericTitle(): void {
+        $text = '{{cite journal | title = X | journal = J }}';
+        $template = $this->make_citation($text);
+        $this->assertFalse($template->add_if_new('title', 'No Title'));
+        $this->assertSame('X', $template->get2('title'));
+    }
+
+    public function testValidateAndAddRejectsGenericName(): void {
+        $text = '{{cite journal | title = X | journal = J }}';
+        $template = $this->make_citation($text);
+        $template->validate_and_add('last1', 'CNN', '', '', false);
+        $this->assertNull($template->get2('last1'));
+        $template->validate_and_add('last1', 'Smith', 'John', '', false);
+        $this->assertNotNull($template->get2('last1'));
+    }
+
+    public function testAddIfNewRejectsMalformedUrl(): void {
+        $text = '{{cite journal | title = X | journal = J }}';
+        $template = $this->make_citation($text);
+        $this->assertFalse($template->add_if_new('url', 'not a url'));
+        $this->assertNull($template->get2('url'));
+        $this->assertTrue($template->add_if_new('url', 'https://example.com'));
+        $this->assertSame('https://example.com', $template->get2('url'));
+    }
 }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1359,8 +1359,8 @@ final class textToolsTest extends testBaseClass {
         $this->assertTrue(is_generic_name('Editor'));        // role label
         $this->assertTrue(is_generic_name('Google'));        // site name
         $this->assertTrue(is_generic_name('about us'));      // generic phrase
-        $this->assertTrue(is_generic_name('Ed.'));           // punctuated ed. is flagged
-        $this->assertFalse(is_generic_name('Ed'));           // bare given name Ed is not
+        $this->assertFalse(is_generic_name('Ed'));           // common given name
+        $this->assertFalse(is_generic_name('Ed.'));          // abbreviation of Edward
         $this->assertFalse(is_generic_name('Advisors'));     // CS1 flags only singular Advisor
         $this->assertFalse(is_generic_name('Smith'));
         $this->assertFalse(is_generic_name('John Q. Public'));

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1351,4 +1351,38 @@ final class textToolsTest extends testBaseClass {
         $this->assertFalse(bibcode_valid('9999PhRvD..89h4022A')); // year must begin with 1 or 2
         $this->assertFalse(bibcode_valid(''));
     }
+
+    public function testIsGenericName(): void {
+        $this->assertTrue(is_generic_name('CNN'));           // site name
+        $this->assertTrue(is_generic_name('Reuters'));       // news agency
+        $this->assertTrue(is_generic_name('Author'));        // role label
+        $this->assertTrue(is_generic_name('Editor'));        // role label
+        $this->assertTrue(is_generic_name('Google'));        // site name
+        $this->assertTrue(is_generic_name('about us'));      // generic phrase
+        $this->assertFalse(is_generic_name('Smith'));
+        $this->assertFalse(is_generic_name('John Q. Public'));
+        $this->assertFalse(is_generic_name(''));
+    }
+
+    public function testIsGenericTitle(): void {
+        $this->assertTrue(is_generic_title('No Title'));
+        $this->assertTrue(is_generic_title('Unknown'));
+        $this->assertTrue(is_generic_title('404'));
+        $this->assertTrue(is_generic_title('Error 404'));
+        $this->assertTrue(is_generic_title('Wayback Machine'));
+        $this->assertTrue(is_generic_title('Page Not Found'));
+        $this->assertFalse(is_generic_title('A real research paper'));
+        $this->assertFalse(is_generic_title(''));
+    }
+
+    public function testUrlValid(): void {
+        $this->assertTrue(url_valid('https://example.com'));
+        $this->assertTrue(url_valid('http://example.com/path?q=1#frag'));
+        $this->assertTrue(url_valid('ftp://example.com'));
+        $this->assertFalse(url_valid('not a url'));   // whitespace
+        $this->assertFalse(url_valid('example.com')); // no scheme
+        $this->assertFalse(url_valid('http:'));       // nothing after scheme
+        $this->assertFalse(url_valid('http://'));     // only slashes
+        $this->assertFalse(url_valid(''));
+    }
 }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1365,12 +1365,14 @@ final class textToolsTest extends testBaseClass {
     }
 
     public function testIsGenericTitle(): void {
+        // Only the pattern triggers live in is_generic_title; the plain-text
+        // phrases (wayback machine, page not found, …) are handled by
+        // BAD_TITLES / ZOTERO_BAD_TITLES.
         $this->assertTrue(is_generic_title('No Title'));
-        $this->assertTrue(is_generic_title('Unknown'));
+        $this->assertTrue(is_generic_title('[unknown]'));
         $this->assertTrue(is_generic_title('404'));
         $this->assertTrue(is_generic_title('Error 404'));
-        $this->assertTrue(is_generic_title('Wayback Machine'));
-        $this->assertTrue(is_generic_title('Page Not Found'));
+        $this->assertFalse(is_generic_title('Wayback Machine'));   // plain phrase -> BAD_TITLES, not here
         $this->assertFalse(is_generic_title('A real research paper'));
         $this->assertFalse(is_generic_title(''));
     }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1359,20 +1359,26 @@ final class textToolsTest extends testBaseClass {
         $this->assertTrue(is_generic_name('Editor'));        // role label
         $this->assertTrue(is_generic_name('Google'));        // site name
         $this->assertTrue(is_generic_name('about us'));      // generic phrase
+        $this->assertTrue(is_generic_name('Ed.'));           // punctuated ed. is flagged
+        $this->assertFalse(is_generic_name('Ed'));           // bare given name Ed is not
+        $this->assertFalse(is_generic_name('Advisors'));     // CS1 flags only singular Advisor
         $this->assertFalse(is_generic_name('Smith'));
         $this->assertFalse(is_generic_name('John Q. Public'));
         $this->assertFalse(is_generic_name(''));
     }
 
     public function testIsGenericTitle(): void {
-        // Only the pattern triggers live in is_generic_title; the plain-text
-        // phrases (wayback machine, page not found, …) are handled by
-        // BAD_TITLES / ZOTERO_BAD_TITLES.
+        // Pattern triggers.
         $this->assertTrue(is_generic_title('No Title'));
         $this->assertTrue(is_generic_title('[unknown]'));
         $this->assertTrue(is_generic_title('404'));
         $this->assertTrue(is_generic_title('Error 404'));
-        $this->assertFalse(is_generic_title('Wayback Machine'));   // plain phrase -> BAD_TITLES, not here
+        // Plain-text phrases not covered by BAD_TITLES / ZOTERO_BAD_TITLES.
+        $this->assertTrue(is_generic_title('HugeDomains'));
+        $this->assertTrue(is_generic_title('Redirecting...'));
+        $this->assertTrue(is_generic_title('usurped title'));
+        // Plain phrases covered by the existing lists are not duplicated here.
+        $this->assertFalse(is_generic_title('Wayback Machine'));
         $this->assertFalse(is_generic_title('A real research paper'));
         $this->assertFalse(is_generic_title(''));
     }

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -319,6 +319,18 @@ function check_citation(Template $template): array {
         }
     }
 
+    // R17: generic names trigger CS1 "Cite uses generic name".
+    foreach (['last', 'first', 'author', 'last1', 'first1', 'author1', 'editor', 'editor1', 'editor-last', 'editor1-last', 'editor-first', 'editor1-first'] as $param) {
+        if ($template->has($param) && is_generic_name($template->get($param))) {
+            $violations[] = "generic-name-in-$param: CS1 \"Cite uses generic name\"";
+        }
+    }
+
+    // R18: generic titles trigger CS1 "Cite uses generic title".
+    if ($template->has('title') && is_generic_title($template->get('title'))) {
+        $violations[] = 'generic-title: CS1 "Cite uses generic title"';
+    }
+
     return $violations;
 }
 
@@ -387,6 +399,8 @@ function build_matrix(): array {
         ['GAP malformed pmc in input survives tidy', '{{cite journal |title=X |journal=J |pmc=notnumeric}}', 'gap'],
         ['GAP malformed arxiv/eprint in input survives tidy', '{{cite journal |title=X |journal=J |eprint=XYZ}}', 'gap'],
         ['GAP malformed bibcode in input survives tidy', '{{cite journal |title=X |journal=J |bibcode=Z}}', 'gap'],
+        ['GAP generic title in input survives tidy', '{{cite journal |title=No Title |journal=J}}', 'gap'],
+        ['GAP generic name in input survives tidy', '{{cite journal |title=X |journal=J |last1=CNN}}', 'gap'],
     ];
 }
 

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -331,6 +331,11 @@ function check_citation(Template $template): array {
         $violations[] = 'generic-title: CS1 "Cite uses generic title"';
     }
 
+    // R19: url must be structurally valid (CS1 "Check |url= value").
+    if ($template->has('url') && !url_valid($template->get('url'))) {
+        $violations[] = 'url-malformed: CS1 "Check |url= value"';
+    }
+
     return $violations;
 }
 
@@ -401,6 +406,7 @@ function build_matrix(): array {
         ['GAP malformed bibcode in input survives tidy', '{{cite journal |title=X |journal=J |bibcode=Z}}', 'gap'],
         ['GAP generic title in input survives tidy', '{{cite journal |title=No Title |journal=J}}', 'gap'],
         ['GAP generic name in input survives tidy', '{{cite journal |title=X |journal=J |last1=CNN}}', 'gap'],
+        ['GAP malformed url in input survives tidy', '{{cite web |url=example.com |title=X}}', 'gap'],
     ];
 }
 


### PR DESCRIPTION
Summary
Tier 2 Batch B of the CS1-conformance plan: generic name/title guards (#6) and URL-format validation on add (#12) — non-breaking guards that stop the bot from writing values that would trigger Help:CS1 errors, without removing any existing functionality.

1. Generic name/title guards (errors 46/47)
New constants in bad_data.php translated from Module:Citation/CS1/Configuration (generic_names/generic_titles reject lists): GENERIC_NAMES (site-name phrases), GENERIC_NAME_PATTERNS (role labels like Author/Editor/Advisor/User + organizational suffixes), GENERIC_TITLES + GENERIC_TITLE_PATTERNS (the generic-title triggers BAD_TITLES/ZOTERO_BAD_TITLES can't cover). Helpers is_generic_name()/is_generic_title() gated in author_is_human() and add_if_new('title'), with report_inaction.

De-duplicated against existing bad_data.php content (exact + substring overlap verified).
CS1's ed/eds triggers intentionally dropped — they false-reject the common given name "Ed" (CS1 never flags it); a data-loss risk outweighing a rare role-marker case.
Guards-only: pre-existing generic names/titles in input are untouched (documented as harness gap cases).
2. URL-format validation on add (error 40)
url_valid() mirrors CS1's check_url (no whitespace/control chars, RFC-3986 scheme, non-empty after scheme), gated in add_if_new('url'). Scheme-less www. floating URLs are normalized to https://… before adding.

3. Harness
New checker rules R17 (generic names), R18 (generic titles), R19 (url format) + 3 gap cases. Matrix: 29 must-pass / 14 gaps, exit 0 in both modes.

Tests
8 new/updated tests: is_generic_name/is_generic_title/url_valid units + gate tests + regression guards (given name "Ed" kept, combined "Sheeran, Ed" kept, www. floating URL scheme).

Verification
Harness 29/14/0 (fast + slow); 8 tests green; phpcs clean; phpstan unchanged (pre-existing setup.php error on master). The 3 known CI flakes (testBadAuthor2, testGoogleBadAuthor, testRedirectFixing) fail identically on clean master — pre-existing, unrelated.

Notes
Intentional: single-word org/site author names (CNN, Reuters, Google, "Bureau") are now rejected on add — CS1 flags them.
Deferred (in plan): protocol-relative // in url_valid; gate-ordering report_inaction noise; \b boundary fidelity; url_valid for chapter-url/archive-url.