### PR TITLE
fix: update codeql-action hash pins to v4.37.9 (cdf488f)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -49,7 +49,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+      uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -63,4 +63,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Upload Trivy image scan results to Security tab
       if: always()
-      uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         sarif_file: 'trivy-image-results.sarif'
         wait-for-processing: false

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           retention-days: 5
 
       - name: Upload results to code scanning
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -44,7 +44,7 @@ jobs:
           ls -lash ${{ env.SARIF_FILE }}
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: ${{ env.SARIF_FILE }}
           wait-for-processing: false


### PR DESCRIPTION
Fixes zizmor alerts 
All five alerts report mismatched version comment for `github/codeql-action` hash pin:

- pinned hash `db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28` resolves to `v4.37.8`
- version comment `# v4` resolves via `refs/tags/v4` to `cdf488f595d80d6e07e03d4674febd5ab45fa938` (`v4.37.9`)

### Changes
- `.github/workflows/codeql-analysis.yml` (3 occurrences: init, autobuild, analyze)
- `.github/workflows/trivy-analysis.yml` (upload-sarif)
- `.github/workflows/docker-build.yml` (upload-sarif)
- `.github/workflows/openssf-scorecard.yml` (upload-sarif, previously `v4.37.8` - bumped for consistency)

Updated pinned hash from `db488dd` to `cdf488f595d80d6e07e03d4674febd5ab45fa938` with comment `# v4.37.9`.

Verified via:
```
git ls-remote https://github.com/github/codeql-action.git | grep -E "v4|cdf488|db488"
cdf488f595d80d6e07e03d4674febd5ab45fa938  refs/tags/v4^{}
cdf488f595d80d6e07e03d4674febd5ab45fa938  refs/tags/v4.37.9^{}
db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  refs/tags/v4.37.8^{}
```

Hash `cdf488f` now matches both `v4` and `v4.37.9`, satisfying zizmor's hash-pin/comment check.
