### PR TITLE
Add support for edit=template in category and process_page

### DIFF
--- a/src/category.php
+++ b/src/category.php
@@ -127,7 +127,28 @@ if ($total > intval($effective_max / 4)) {
 if (defined('MAX_PAGES_OVERRIDE') && $total > $default_web_limit) {
     report_info('Whitelisted category has ' . (string) $total . ' pages; proceeding with extended limit.');
 }
-$edit_summary_end = "| Suggested by " . $api->get_the_user() . " | [[Category:{$category}]] | #UCB_Category ";
+$edit_summary_end = "| Suggested by " . $api->get_the_user() . " | [[Category:{$category}]] ";
+if (!empty($_REQUEST["edit"]) && is_string($_REQUEST["edit"])) {
+    if ($_REQUEST["edit"] === 'automated_tools') {
+        $edit_summary_end .= "| #UCB_automated_tools ";
+    } elseif ($_REQUEST["edit"] === 'toolbar') {
+        $edit_summary_end .= "| #UCB_toolbar ";
+    } elseif ($_REQUEST["edit"] === 'template') {
+        $edit_summary_end .= "| #UCB_template ";
+    } elseif ($_REQUEST["edit"] === 'webform') {
+        $edit_summary_end .= "| #UCB_webform ";
+    } elseif ($_REQUEST["edit"] === 'Headbomb') {
+        $edit_summary_end .= "| #UCB_Headbomb ";
+    } elseif ($_REQUEST["edit"] === 'Smith609') {
+        $edit_summary_end .= "| #UCB_Smith609 ";
+    } elseif ($_REQUEST["edit"] === 'arXiv') {
+        $edit_summary_end .= "| #UCB_arXiv ";
+    } else {
+        $edit_summary_end .= "| #UCB_Other ";
+    }
+} else {
+    $edit_summary_end .= "| #UCB_Category ";
+}
 if (defined('MAX_PAGES_OVERRIDE')) {
     if ($dev_user_run) {
         $edit_summary_end .= "| Developer - max category limit override enabled ";

--- a/src/includes/request_security.php
+++ b/src/includes/request_security.php
@@ -64,7 +64,7 @@ function category_confirmation_fields(string $category, array $query): array {
         'cat' => $category,
         'extended_limit' => '1',
     ];
-    foreach (['wiki_base', 'pcre'] as $name) {
+    foreach (['edit', 'wiki_base', 'pcre'] as $name) {
         if (isset($query[$name]) && is_string($query[$name])) {
             $fields[$name] = $query[$name];
         }

--- a/src/process_page.php
+++ b/src/process_page.php
@@ -119,6 +119,8 @@ if (!empty($_REQUEST["edit"]) && is_string($_REQUEST["edit"])) {
         $edit_summary_end .= "| #UCB_automated_tools ";
     } elseif ($_REQUEST["edit"] === 'toolbar') {
         $edit_summary_end .= "| #UCB_toolbar ";
+    } elseif ($_REQUEST["edit"] === 'template') {
+        $edit_summary_end .= "| #UCB_template ";
     } elseif ($_REQUEST["edit"] === 'webform') {
         $edit_summary_end .= "| #UCB_webform ";
     } elseif ($_REQUEST["edit"] === 'Headbomb') {


### PR DESCRIPTION
Category runs now use a single hashtag:
- no edit param -> | #UCB_Category (webform)
- edit=toolbar -> | #UCB_toolbar
- edit=template -> | #UCB_template

Template:Citation_bot_autoclean can use category.php?edit=template instead of toolbar while toolbar remains available elsewhere. Preserves edit through category_confirmation_fields and handles template for process_page as well.