### PR TITLE
Fix fatal undefined constant on logged-in kill_big_job.php requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,11 +391,12 @@ Check `src/includes/setup.php` for debug flags and logging configuration.
 6. Update documentation
 7. **Always check whether `.github/labeler.yml` needs a new entry** when adding or renaming files (especially new tooling, workflows, or entrypoints); the automatic PR labeling depends on it
 8. Submit pull request with clear description
-9. **Common Pitfalls:**
+ 9. **Common Pitfalls:**
 
    - Forgetting multi-byte string functions
    - Not handling API failures gracefully
    - Violating the verbose code style with compact one-liners
+   - Entry points that do not load `setup.php` (e.g. `src/kill_big_job.php`) must define the `CI` and `HTML_OUTPUT` constants themselves: output helpers in `src/includes/user_messages.php` read `HTML_OUTPUT` unguarded, and an undefined constant fatals mid-page, truncating the output to a blank page. Note that tests extending `testBaseClass.php` load `setup.php` and will mask this failure — use the standalone separate-process pattern in `tests/phpunit/killBigJobPageTest.php` when testing such pages.
 
 ## Bug Reporting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,7 +391,7 @@ Check `src/includes/setup.php` for debug flags and logging configuration.
 6. Update documentation
 7. **Always check whether `.github/labeler.yml` needs a new entry** when adding or renaming files (especially new tooling, workflows, or entrypoints); the automatic PR labeling depends on it
 8. Submit pull request with clear description
- 9. **Common Pitfalls:**
+9. **Common Pitfalls:**
 
    - Forgetting multi-byte string functions
    - Not handling API failures gracefully

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,7 @@ Includes (under `src/includes/`):
 ## Style and structure notes
 
 - Constants and definitions should be provided in `constants.php`.
+- Entry points that do not load `src/includes/setup.php` (currently `src/kill_big_job.php`) must define the `CI` and `HTML_OUTPUT` constants themselves, as the output helpers in `src/includes/user_messages.php` read them unguarded. `setup.php` defines these based on the run context (CLI vs web); see `src/kill_big_job.php` for a web-only example.
 - A good balance between splitting functionality into single files and avoiding too many files should be maintained.
 - The code is generally NOT written densely.
 - Beware assignments in conditionals, one-line `if`/`foreach`/`else` statements, and action taking place through method calls that take place in assignments or equality checks.

--- a/src/kill_big_job.php
+++ b/src/kill_big_job.php
@@ -15,6 +15,15 @@ session_start(public_session_start_options(true));
 require_once __DIR__ . '/includes/big_jobs.php';
 require_once __DIR__ . '/includes/request_security.php';
 
+// setup.php is deliberately not loaded on this lightweight page, so the two
+// output-mode constants it defines must be provided here, matching a web request.
+if (!defined('CI')) {
+    define('CI', (bool) getenv('CI'));
+}
+if (!defined('HTML_OUTPUT')) {
+    define('HTML_OUTPUT', true);
+}
+
 ob_implicit_flush(true);
 
 if (!isset($_SESSION['citation_bot_user_id'])) {

--- a/tests/phpunit/killBigJobPageTest.php
+++ b/tests/phpunit/killBigJobPageTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+/**
+ * Exercises the real kill_big_job.php entry point without loading setup.php,
+ * reproducing the cold web-request environment where HTML_OUTPUT and CI are
+ * never defined. Deliberately does NOT extend testBaseClass, which would
+ * define those constants and hide the failure this guards against.
+ */
+final class killBigJobPageTest extends PHPUnit\Framework\TestCase {
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLoggedInGetRequestRendersConfirmationForm(): void {
+        putenv('PUBLIC_BASE_URL=https://citations.toolforge.org');
+        putenv('ALLOWED_HOSTS=citations.toolforge.org');
+        putenv('ALLOWED_ORIGINS=https://citations.toolforge.org');
+        $_SERVER['HTTP_HOST'] = 'citations.toolforge.org';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        unset($_SERVER['HTTP_ORIGIN'], $_GET, $_POST, $_REQUEST);
+
+        session_id('kill-big-job-page-test-session');
+        session_start();
+        $_SESSION['citation_bot_user_id'] = 12345;
+        session_write_close();
+
+        try {
+            ob_start();
+            require __DIR__ . '/../../src/kill_big_job.php';
+            $body = (string) ob_get_clean();
+        } catch (Throwable $e) {
+            ob_end_clean();
+            $this->fail('kill_big_job.php fatals on a logged-in GET request: ' . $e->getMessage());
+        }
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+
+        $this->assertStringContainsString('<title>Killing the big job</title>', $body);
+        $this->assertStringContainsString('Stop large job', $body);
+        $this->assertStringContainsString('method="post"', $body);
+        $this->assertStringContainsString('name="csrf_token"', $body);
+        $this->assertStringContainsString('</body></html>', $body);
+        $this->assertStringNotContainsString('You are not logged in', $body);
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testConfirmedPostReportsMissingJobWhenNoLockFileExists(): void {
+        putenv('PUBLIC_BASE_URL=https://citations.toolforge.org');
+        putenv('ALLOWED_HOSTS=citations.toolforge.org');
+        putenv('ALLOWED_ORIGINS=https://citations.toolforge.org');
+        $_SERVER['HTTP_HOST'] = 'citations.toolforge.org';
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        unset($_SERVER['HTTP_ORIGIN'], $_GET, $_REQUEST);
+        $_POST = ['csrf_token' => 'kill-big-job-page-test-token'];
+
+        session_id('kill-big-job-page-test-session');
+        session_start();
+        $_SESSION['citation_bot_user_id'] = 12345;
+        $_SESSION['csrf_token'] = 'kill-big-job-page-test-token';
+        session_write_close();
+
+        ob_start();
+        require __DIR__ . '/../../src/kill_big_job.php';
+        $body = (string) ob_get_clean();
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+
+        $this->assertStringContainsString('<title>Killing the big job</title>', $body);
+        $this->assertStringContainsString('No existing large job found', $body);
+        $this->assertStringContainsString('</body></html>', $body);
+    }
+}


### PR DESCRIPTION
kill_big_job.php deliberately does not load setup.php, so HTML_OUTPUT and CI were never defined. The logged-in GET branch therefore fatalled inside post_confirmation_form()/echoable() with 'Undefined constant HTML_OUTPUT', truncating the page right after <pre> and appearing as a blank page. Define both constants for the web-request context, matching setup.php semantics.

Add killBigJobPageTest which runs the real entry point in a separate process without setup.php, reproducing the cold web environment; testBaseClass would mask the failure by defining the constants.