### PR TITLE
Map website= onto title/chapter when converting cite web to cite book

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -1535,6 +1535,12 @@ final class Template
                 if ($this->has('contribution') || $this->has('contribution-url')) {
                     return false;
                 }
+                // Adding a chapter immediately triggers tidy_parameter('chapter').
+                // Do not create a book-only field on an ambiguous cite web when
+                // that follow-up conversion would be unsafe.
+                if ($this->wikiname() === 'cite web' && !$this->can_auto_convert_web_to_cite_book()) {
+                    return false;
+                }
                 if ($this->wikiname() === 'citation') {
                     foreach (WORK_ALIASES as $work_alias) {
                         if ($this->has($work_alias) && !$this->blank($work_alias)) {
@@ -3443,6 +3449,42 @@ final class Template
         }
     }
 
+    /**
+     * Low-confidence metadata such as an ISBN or a newly found chapter should
+     * only auto-promote cite web when the existing parameters can be represented
+     * by cite book without guessing or dropping data.
+     */
+    public function can_auto_convert_web_to_cite_book(): bool {
+        if ($this->wikiname() !== 'cite web') {
+            return true;
+        }
+
+        // cite book does not support issue=/number=.
+        if (!$this->blank(ISSUE_ALIASES)) {
+            return false;
+        }
+
+        // Most work aliases identify a periodical/site.  Keep the existing
+        // ISBN conversion behavior only for work= values already recognized
+        // by Citation Bot as book-series metadata.
+        foreach (WORK_ALIASES as $work_alias) {
+            if ($work_alias !== 'work' && !$this->blank($work_alias)) {
+                return false;
+            }
+        }
+        if ($this->has('work')) {
+            if (
+                $this->blank('title') ||
+                !$this->is_book_series('work') ||
+                !$this->blank(['trans-work', 'script-work'])
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public function change_name_to(string $new_name, bool $rename_cite_book = true, bool $rename_anything = false): void {
         if (mb_strpos($this->get('doi'), '10.1093') !== false && $this->wikiname() !== 'cite web') {
             return;
@@ -3473,6 +3515,19 @@ final class Template
         }
         $new_name = mb_strtolower(mb_trim($new_name)); // Match wikiname() output and cite book below
         if ($new_name === $this->wikiname()) {
+            return;
+        }
+        // website= identifies the delivery site in cite web.  cite book has no
+        // website= parameter, so preserve it as via=.  If a different via=
+        // already exists, declining the conversion is safer than losing either.
+        if (
+            $new_name === 'cite book' &&
+            $this->has('website') &&
+            $this->has('via') &&
+            !str_equivalent($this->get('website'), $this->get('via')) &&
+            !($this->has('work') && str_equivalent($this->get('website'), $this->get('work'))) &&
+            !($this->has('title') && str_equivalent($this->get('website'), $this->get('title')))
+        ) {
             return;
         }
         if ($this->has('conference') && $this->wikiname() === 'cite conference') {
@@ -3567,6 +3622,21 @@ final class Template
             } elseif (!$this->blank(['chapter-url', 'chapterurl']) && str_i_same($this->get('chapter-url'), $this->get('url'))) {
                 $this->forget('url');
             } // otherwise they are different urls
+
+            // website= is a delivery-site field in cite web, not evidence for a
+            // containing book title.  Preserve that meaning in cite book as via=.
+            // A conflicting via= was rejected before changing the template name.
+            if ($this->has('website')) {
+                if (
+                    ($this->has('work') && str_equivalent($this->get('website'), $this->get('work'))) ||
+                    ($this->has('title') && str_equivalent($this->get('website'), $this->get('title'))) ||
+                    $this->has('via')
+                ) {
+                    $this->forget('website');
+                } else {
+                    $this->rename('website', 'via');
+                }
+            }
 
             // If there is a work=/title= pair while converting to cite book, map to the
             // CS1 chapter=/title=/series= set. A work that names a book series must
@@ -4018,7 +4088,11 @@ final class Template
                             return;
                         }
                     }
-                    if ($this->has('chapter') && $this->blank(['journal', 'bibcode', 'jstor', 'pmid'])) {
+                    if (
+                        $this->has('chapter') &&
+                        $this->blank(['journal', 'bibcode', 'jstor', 'pmid']) &&
+                        $this->can_auto_convert_web_to_cite_book()
+                    ) {
                         $this->change_name_to('cite book');
                     }
                     return;
@@ -4507,7 +4581,10 @@ final class Template
                     }
                     $this->set('isbn', safe_preg_replace('~\s?-\s?~', '-', $this->get('isbn'))); // a White space next to a dash
                     $this->set('isbn', $this->isbn10Toisbn13($this->get('isbn'), false));
-                    if ($this->blank('journal') || $this->has('chapter') || $this->wikiname() === 'cite web') {
+                    if (
+                        ($this->blank('journal') || $this->has('chapter') || $this->wikiname() === 'cite web') &&
+                        $this->can_auto_convert_web_to_cite_book()
+                    ) {
                         $this->change_name_to('cite book');
                     }
                     $this->forget('asin');
@@ -6406,7 +6483,8 @@ final class Template
             }
             if (
                 ($this->wikiname() === 'cite document' || $this->wikiname() === 'cite journal' || $this->wikiname() === 'cite web') &&
-                (mb_strpos($this->get('isbn'), '978-0-19') === 0 || mb_strpos($this->get('isbn'), '978019') === 0 || mb_strpos($this->get('isbn'), '978-019') === 0)
+                (mb_strpos($this->get('isbn'), '978-0-19') === 0 || mb_strpos($this->get('isbn'), '978019') === 0 || mb_strpos($this->get('isbn'), '978-019') === 0) &&
+                $this->can_auto_convert_web_to_cite_book()
             ) {
                 $this->change_name_to('cite book', true, true);
             }
@@ -6497,6 +6575,20 @@ final class Template
 
             if ($this->wikiname() === 'cite web') {
                 if (!$this->blank_other_than_comments('title') && !$this->blank_other_than_comments('chapter')) {
+                    // website= identifies the delivery site here, and cite book has no
+                    // website= parameter, so mirror the change_name_to() handling.
+                    // Staying cite web is not an option: chapter= is itself unsupported.
+                    if ($this->has('website')) {
+                        if (
+                            ($this->has('work') && str_equivalent($this->get('website'), $this->get('work'))) ||
+                            ($this->has('title') && str_equivalent($this->get('website'), $this->get('title'))) ||
+                            $this->has('via')
+                        ) {
+                            $this->forget('website');
+                        } else {
+                            $this->rename('website', 'via');
+                        }
+                    }
                     if ($this->name === 'cite web') {
                         // Need special code to keep caps the same
                         $this->name = 'cite book';

--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -1878,11 +1878,17 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
 
         } elseif (preg_match("~^https?://(?:www\.|)amazon(?P<domain>\.[\w\.]{1,7})/.*dp/(?P<id>\d+X?)~i", $url, $match)) {
 
-            if ($template->wikiname() === 'cite web') {
+            $was_cite_web = $template->wikiname() === 'cite web';
+            if ($was_cite_web) {
                 $template->change_name_to('cite book');
             }
             if ($match['domain'] === ".com") {
-                if (!$url_sent) {
+                if (!$url_sent && (!$was_cite_web || $template->wikiname() === 'cite book')) {
+                    // Drop the URL when it is redundant (template was already a
+                    // book citation, or the conversion succeeded). If the
+                    // conversion was declined (see Template::change_name_to()),
+                    // the template must remain a valid cite web, which
+                    // requires a url=.
                     $template->forget($url_type);
                     if (mb_stripos($template->get('publisher'), 'amazon') !== false) {
                         $template->forget('publisher');
@@ -1903,7 +1909,7 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
                         return false;  // do not continue and delete it, because of TODO above
                     }
                 }
-                if (!$url_sent) {
+                if (!$url_sent && (!$was_cite_web || $template->wikiname() === 'cite book')) {
                     $template->forget($url_type); // will forget accessdate too
                     if (mb_stripos($template->get('publisher'), 'amazon') !== false) {
                         $template->forget('publisher');
@@ -2106,13 +2112,19 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
             return false;
         } elseif (preg_match("~^https?://lccn\.loc\.gov/(\d{4,})$~i", $url, $match) &&
                             (mb_stripos($template->parsed_text(), 'library') === false)) { // Sometimes it is web cite to Library of Congress
-            if ($template->wikiname() === 'cite web') {
+            $was_cite_web = $template->wikiname() === 'cite web';
+            if ($was_cite_web) {
                 $template->change_name_to('cite book');  // Better template choice
             }
             if ($template->blank('lccn')) {
                 report_modification("Converting URL to LCCN parameter");
             }
-            if (!$url_sent) {
+            if (!$url_sent && (!$was_cite_web || $template->wikiname() === 'cite book')) {
+                // Drop the URL when it is redundant (template was already a
+                // book citation, or the conversion succeeded). If the
+                // conversion was declined (see Template::change_name_to()),
+                // the template must remain a valid cite web, which requires
+                // a url=.
                 $template->forget($url_type);
             }
             return $template->add_if_new('lccn', $match[1]);
@@ -2120,10 +2132,16 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
             if ($template->blank('ol')) {
                 report_modification("Converting URL to OL parameter");
             }
-            if ($template->wikiname() === 'cite web') {
+            $was_cite_web = $template->wikiname() === 'cite web';
+            if ($was_cite_web) {
                 $template->change_name_to('cite book');  // Better template choice
             }
-            if (!$url_sent) {
+            if (!$url_sent && (!$was_cite_web || $template->wikiname() === 'cite book')) {
+                // Drop the URL when it is redundant (template was already a
+                // book citation, or the conversion succeeded). If the
+                // conversion was declined (see Template::change_name_to()),
+                // the template must remain a valid cite web, which requires
+                // a url=.
                 $template->forget($url_type);
             }
             return $template->add_if_new('ol', $match[1]);

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -955,6 +955,38 @@ final class Zotero {
         if (isset($result->title) && $result->title === 'Cultural Advice' && mb_strpos($url, 'edu.au') !== false) {
             unset($result->title); // A warning, not a title
         }
+
+        // website= usually names the delivery site.  The OpenEdition report is
+        // different: Zotero independently identifies website= as bookTitle and
+        // the existing title as the bookSection title.  Only that corroborated
+        // shape is strong enough to reinterpret the existing fields.
+        if (
+            $template->wikiname() === 'cite web' &&
+            $template->has('website') &&
+            $template->has('title') &&
+            $template->blank(CHAPTER_ALIASES) &&
+            isset($result->bookTitle, $result->title, $result->itemType) &&
+            $result->itemType === 'bookSection' &&
+            // Do not reinterpret fields when this looks like a review of the
+            // book rather than a chapter of it (same guard as the itemType
+            // switch below) - see the "Book review confusion" reports.
+            mb_stripos($url . (string) $result->title . (string) $result->bookTitle, 'review') === false &&
+            str_equivalent($template->get('website'), (string) $result->bookTitle) &&
+            titles_are_similar($template->get('title'), (string) $result->title) &&
+            $template->blank(['journal', 'newspaper', 'magazine', 'periodical', 'encyclopedia', 'encyclopaedia']) &&
+            $template->blank(ISSUE_ALIASES) &&
+            $template->blank(['trans-title', 'script-title', 'trans-website', 'script-website', 'trans-work', 'script-work']) &&
+            $template->blank(TITLE_LINK_ALIASES) &&
+            ($template->blank('work') || str_equivalent($template->get('work'), $template->get('website')))
+        ) {
+            if ($template->has('work')) {
+                $template->forget('work');
+            }
+            $template->rename('title', 'chapter');
+            $template->rename('website', 'title');
+            $template->change_name_to('cite book');
+        }
+
         if ($template->has('title')) {
             if (isset($result->title) && titles_are_similar($template->get('title'), (string) $result->title)) {
                 unset($result->title);
@@ -1129,7 +1161,7 @@ final class Zotero {
                     // Too much bad data to risk switching journal to book or vice versa.
                     // also reject 'review'
                     if ($template->wikiname() === 'cite web' &&
-                            $template->blank('website') && // Leads to error
+                            $template->can_auto_convert_web_to_cite_book() &&
                             mb_stripos($url . @$result->title . @$result->bookTitle . @$result->publicationTitle, 'review') === false &&
                             mb_stripos($url, 'archive.org') === false && !preg_match('~^https?://[^/]*journal~', $url) &&
                             mb_stripos($url, 'booklistonline') === false &&

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -2843,4 +2843,126 @@ final class TemplatePart2Test extends testBaseClass {
         $expanded->change_name_to('cite book');
         $this->assertSame('Special Series Name', $expanded->get2('series'));
     }
+
+    public function testWebsiteBecomesViaOnForcedBookConversion(): void {
+        $text = '{{cite web |title=Some book |website=Google Books}}';
+        $expanded = $this->make_citation($text);
+        $expanded->change_name_to('cite book');
+        $this->assertSame('cite book', $expanded->wikiname());
+        $this->assertNull($expanded->get2('website'));
+        $this->assertSame('Google Books', $expanded->get2('via'));
+        $this->assertSame('Some book', $expanded->get2('title'));
+    }
+
+    public function testWebsiteViaConflictBlocksForcedBookConversion(): void {
+        $text = '{{cite web |title=Some book |website=Google Books |via=HathiTrust}}';
+        $expanded = $this->make_citation($text);
+        $expanded->change_name_to('cite book');
+        $this->assertSame('cite web', $expanded->wikiname());
+        $this->assertSame('Google Books', $expanded->get2('website'));
+        $this->assertSame('HathiTrust', $expanded->get2('via'));
+    }
+
+    public function testEquivalentWebsiteAndWorkDroppedOnForcedBookConversion(): void {
+        $text = '{{cite web |title=Some chapter |work=Some book |website=Some book |pages=1–2}}';
+        $expanded = $this->make_citation($text);
+        $expanded->change_name_to('cite book');
+        $this->assertSame('cite book', $expanded->wikiname());
+        $this->assertNull($expanded->get2('website'));
+        $this->assertNull($expanded->get2('via'));
+        $this->assertNull($expanded->get2('work'));
+        $this->assertSame('Some book', $expanded->get2('title'));
+        $this->assertSame('Some chapter', $expanded->get2('chapter'));
+    }
+
+    public function testIsbnAdditionDoesNotConvertWebWithWebsite(): void {
+        $text = '{{cite web |url=https://example.com/chapter |title=Some chapter |website=Google Books}}';
+        $expanded = $this->make_citation($text);
+        $expanded->add_if_new('isbn', '978-615-5211-93-5');
+        $this->assertSame('cite web', $expanded->wikiname());
+        $this->assertSame('Google Books', $expanded->get2('website'));
+        $this->assertNull($expanded->get2('chapter'));
+        $this->assertSame('978-615-5211-93-5', $expanded->get2('isbn'));
+    }
+
+    public function testIsbnAdditionDoesNotConvertWebWithJournal(): void {
+        $text = '{{cite web |url=https://example.com/article |title=Some article |journal=Some Journal}}';
+        $expanded = $this->make_citation($text);
+        $expanded->add_if_new('isbn', '978-615-5211-93-5');
+        $this->assertSame('cite web', $expanded->wikiname());
+        $this->assertSame('Some Journal', $expanded->get2('journal'));
+    }
+
+    public function testIsbnAdditionDoesNotConvertWebWithIssue(): void {
+        $text = '{{cite web |url=https://example.com/article |title=Some article |issue=4}}';
+        $expanded = $this->make_citation($text);
+        $expanded->add_if_new('isbn', '978-615-5211-93-5');
+        $this->assertSame('cite web', $expanded->wikiname());
+        $this->assertSame('4', $expanded->get2('issue'));
+    }
+
+    public function testIsbnAdditionStillConvertsUnambiguousWebCitation(): void {
+        $text = '{{cite web |title=Some book}}';
+        $expanded = $this->make_citation($text);
+        $expanded->add_if_new('isbn', '978-615-5211-93-5');
+        $this->assertSame('cite book', $expanded->wikiname());
+        $this->assertSame('Some book', $expanded->get2('title'));
+    }
+
+    public function testIsbnAdditionStillConvertsRecognizedBookSeriesWork(): void {
+        $text = '{{cite web |title=Some paper |work=Lecture Notes in Computer Science}}';
+        $expanded = $this->make_citation($text);
+        $expanded->add_if_new('isbn', '978-615-5211-93-5');
+        $this->assertSame('cite book', $expanded->wikiname());
+        $this->assertNull($expanded->get2('work'));
+        $this->assertSame('Lecture Notes in Computer Science', $expanded->get2('series'));
+        $this->assertSame('Some paper', $expanded->get2('title'));
+    }
+
+    public function testChapterAdditionDoesNotCreateAmbiguousBookCitation(): void {
+        $text = '{{cite web |url=https://example.com/chapter |title=Landing page |website=Actual Book Title}}';
+        $expanded = $this->make_citation($text);
+        $this->assertFalse($expanded->add_if_new('chapter', 'Actual Chapter'));
+        $this->assertSame('cite web', $expanded->wikiname());
+        $this->assertNull($expanded->get2('chapter'));
+        $this->assertSame('Actual Book Title', $expanded->get2('website'));
+    }
+
+    public function testOxfordIsbnFinalTidyDoesNotConvertAmbiguousWebCitation(): void {
+        $text = '{{cite web |url=https://example.com/chapter |title=Some chapter |website=Google Books |isbn=978-0-19-959254-8}}';
+        $expanded = $this->make_citation($text);
+        $expanded->final_tidy();
+        $this->assertSame('cite web', $expanded->wikiname());
+        $this->assertSame('Google Books', $expanded->get2('website'));
+    }
+
+    public function testFinalTidyWebsiteBecomesViaOnChapteredWebCitation(): void {
+        // A human-written chapter= on a cite web with a delivery-site website=:
+        // final_tidy() converts directly to cite book (bypassing change_name_to),
+        // and website= must be preserved as via= rather than left where CS1
+        // would report "|website= ignored". Staying cite web is not an option,
+        // since chapter= is itself unsupported there.
+        $text = '{{cite web |title=Some book |chapter=Actual Chapter |website=Google Books |url=https://example.com}}';
+        $expanded = $this->make_citation($text);
+        $expanded->final_tidy();
+        $this->assertSame('cite book', $expanded->wikiname());
+        $this->assertNull($expanded->get2('website'));
+        $this->assertSame('Google Books', $expanded->get2('via'));
+        $this->assertSame('Actual Chapter', $expanded->get2('chapter'));
+    }
+
+    public function testDeclinedAmazonConversionKeepsUrl(): void {
+        // A cite web with both website= and a conflicting via= declines the
+        // book conversion; the Amazon URL must then remain in place, since
+        // cite web requires a url=. (The URL-to-ASIN/ISBN identifier handling
+        // is existing behavior and not what this test is about.)
+        $text = '{{cite web |title=Some book |website=Amazon |via=Goodreads |url=https://www.amazon.com/dp/1234567890}}';
+        $expanded = $this->make_citation($text);
+        $expanded->get_identifiers_from_url();
+        $this->assertSame('cite web', $expanded->wikiname());
+        $this->assertNotNull($expanded->get2('url'));
+        $this->assertTrue($expanded->has('asin') || $expanded->has('isbn'));
+        $this->assertSame('Amazon', $expanded->get2('website'));
+        $this->assertSame('Goodreads', $expanded->get2('via'));
+    }
 }

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -1544,6 +1544,113 @@ final class zoteroTest extends testBaseClass {
         $this->assertNull($template->get2('work'));
     }
 
+    public function testBookSectionWebsiteMatchingMetadataConvertsToBook(): void {
+        $text = '{{cite web |title=The United States of Greater Austria |url=https://books.openedition.org/ceup/2007?lang=en |website=Modernism: The Creation of Nation-States |publisher=Central European University Press |pages=312–318}}';
+        $template = $this->make_citation($text);
+        $zotero_data = [
+            (object) [
+                'title' => 'The United States of Greater Austria',
+                'bookTitle' => 'Modernism: The Creation of Nation-States',
+                'publisher' => 'Central European University Press',
+                'pages' => '312-318',
+                'ISBN' => '978-615-5211-93-5',
+                'itemType' => 'bookSection',
+            ],
+        ];
+
+        Zotero::process_zotero_response(
+            (string) json_encode($zotero_data),
+            $template,
+            'https://books.openedition.org/ceup/2007?lang=en',
+            0
+        );
+
+        $this->assertSame('cite book', $template->wikiname());
+        $this->assertNull($template->get2('website'));
+        $this->assertNull($template->get2('work'));
+        $this->assertSame('Modernism: The Creation of Nation-States', $template->get2('title'));
+        $this->assertSame('The United States of Greater Austria', $template->get2('chapter'));
+        $this->assertSame('978-615-5211-93-5', $template->get2('isbn'));
+    }
+
+    public function testBookSectionWebsiteMismatchDoesNotPromoteDeliverySite(): void {
+        $text = '{{cite web |title=Some chapter |url=https://example.com/book/chapter |website=Google Books}}';
+        $template = $this->make_citation($text);
+        $zotero_data = [
+            (object) [
+                'title' => 'Some chapter',
+                'bookTitle' => 'Actual Book Title',
+                'ISBN' => '978-615-5211-93-5',
+                'itemType' => 'bookSection',
+            ],
+        ];
+
+        Zotero::process_zotero_response(
+            (string) json_encode($zotero_data),
+            $template,
+            'https://example.com/book/chapter',
+            0
+        );
+
+        $this->assertSame('cite web', $template->wikiname());
+        $this->assertSame('Google Books', $template->get2('website'));
+        $this->assertSame('Some chapter', $template->get2('title'));
+        $this->assertNull($template->get2('chapter'));
+        $this->assertSame('978-615-5211-93-5', $template->get2('isbn'));
+    }
+
+    public function testBookSectionWebsiteMatchRequiresSectionTitleAgreement(): void {
+        $text = '{{cite web |title=Landing page |url=https://example.com/book/chapter |website=Actual Book Title}}';
+        $template = $this->make_citation($text);
+        $zotero_data = [
+            (object) [
+                'title' => 'Actual Chapter',
+                'bookTitle' => 'Actual Book Title',
+                'ISBN' => '978-615-5211-93-5',
+                'itemType' => 'bookSection',
+            ],
+        ];
+
+        Zotero::process_zotero_response(
+            (string) json_encode($zotero_data),
+            $template,
+            'https://example.com/book/chapter',
+            0
+        );
+
+        $this->assertSame('cite web', $template->wikiname());
+        $this->assertSame('Actual Book Title', $template->get2('website'));
+        $this->assertSame('Landing page', $template->get2('title'));
+        $this->assertNull($template->get2('chapter'));
+    }
+
+    public function testBookSectionReviewDataDoesNotPromoteWebsite(): void {
+        // A review of the book must not be reinterpreted as a chapter of it
+        // (the "Book review confusion" failure mode).
+        $text = '{{cite web |title=Review of the actual book |url=https://example.com/review |website=Actual Book Title}}';
+        $template = $this->make_citation($text);
+        $zotero_data = [
+            (object) [
+                'title' => 'Review of the actual book',
+                'bookTitle' => 'Actual Book Title',
+                'ISBN' => '978-615-5211-93-5',
+                'itemType' => 'bookSection',
+            ],
+        ];
+
+        Zotero::process_zotero_response(
+            (string) json_encode($zotero_data),
+            $template,
+            'https://example.com/review',
+            0
+        );
+
+        $this->assertSame('cite web', $template->wikiname());
+        $this->assertSame('Actual Book Title', $template->get2('website'));
+        $this->assertSame('Review of the actual book', $template->get2('title'));
+        $this->assertNull($template->get2('chapter'));
+    }
+
     public function testUfffcStrippedFromTitle(): void {
         $text = '{{cite web|id=}}';
         $template = $this->make_citation($text);

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -357,6 +357,7 @@ function build_matrix(): array {
         ['Erxleben path: work=series lands in series=', '{{cite web |title=Harness paper alpha |work=Lecture Notes in Computer Science |date=2014 |isbn=978-0-19-852011-5}}', 'pass'],
         ['Najman path: title=book title kept, work=series -> series=', '{{cite web |title=Harness book title beta |work=Lecture notes in mathematics |date=2017 |isbn=978-0-19-852011-5}}', 'pass'],
         ['No-clobber: existing series= preserved', '{{cite web |title=Harness paper gamma |work=Lecture Notes in Computer Science |series=Special Series Name |date=2014 |isbn=978-0-19-852011-5}}', 'pass'],
+        ['ISBN does not force periodical cite web to book', '{{cite web |url=https://example.com/article |title=Harness article delta |journal=Harness Journal |isbn=978-0-306-40615-7}}', 'pass'],
 
         // --- orphaned *-access removal (merged Tier 1 fix) ---
         ['Orphaned url-access removed', '{{cite journal |title=X |journal=J |url-access=subscription}}', 'pass'],


### PR DESCRIPTION
## Problem

When Citation Bot converts a `{{cite web}}` to `{{cite book}}` (e.g. after finding an ISBN), parameters that are valid in `cite web` but unsupported in `cite book` were left in place, so every converted citation could trigger a CS1 error. The reported case (OpenEdition Books chapters):

```wikitext
{{cite web |last=Popovici |first=Aurel C. |orig-date=1906 |title=The United States of Greater Austria
 |url=https://books.openedition.org/ceup/2007?lang=en |access-date=17 July 2026
 |website=Modernism: The Creation of Nation-States |publisher=Central European University Press |pages=312-318}}
```

was expanded to a `{{cite book}}` that still carried `|website=`, rendering:

> Popovici, Aurel C. (21 January 2013) [1906]. The United States of Greater Austria. Central European University Press. pp. 312-318. ISBN 978-615-5211-93-5. `{{cite book}}`: `|website=` ignored

A first draft of this PR mapped every `|website=` onto `|title=` on conversion. That was too broad: `|website=` normally names the delivery site (e.g. `Google Books`), so it can silently fabricate a wrong book title.

## Root cause

Five independent paths can promote `cite web` to `cite book`, and none of them handled `|website=` (or the other ambiguous fields) safely:

1. `tidy_parameter('isbn')` â€” converted whenever an ISBN was added (the path that triggered this report);
2. `tidy_parameter('chapter')`;
3. the Oxford-ISBN conversion in `final_tidy()`;
4. the direct title+chapter conversion in `final_tidy()` (bypasses `change_name_to()`);
5. Zotero's `book`/`bookSection` item-type switch (guarded `|website=` only, not `journal=`/`issue=`/etc.).

## Fix

### 1. Centralized conversion gate

New `Template::can_auto_convert_web_to_cite_book()`, used by the automatic ISBN, chapter, Oxford-ISBN and Zotero paths. For a `cite web`, automatic conversion is refused when `issue=`/`number=` is set, when a periodical/site alias (`website=`, `journal=`, `newspaper=`, `magazine=`, `periodical=`, `encyclopedia=`) is set, or when `work=` is not already recognized book-series metadata. Recognized book-series `work=` values stay eligible, preserving the Erxleben/Najman conversions and the no-clobber series case.

### 2. Conservative `|website=` semantics

When an explicit conversion happens, a remaining `|website=` is treated as the delivery site and moved to `via=`. If it merely duplicates `work=`, `title=` or the existing `via=`, the redundant `|website=` is dropped. If a *different* non-equivalent `via=` already exists, the conversion is declined instead of discarding either value. `|website=` is never turned into a book title just because the template became `cite book`. This mapping lives in `change_name_to()` and, for the `final_tidy()` path that bypasses it, is duplicated inline at the conversion site.

### 3. OpenEdition promotion only with corroborating Zotero data

For `itemType=bookSection`, the existing `|title=` is moved to `|chapter=` and `|website=` is promoted to `|title=` only when Zotero independently confirms both: `|website=` equals Zotero's `bookTitle`, and the existing `|title=` matches Zotero's section title (with the same "review" rejection the item-type switch already applies, guarding the book-review confusion failure mode). Otherwise the citation stays `cite web`.

### 4. No book-only chapter on ambiguous cite webs

`add_if_new('chapter', ...)` refuses to create a `chapter=` field when the same gate says the citation cannot safely become a book, so API metadata cannot manufacture the inputs for an unsafe conversion.

### 5. URL-to-identifier callers never orphan a declined citation

The Amazon / LCCN / Open Library URL handlers (like the OCLC handler already did) only drop the source URL when the conversion actually happened. A declined conversion keeps `|url=`, leaving a fully valid `cite web`.

## Verification against the CS1 documentation

Per [Template:Cite web documentation](https://en.wikipedia.org/wiki/Template:Cite_web), a declined conversion leaves a completely error-free citation: `|isbn=`, `|asin=`, `|lccn=`, `|oclc=`, `|ol=`, `|via=`, `|page(s)=` are all supported by `{{cite web}}` (the ISBN only adds the harmless "periodical has ISBN" maintenance note). `|chapter=` and `|issue=` are *not* supported by `{{cite web}}`, which is why the direct `final_tidy()` path must still convert (with `|website=` â†’ `|via=`) instead of declining, and why the gate refuses `|issue=` conversions. `|work=`/`|journal=`/`|newspaper=`/`|magazine=` are aliases of `|website=` in `{{cite web}}`, so declining loses nothing. `|website=` remains unsupported in `{{cite book}}` â€” the original error this PR fixes.

## Talk-page alignment

Implements the rule from ["Mangles cite web to cite book conversion by failing to change parameter names"](https://en.wikipedia.org/wiki/User_talk:Citation_bot#Mangles_cite_web_to_cite_book_conversion_by_failing_to_change_parameter_names): convert with proper `chapter=`/`title=`/`series=` renaming when the bot can figure it out, otherwise do not convert, and never create errors. All five conversion paths now follow it, extended to `|website=`.

## Tests

- `TemplatePart2Test`: 12 new tests â€” `via=` preservation, `via=`-conflict decline, equivalent `website=`/`work=` dedup, ISBN not forcing ambiguous `website=`/`journal=`/`issue=` citations to book, unambiguous ISBN and book-series conversions still working, chapter-add refusal, Oxford-ISBN path, `final_tidy()` title+chapter path, declined Amazon conversion keeping its URL.
- `zoteroTest`: 4 new `bookSection` cases â€” the OpenEdition-style positive case, delivery-site/book-title mismatch, section-title mismatch, and review data not triggering promotion.
- `tools/cs1_harness.php`: new must-pass case proving ISBN discovery no longer turns a periodical `cite web` into an invalid `cite book`.

## Validation

- `php tools/cs1_harness.php` and `php tools/cs1_harness.php --slow`: 30 passed, 14 known gaps, 0 failed, 0 unexpectedly resolved.
- Targeted `TemplatePart2Test`/`MiscToolsTest` runs (conversion/website/ISBN/chapter/Oxford/Amazon/LCCN/OCLC filters): 125 tests, 443 assertions, all green.
- `zoteroTest` bookSection cases: 4 tests, 27 assertions, all green.
- Remaining local failures are pre-existing network-dependent tests, verified identical on the base commit.
