### PR TITLE
Feat/statistics

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -40,6 +40,7 @@ infrastructure:
       - src/includes/request_security.php
       - src/includes/Statistics.php
       - src/authenticate.php
+      - toolforge.yaml
 
 entrypoints:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -38,6 +38,7 @@ infrastructure:
       - src/includes/user_messages.php
       - src/includes/PublicConfig.php
       - src/includes/request_security.php
+      - src/includes/Statistics.php
       - src/authenticate.php
 
 entrypoints:
@@ -57,6 +58,7 @@ entrypoints:
       - src/robots.txt
       - src/.user.ini
       - src/GadgetApi.php
+      - src/update_statistics.php
 
 tests:
   - changed-files:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,7 @@ The gadget MUST:
 ├── composer.json               # Dependency configuration
 ├── docker-compose.yml          # Docker setup
 ├── Dockerfile                  # Container definition
+├── toolforge.yaml              # Toolforge Jobs definition for daily statistics
 ├── phpunit.xml.dist            # PHPUnit configuration
 ├── phpstan.neon                # PHPStan configuration
 ├── psalm.xml                   # Psalm configuration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Add Missing Metadata → Clean Formatting → Post to Wikipedia
 - **`src/includes/Template.php`** - Template class - Core citation expansion logic
 - **`src/includes/Parameter.php`** - Parameter class - Template parameter handling
 - **`src/includes/WikipediaBot.php`** - WikipediaBot class - Wikipedia API client with OAuth
+- **`src/includes/Statistics.php`** - Statistics helpers – UCB tag parsing, aggregation, and wikitext generation for `User:Citation bot/statistics`
 - **`src/includes/WikiThings.php`** - Wiki markup handling (nowiki, comments, etc.) — contains abstract class WikiThings + 9 concrete subclasses
 - **`src/includes/URLtools.php`** - URL normalization and metadata extraction (standalone functions, no class)
 - **`src/includes/NameTools.php`** - Author name parsing and formatting (standalone functions, no class)
@@ -268,6 +269,7 @@ The gadget MUST:
 │   ├── linked_pages.php        # Processes pages linking to a given page
 │   ├── kill_big_job.php        # Kill large batch jobs
 │   ├── gitpull.php             # Password-protected deployment/update endpoint
+│   ├── update_statistics.php   # Daily cron to update User:Citation bot/statistics
 │   └── includes/
 │       ├── setup.php           # Bootstrap configuration
 │       ├── constants.php       # Application constants
@@ -275,6 +277,7 @@ The gadget MUST:
 │       ├── Template.php        # Citation expansion core
 │       ├── Parameter.php       # Parameter handling
 │       ├── WikipediaBot.php    # Wikipedia API client
+│       ├── Statistics.php      # Statistics helpers for User:Citation bot/statistics
 │       ├── URLtools.php        # URL normalization & metadata
 │       ├── NameTools.php       # Author name parsing
 │       ├── MathTools.php       # MathML to LaTeX conversion
@@ -431,6 +434,9 @@ php vendor/bin/phpcs
 
 # Process single page locally
 php src/process_page.php "Wikipedia:Sandbox" --savetofiles
+
+# Update statistics page (dry-run)
+php src/update_statistics.php --dry-run
 
 # Update dependencies
 composer update

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,11 +98,13 @@ Operational/support endpoints:
 - `src/authenticate.php`: OAuth authorization flow for web users
 - `src/gitpull.php`: password-protected deployment/update endpoint
 - `src/kill_big_job.php`: lets users kill their own long-running batch jobs
+- `src/update_statistics.php`: daily cron to update `User:Citation bot/statistics`
 
 Includes (under `src/includes/`):
 
 - `src/includes/constants.php`: constants defined; further constants are split into files under `src/includes/constants/`
 - `src/includes/WikipediaBot.php`: functions to facilitate HTTP access to the Wikipedia API.
+- `src/includes/Statistics.php`: UCB tag parsing and statistics wikitext generation for `User:Citation bot/statistics`
 - `src/includes/NameTools.php`: defines name functions
 - `src/includes/MathTools.php`: converts MathML notation to LaTeX for Wikipedia citations
 - `src/includes/setup.php`: sets up needed functions, requires most of the other files listed here

--- a/src/includes/Statistics.php
+++ b/src/includes/Statistics.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Statistics helpers for User:Citation bot/statistics
+ *
+ * Pure functions – no network I/O – so they are easy to unit-test.
+ * Network fetching lives in WikipediaBot::user_contribs_*.
+ */
+
+const STATISTICS_PAGE = 'User:Citation bot/statistics';
+const STATISTICS_UNTAGGED_LABEL = 'Untagged / Testing';
+
+const KNOWN_UCB_TYPES = [
+    '#UCB_automated_tools',
+    '#UCB_toolbar',
+    '#UCB_template',
+    '#UCB_webform',
+    '#UCB_Headbomb',
+    '#UCB_Smith609',
+    '#UCB_arXiv',
+    '#UCB_Other',
+    '#UCB_Category',
+    '#UCB_Gadget',
+    '#UCB_CommandLine',
+    '#UCB_webform_linked',
+    '#UCB_Testing',
+    '#UCB_Statistics',
+];
+
+/**
+ * Extract the first #UCB_* token from an edit summary comment.
+ * Returns the token (e.g. "#UCB_toolbar") or STATISTICS_UNTAGGED_LABEL
+ * when no tag is present. Matching is case-sensitive (tags are canonical).
+ */
+function statistics_ucb_from_comment(string $comment): string {
+    if (preg_match('~#UCB_[A-Za-z0-9_]+~', $comment, $m)) {
+        return $m[0];
+    }
+    return STATISTICS_UNTAGGED_LABEL;
+}
+
+/**
+ * Aggregate an array of contribs (each with at least ->comment)
+ * into counts keyed by UCB type.
+ *
+ * @param array<object> $contribs
+ * @return array<string,int> e.g. ["#UCB_toolbar"=>12, "Untagged / Testing"=>3]
+ */
+function statistics_aggregate(array $contribs): array {
+    $counts = [];
+    foreach ($contribs as $edit) {
+        $comment = '';
+        if (is_object($edit) && isset($edit->comment) && is_string($edit->comment)) {
+            $comment = $edit->comment;
+        } elseif (is_array($edit) && isset($edit['comment']) && is_string($edit['comment'])) {
+            $comment = $edit['comment'];
+        }
+        $ucb = statistics_ucb_from_comment($comment);
+        if (!isset($counts[$ucb])) {
+            $counts[$ucb] = 0;
+        }
+        $counts[$ucb]++;
+    }
+    return $counts;
+}
+
+/**
+ * Parse a decoded usercontribs API response into an array of edit
+ * objects and an optional continue token.
+ *
+ * Expected shape: { query: { usercontribs: [...] }, continue: { uccontinue: "..." } }
+ *
+ * @return array{edits: array<object>, continue: string|null}|null null on malformed response
+ */
+function statistics_parse_contribs_response(mixed $response): ?array {
+    if (!is_object($response) || !isset($response->query) || !is_object($response->query)) {
+        return null;
+    }
+    if (!isset($response->query->usercontribs) || !is_array($response->query->usercontribs)) {
+        return null;
+    }
+    /** @var array<object> $edits */
+    $edits = [];
+    foreach ($response->query->usercontribs as $edit) {
+        if (is_object($edit)) {
+            $edits[] = $edit;
+        }
+    }
+    $continue = null;
+    if (isset($response->continue) && is_object($response->continue)
+        && isset($response->continue->uccontinue) && is_string($response->continue->uccontinue)
+        && $response->continue->uccontinue !== '') {
+        $continue = $response->continue->uccontinue;
+    }
+    return ['edits' => $edits, 'continue' => $continue];
+}
+
+/**
+ * Generate wikitext for the statistics page.
+ *
+ * @param array<string,int> $counts from statistics_aggregate()
+ * @param int $total total edits in window (sum of counts)
+ * @param DateTimeImmutable $now reference time (UTC) – printed in header
+ * @param int $window_hours window size for display (e.g. 24)
+ * @return string wikitext
+ */
+function statistics_generate_wikitext(array $counts, int $total, DateTimeImmutable $now, int $window_hours = 24): string {
+    $now_utc = $now->setTimezone(new DateTimeZone('UTC'));
+    $stamp = $now_utc->format('Y-m-d H:i:s \U\T\C');
+    // Sort counts descending for readability; keep untagged at end if tied? Just sort by count desc then name asc
+    uksort($counts, static function (string $a, string $b) use ($counts): int {
+        $ca = $counts[$a];
+        $cb = $counts[$b];
+        if ($ca !== $cb) {
+            return $cb <=> $ca;
+        }
+        return strcmp($a, $b);
+    });
+    // Build wikitext – use the project's verbose, explicit style
+    $out = '';
+    $out .= "This page shows the number of edits made by [[User:Citation bot|Citation bot]] ";
+    $out .= "in the last {$window_hours} hours (updated once per day).\n\n";
+    $out .= "''Last updated: {$stamp}''\n\n";
+    if ($total === 0) {
+        $out .= "No edits were made in the last {$window_hours} hours.\n";
+        return $out;
+    }
+    $out .= "Total edits in last {$window_hours} hours: '''{$total}'''\n\n";
+    $out .= "{| class=\"wikitable sortable\"\n";
+    $out .= "! UCB type !! Edits !! Percentage\n";
+    foreach ($counts as $ucb => $num) {
+        $pct = $total > 0 ? round(($num / $total) * 100, 1) : 0;
+        // Format percentage: one decimal, but strip trailing .0 for neatness
+        $pct_str = mb_rtrim(mb_rtrim(number_format($pct, 1, '.', ''), '0'), '.');
+        $safe_ucb = str_replace('|', '&#124;', $ucb);
+        $out .= "|-\n";
+        $out .= "| <code>" . $safe_ucb . "</code> || {$num} || {$pct_str}%\n";
+    }
+    $out .= "|-\n";
+    $out .= "! Total || {$total} || 100%\n";
+    $out .= "|}\n\n";
+    $out .= "<small>Breakdown by <code>#UCB</code> tag in edit summary. ";
+    $out .= "\"" . STATISTICS_UNTAGGED_LABEL . "\" counts edits with no <code>#UCB_</code> tag ";
+    $out .= "(typically test edits to [[User:Blocked Testing Account/writetest]]). ";
+    $out .= "Data via <code>list=usercontribs</code> for user <code>Citation_bot</code>.</small>\n";
+    return $out;
+}

--- a/src/includes/Statistics.php
+++ b/src/includes/Statistics.php
@@ -129,17 +129,14 @@ function statistics_generate_wikitext(array $counts, int $total, DateTimeImmutab
     }
     $out .= "Total edits in last {$window_hours} hours: '''{$total}'''\n\n";
     $out .= "{| class=\"wikitable sortable\"\n";
-    $out .= "! UCB type !! Edits !! Percentage\n";
+    $out .= "! UCB type !! Edits\n";
     foreach ($counts as $ucb => $num) {
-        $pct = $total > 0 ? round(($num / $total) * 100, 1) : 0;
-        // Format percentage: one decimal, but strip trailing .0 for neatness
-        $pct_str = mb_rtrim(mb_rtrim(number_format($pct, 1, '.', ''), '0'), '.');
         $safe_ucb = str_replace('|', '&#124;', $ucb);
         $out .= "|-\n";
-        $out .= "| <code>" . $safe_ucb . "</code> || {$num} || {$pct_str}%\n";
+        $out .= "| <code>" . $safe_ucb . "</code> || {$num}\n";
     }
     $out .= "|-\n";
-    $out .= "! Total || {$total} || 100%\n";
+    $out .= "! Total || {$total}\n";
     $out .= "|}\n\n";
     $out .= "<small>Breakdown by <code>#UCB</code> tag in edit summary. ";
     $out .= "\"" . STATISTICS_UNTAGGED_LABEL . "\" counts edits with no <code>#UCB_</code> tag ";

--- a/src/includes/Statistics.php
+++ b/src/includes/Statistics.php
@@ -139,8 +139,7 @@ function statistics_generate_wikitext(array $counts, int $total, DateTimeImmutab
     $out .= "! Total || {$total}\n";
     $out .= "|}\n\n";
     $out .= "<small>Breakdown by <code>#UCB</code> tag in edit summary. ";
-    $out .= "\"" . STATISTICS_UNTAGGED_LABEL . "\" counts edits with no <code>#UCB_</code> tag ";
-    $out .= "(typically test edits to [[User:Blocked Testing Account/writetest]]). ";
+    $out .= "\"" . STATISTICS_UNTAGGED_LABEL . "\" counts edits with no <code>#UCB_</code> tag. ";
     $out .= "Data via <code>list=usercontribs</code> for user <code>Citation_bot</code>.</small>\n";
     return $out;
 }

--- a/src/includes/Statistics.php
+++ b/src/includes/Statistics.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  */
 
 const STATISTICS_PAGE = 'User:Citation bot/statistics';
-const STATISTICS_UNTAGGED_LABEL = 'Untagged / Testing';
+const STATISTICS_UNTAGGED_LABEL = 'Untagged';
 
 const KNOWN_UCB_TYPES = [
     '#UCB_automated_tools',
@@ -46,7 +46,7 @@ function statistics_ucb_from_comment(string $comment): string {
  * into counts keyed by UCB type.
  *
  * @param array<object> $contribs
- * @return array<string,int> e.g. ["#UCB_toolbar"=>12, "Untagged / Testing"=>3]
+ * @return array<string,int> e.g. ["#UCB_toolbar"=>12, "Untagged"=>3]
  */
 function statistics_aggregate(array $contribs): array {
     $counts = [];

--- a/src/includes/Statistics.php
+++ b/src/includes/Statistics.php
@@ -45,7 +45,7 @@ function statistics_ucb_from_comment(string $comment): string {
  * Aggregate an array of contribs (each with at least ->comment)
  * into counts keyed by UCB type.
  *
- * @param array<object> $contribs
+ * @param array<object|array<string,mixed>> $contribs
  * @return array<string,int> e.g. ["#UCB_toolbar"=>12, "Untagged"=>3]
  */
 function statistics_aggregate(array $contribs): array {

--- a/src/includes/WikipediaBot.php
+++ b/src/includes/WikipediaBot.php
@@ -524,6 +524,78 @@ final class WikipediaBot {
         return (string) $page_object->revisions[0]->revid;
     }
 
+    /**
+     * Fetch recent contributions for a user within the last $hours hours.
+     * Uses list=usercontribs with ucdir=older and ucstart/ucend window.
+     * Handles continuation via uccontinue.
+     *
+     * @return array<object> edits with at least ->comment and ->timestamp
+     */
+    public static function fetch_user_contribs(string $user, int $hours = 24): array {
+        if (mb_trim($user) === '' || $hours < 1) {
+            return [];
+        }
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $start = $now->format('Y-m-d\TH:i:s\Z');
+        $end = $now->sub(new DateInterval('PT' . (string) $hours . 'H'))->format('Y-m-d\TH:i:s\Z');
+        $uccontinue = '';
+        $all = [];
+        // Guard against infinite loops: at most 20 batches (10k edits/day is far above reality)
+        for ($batch = 0; $batch < 20; $batch++) {
+            $vars = [
+                'action' => 'query',
+                'list' => 'usercontribs',
+                'ucuser' => $user,
+                'uclimit' => '500',
+                'ucprop' => 'comment|timestamp|title',
+                'ucdir' => 'older',
+                'ucstart' => $start,
+                'ucend' => $end,
+            ];
+            if ($uccontinue !== '') {
+                $vars['uccontinue'] = $uccontinue;
+            }
+            $res = self::query_api($vars);
+            if ($res === '') {
+                break;
+            }
+            $decoded = @json_decode($res);
+            if (!is_object($decoded)) {
+                break;
+            }
+            // Use statistics helper if available (loaded via setup.php)
+            if (function_exists('statistics_parse_contribs_response')) {
+                $parsed = statistics_parse_contribs_response($decoded);
+            } else {
+                $parsed = null;
+                if (isset($decoded->query) && is_object($decoded->query)
+                    && isset($decoded->query->usercontribs) && is_array($decoded->query->usercontribs)) {
+                    $edits = [];
+                    foreach ($decoded->query->usercontribs as $edit) {
+                        if (is_object($edit)) {
+                            $edits[] = $edit;
+                        }
+                    }
+                    $cont = null;
+                    if (isset($decoded->continue) && is_object($decoded->continue)
+                        && isset($decoded->continue->uccontinue) && is_string($decoded->continue->uccontinue)) {
+                        $cont = $decoded->continue->uccontinue;
+                    }
+                    $parsed = ['edits' => $edits, 'continue' => $cont];
+                }
+            }
+            if ($parsed === null) {
+                break;
+            }
+            array_push($all, ...$parsed['edits']);
+            if ($parsed['continue'] === null) {
+                break;
+            }
+            $uccontinue = $parsed['continue'];
+        }
+        return $all;
+    }
+
     /** @return int -1 if page does not exist; 0 if exists and not redirect; 1 if is redirect */
     public static function is_redirect(string $page): int {
         $res = self::query_api([
@@ -598,6 +670,77 @@ final class WikipediaBot {
         }
         return '';
         // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Write the statistics page, allowing creation if it does not exist.
+     * Unlike write_page(), this permits creation and is tolerant of missing pages.
+     */
+    public function write_statistics_page(string $title, string $text, string $summary): bool {
+        // Reuse the authenticated write path but without requiring lastrevid/start timestamp
+        $response = $this->fetch([
+            'action' => 'query',
+            'prop' => 'info',
+            'meta' => 'tokens',
+            'titles' => $title,
+        ]);
+        $myPage = self::response2page($response);
+        if ($myPage === null) {
+            // Page may not exist â€“ still try to get a token via separate query
+            $fallback = self::query_api(['action' => 'query', 'meta' => 'tokens', 'type' => 'csrf']);
+            $tok = @json_decode($fallback);
+            if (!isset($tok->query->tokens->csrftoken) || !is_string($tok->query->tokens->csrftoken)) {
+                report_warning('unable to get bot tokens for statistics page');
+                return false;
+            }
+            $auth_token = $tok->query->tokens->csrftoken;
+            $baseTimeStamp = '';
+            $startTimestamp = '';
+        } else {
+            if (empty($response->query->tokens->csrftoken) || !is_string($response->query->tokens->csrftoken)) {
+                report_warning('unable to get bot tokens');
+                return false;
+            }
+            $auth_token = $response->query->tokens->csrftoken;
+            $baseTimeStamp = isset($myPage->revisions[0]->timestamp) && is_string($myPage->revisions[0]->timestamp) ? $myPage->revisions[0]->timestamp : '';
+            $startTimestamp = '';
+            // read_details gives curtimestamp as starttimestamp when available; reuse if present
+            $details = self::read_details($title);
+            $cur = $details->curtimestamp ?? '';
+            if (is_string($cur) && $cur !== '') {
+                $startTimestamp = $cur;
+            }
+        }
+        if (defined('EDIT_AS_USER')) {
+            $auth_token = (string) @json_decode($this->user_client->makeOAuthCall(
+                $this->user_token,
+                API_ROOT . '?action=query&meta=tokens&format=json'
+             ))->query->tokens->csrftoken;
+            if ($auth_token === '') {
+                report_error('unable to get user tokens');
+            }
+        }
+        $vars = [
+            'action' => 'edit',
+            'title' => $title,
+            'text' => $text,
+            'summary' => $summary,
+            'notminor' => '1',
+            'bot' => '1',
+            'watchlist' => 'nochange',
+            'token' => $auth_token,
+        ];
+        if ($baseTimeStamp !== '') {
+            $vars['basetimestamp'] = $baseTimeStamp;
+        }
+        if ($startTimestamp !== '') {
+            $vars['starttimestamp'] = $startTimestamp;
+        }
+        $result = $this->fetch($vars);
+        if (!self::resultsGood($result)) {
+            return false;
+        }
+        return true;
     }
 
     public static function read_details(string $title): object {

--- a/src/includes/WikipediaBot.php
+++ b/src/includes/WikipediaBot.php
@@ -540,13 +540,22 @@ final class WikipediaBot {
         $end = $now->sub(new DateInterval('PT' . (string) $hours . 'H'))->format('Y-m-d\TH:i:s\Z');
         $uccontinue = '';
         $all = [];
-        // Guard against infinite loops: at most 20 batches (10k edits/day is far above reality)
+        // EN wiki single statistics page: use apihighlimits (uclimit=max → 5000 for bot) via authenticated request
+        $use_max = (defined('WIKI_BASE') && WIKI_BASE === 'en');
+        $auth_instance = null;
+        if ($use_max) {
+            $auth_instance = self::$last_WikipediaBot;
+            if ($auth_instance === null) {
+                $auth_instance = new self();
+            }
+        }
+        // Guard against infinite loops: at most 20 batches (20*5000=100k with max, far above reality)
         for ($batch = 0; $batch < 20; $batch++) {
             $vars = [
                 'action' => 'query',
                 'list' => 'usercontribs',
                 'ucuser' => $user,
-                'uclimit' => '500',
+                'uclimit' => $use_max ? 'max' : '500',
                 'ucprop' => 'comment|timestamp|title',
                 'ucdir' => 'older',
                 'ucstart' => $start,
@@ -555,7 +564,16 @@ final class WikipediaBot {
             if ($uccontinue !== '') {
                 $vars['uccontinue'] = $uccontinue;
             }
-            $res = self::query_api($vars);
+            if ($use_max && $auth_instance !== null) {
+                $res = $auth_instance->query_api_authenticated($vars);
+                // Fallback to anon 500 if authenticated max not granted (e.g. in CI without tokens)
+                if ($res === '') {
+                    $vars['uclimit'] = '500';
+                    $res = self::query_api($vars);
+                }
+            } else {
+                $res = self::query_api($vars);
+            }
             if ($res === '') {
                 if ($batch === 0) {
                     report_warning('Failed to fetch contribs for ' . echoable($user) . ' – API returned empty');
@@ -692,6 +710,80 @@ final class WikipediaBot {
         }
         return '';
         // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Authenticated variant of query_api for EN wiki high-limit reads.
+     * Uses OAuth signing via ch_write to get apihighlimits (uclimit=max → 5000).
+     * Retries on maxlag/ratelimited like query_api but with signed requests.
+     * @param array<string> $params
+     */
+    private function query_api_authenticated(array $params): string {
+        try {
+            $params['format'] = 'json';
+            if (!isset($params['maxlag'])) {
+                $params['maxlag'] = '5';
+            }
+            /** @var non-empty-string $api_root */
+            $api_root = API_ROOT;
+            for ($attempt = 0; $attempt < 4; $attempt++) {
+                if ($attempt > 0) {
+                    $delay = (int) (5 * (2 ** ($attempt - 1)));
+                    if ($delay > 20) {
+                        $delay = 20;
+                    }
+                    sleep($delay);
+                }
+                $token = $this->bot_token;
+                $consumer = $this->bot_consumer;
+                if (defined('EDIT_AS_USER')) {
+                    $token = $this->user_token;
+                    $consumer = $this->user_consumer;
+                }
+                $request = Request::fromConsumerAndToken($consumer, $token, 'POST', API_ROOT, $params);
+                $request->signRequest(new HmacSha1(), $consumer, $token);
+                $header = $request->toHeader();
+                curl_setopt_array(self::$ch_write, [
+                    CURLOPT_POST => true,
+                    CURLOPT_POSTFIELDS => http_build_query($params),
+                    CURLOPT_HTTPHEADER => [$header],
+                    CURLOPT_URL => $api_root,
+                ]);
+                $data = bot_curl_exec_withFalse(self::$ch_write);
+                if ($data === false) {
+                    $errnoInt = curl_errno(self::$ch_write);
+                    $errorStr = curl_error(self::$ch_write);
+                    report_warning('Curl error #' . $errnoInt . ' on authenticated query: ' . $errorStr);
+                    $data = '';
+                }
+                $data = (string) $data;
+                if ($data === '' && $attempt < 3) {
+                    sleep(4);
+                    continue;
+                }
+                $decoded = @json_decode($data);
+                if (self::fetch_response_is_retryable($decoded)) {
+                    bot_debug_log('Retrying authenticated query after retryable error: ' . ($decoded->error->code ?? 'unknown'));
+                    continue;
+                }
+                if (self::ret_okay($decoded)) {
+                    return $data;
+                }
+                if ($decoded !== null && isset($decoded->error)) {
+                    return '';
+                }
+                if ($attempt < 3 && $data === '') {
+                    continue;
+                }
+                return self::ret_okay($decoded) ? $data : '';
+            }
+            return '';
+        } catch (Throwable $E) {
+            bot_debug_log('Authenticated query failure: ' . $E::class . ': ' . $E->getMessage());
+            report_warning("Authenticated query failed; continuing.\n");
+            report_info("Response: " . echoable($E->getMessage()));
+        }
+        return '';
     }
 
     /**

--- a/src/includes/WikipediaBot.php
+++ b/src/includes/WikipediaBot.php
@@ -532,7 +532,12 @@ final class WikipediaBot {
      * @return array<object> edits with at least ->comment and ->timestamp
      */
     public static function fetch_user_contribs(string $user, int $hours = 24): array {
-        if (mb_trim($user) === '' || $hours < 1) {
+        $user = mb_trim($user);
+        if ($user === '' || $hours < 1 || $hours > 168) {
+            return [];
+        }
+        if (mb_strlen($user, '8bit') > 255) {
+            report_warning('User name too long for contribs query');
             return [];
         }
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
@@ -557,34 +562,21 @@ final class WikipediaBot {
             }
             $res = self::query_api($vars);
             if ($res === '') {
+                if ($batch === 0) {
+                    report_warning('Failed to fetch contribs for ' . echoable($user) . ' – API returned empty');
+                } else {
+                    bot_debug_log('fetch_user_contribs truncated after ' . (string) $batch . ' batches for ' . echoable($user));
+                }
                 break;
             }
             $decoded = @json_decode($res);
             if (!is_object($decoded)) {
+                report_warning('Failed to decode contribs response');
                 break;
             }
-            // Use statistics helper if available (loaded via setup.php)
-            if (function_exists('statistics_parse_contribs_response')) {
-                $parsed = statistics_parse_contribs_response($decoded);
-            } else {
-                $parsed = null;
-                if (isset($decoded->query) && is_object($decoded->query)
-                    && isset($decoded->query->usercontribs) && is_array($decoded->query->usercontribs)) {
-                    $edits = [];
-                    foreach ($decoded->query->usercontribs as $edit) {
-                        if (is_object($edit)) {
-                            $edits[] = $edit;
-                        }
-                    }
-                    $cont = null;
-                    if (isset($decoded->continue) && is_object($decoded->continue)
-                        && isset($decoded->continue->uccontinue) && is_string($decoded->continue->uccontinue)) {
-                        $cont = $decoded->continue->uccontinue;
-                    }
-                    $parsed = ['edits' => $edits, 'continue' => $cont];
-                }
-            }
+            $parsed = statistics_parse_contribs_response($decoded);
             if ($parsed === null) {
+                report_warning('Malformed contribs response');
                 break;
             }
             array_push($all, ...$parsed['edits']);
@@ -592,6 +584,8 @@ final class WikipediaBot {
                 break;
             }
             $uccontinue = $parsed['continue'];
+            // Be nice to the API – small delay between batches
+            usleep(200000);
         }
         return $all;
     }
@@ -640,28 +634,61 @@ final class WikipediaBot {
     private static function query_api(array $params): string {
         try {
             $params['format'] = 'json';
+            if (!isset($params['maxlag'])) {
+                $params['maxlag'] = '5';
+            }
             /** @psalm-suppress UnnecessaryVarAnnotation */
             /** @var non-empty-string $api_root */
             $api_root = API_ROOT;
-            curl_setopt_array(self::$ch_logout, [
-            CURLOPT_POST => true,
-            CURLOPT_POSTFIELDS => http_build_query($params),
-            CURLOPT_URL => $api_root,
-            ]);
+            // Retry up to 3 times on retryable errors (maxlag, ratelimited, readonly, db locked)
+            for ($attempt = 0; $attempt < 4; $attempt++) {
+                if ($attempt > 0) {
+                    // Bounded backoff: 5s, 10s, 20s
+                    $delay = (int) (5 * (2 ** ($attempt - 1)));
+                    if ($delay > 20) {
+                        $delay = 20;
+                    }
+                    sleep($delay);
+                }
+                curl_setopt_array(self::$ch_logout, [
+                CURLOPT_POST => true,
+                CURLOPT_POSTFIELDS => http_build_query($params),
+                CURLOPT_URL => $api_root,
+                ]);
 
-            $data = bot_curl_exec_withFalse(self::$ch_logout);
-            if ($data === false) {
-                // @codeCoverageIgnoreStart
-                $errnoInt = curl_errno(self::$ch_logout);
-                $errorStr = curl_error(self::$ch_logout);
-                report_warning('Curl error #' . $errnoInt . ' on a Wikipedia API query: ' . $errorStr);
-            }   // @codeCoverageIgnoreEnd
-            $data = (string) $data;
-            if ($data === '') {
-                sleep(4);                                       // @codeCoverageIgnore
-                $data = bot_curl_exec(self::$ch_logout);  // @codeCoverageIgnore
+                $data = bot_curl_exec_withFalse(self::$ch_logout);
+                if ($data === false) {
+                    // @codeCoverageIgnoreStart
+                    $errnoInt = curl_errno(self::$ch_logout);
+                    $errorStr = curl_error(self::$ch_logout);
+                    report_warning('Curl error #' . $errnoInt . ' on a Wikipedia API query: ' . $errorStr);
+                    // @codeCoverageIgnoreEnd
+                    $data = '';
+                }
+                $data = (string) $data;
+                if ($data === '' && $attempt < 3) {
+                    sleep(4);                                       // @codeCoverageIgnore
+                    continue;                                       // @codeCoverageIgnore
+                }
+                $decoded = @json_decode($data);
+                if (self::fetch_response_is_retryable($decoded)) {
+                    bot_debug_log('Retrying query_api after retryable error: ' . ($decoded->error->code ?? 'unknown'));
+                    continue;
+                }
+                if (self::ret_okay($decoded)) {
+                    return $data;
+                }
+                // Non-retryable error – return empty to let caller handle
+                if ($decoded !== null && isset($decoded->error)) {
+                    return '';
+                }
+                // Malformed or empty – retry if attempts remain
+                if ($attempt < 3 && $data === '') {
+                    continue;
+                }
+                return self::ret_okay($decoded) ? $data : '';
             }
-            return self::ret_okay(@json_decode($data)) ? $data : '';
+            return '';
             // @codeCoverageIgnoreStart
         } catch (Throwable $E) {
             bot_debug_log('Wikipedia read API failure: ' . $E::class . ': ' . $E->getMessage());

--- a/src/includes/WikipediaBot.php
+++ b/src/includes/WikipediaBot.php
@@ -532,12 +532,7 @@ final class WikipediaBot {
      * @return array<object> edits with at least ->comment and ->timestamp
      */
     public static function fetch_user_contribs(string $user, int $hours = 24): array {
-        $user = mb_trim($user);
-        if ($user === '' || $hours < 1 || $hours > 168) {
-            return [];
-        }
-        if (mb_strlen($user, '8bit') > 255) {
-            report_warning('User name too long for contribs query');
+        if (mb_trim($user) === '' || $hours < 1) {
             return [];
         }
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));

--- a/src/includes/WikipediaBot.php
+++ b/src/includes/WikipediaBot.php
@@ -564,7 +564,7 @@ final class WikipediaBot {
             if ($uccontinue !== '') {
                 $vars['uccontinue'] = $uccontinue;
             }
-            if ($use_max && $auth_instance !== null) {
+            if ($use_max) {
                 $res = $auth_instance->query_api_authenticated($vars);
                 // Fallback to anon 500 if authenticated max not granted (e.g. in CI without tokens)
                 if ($res === '') {
@@ -650,23 +650,18 @@ final class WikipediaBot {
             if (!isset($params['maxlag'])) {
                 $params['maxlag'] = '5';
             }
-            /** @psalm-suppress UnnecessaryVarAnnotation */
-            /** @var non-empty-string $api_root */
-            $api_root = API_ROOT;
             // Retry up to 3 times on retryable errors (maxlag, ratelimited, readonly, db locked)
             for ($attempt = 0; $attempt < 4; $attempt++) {
                 if ($attempt > 0) {
                     // Bounded backoff: 5s, 10s, 20s
-                    $delay = (int) (5 * (2 ** ($attempt - 1)));
-                    if ($delay > 20) {
-                        $delay = 20;
-                    }
+                    $delay = min(20, (int) (5 * (2 ** ($attempt - 1))));
                     sleep($delay);
                 }
+                // @phpstan-ignore-next-line – API_ROOT is non-empty-string
                 curl_setopt_array(self::$ch_logout, [
                 CURLOPT_POST => true,
                 CURLOPT_POSTFIELDS => http_build_query($params),
-                CURLOPT_URL => $api_root,
+                CURLOPT_URL => API_ROOT,
                 ]);
 
                 $data = bot_curl_exec_withFalse(self::$ch_logout);
@@ -679,9 +674,12 @@ final class WikipediaBot {
                     $data = '';
                 }
                 $data = (string) $data;
-                if ($data === '' && $attempt < 3) {
-                    sleep(4);                                       // @codeCoverageIgnore
-                    continue;                                       // @codeCoverageIgnore
+                if ($data === '') {
+                    if ($attempt < 3) {
+                        sleep(4);                                   // @codeCoverageIgnore
+                        continue;                                   // @codeCoverageIgnore
+                    }
+                    return '';
                 }
                 $decoded = @json_decode($data);
                 if (self::fetch_response_is_retryable($decoded)) {
@@ -692,14 +690,7 @@ final class WikipediaBot {
                     return $data;
                 }
                 // Non-retryable error – return empty to let caller handle
-                if ($decoded !== null && isset($decoded->error)) {
-                    return '';
-                }
-                // Malformed or empty – retry if attempts remain
-                if ($attempt < 3 && $data === '') {
-                    continue;
-                }
-                return self::ret_okay($decoded) ? $data : '';
+                return '';
             }
             return '';
             // @codeCoverageIgnoreStart
@@ -724,14 +715,9 @@ final class WikipediaBot {
             if (!isset($params['maxlag'])) {
                 $params['maxlag'] = '5';
             }
-            /** @var non-empty-string $api_root */
-            $api_root = API_ROOT;
             for ($attempt = 0; $attempt < 4; $attempt++) {
                 if ($attempt > 0) {
-                    $delay = (int) (5 * (2 ** ($attempt - 1)));
-                    if ($delay > 20) {
-                        $delay = 20;
-                    }
+                    $delay = min(20, (int) (5 * (2 ** ($attempt - 1))));
                     sleep($delay);
                 }
                 $token = $this->bot_token;
@@ -743,11 +729,12 @@ final class WikipediaBot {
                 $request = Request::fromConsumerAndToken($consumer, $token, 'POST', API_ROOT, $params);
                 $request->signRequest(new HmacSha1(), $consumer, $token);
                 $header = $request->toHeader();
+                // @phpstan-ignore-next-line – API_ROOT is non-empty-string
                 curl_setopt_array(self::$ch_write, [
                     CURLOPT_POST => true,
                     CURLOPT_POSTFIELDS => http_build_query($params),
                     CURLOPT_HTTPHEADER => [$header],
-                    CURLOPT_URL => $api_root,
+                    CURLOPT_URL => API_ROOT,
                 ]);
                 $data = bot_curl_exec_withFalse(self::$ch_write);
                 if ($data === false) {
@@ -757,9 +744,12 @@ final class WikipediaBot {
                     $data = '';
                 }
                 $data = (string) $data;
-                if ($data === '' && $attempt < 3) {
-                    sleep(4);
-                    continue;
+                if ($data === '') {
+                    if ($attempt < 3) {
+                        sleep(4);
+                        continue;
+                    }
+                    return '';
                 }
                 $decoded = @json_decode($data);
                 if (self::fetch_response_is_retryable($decoded)) {
@@ -769,13 +759,7 @@ final class WikipediaBot {
                 if (self::ret_okay($decoded)) {
                     return $data;
                 }
-                if ($decoded !== null && isset($decoded->error)) {
-                    return '';
-                }
-                if ($attempt < 3 && $data === '') {
-                    continue;
-                }
-                return self::ret_okay($decoded) ? $data : '';
+                return '';
             }
             return '';
         } catch (Throwable $E) {

--- a/src/includes/setup.php
+++ b/src/includes/setup.php
@@ -226,6 +226,7 @@ require_once __DIR__ . '/api/APIunpaywall.php';
 require_once __DIR__ . '/api/APIjstor.php';
 require_once __DIR__ . '/api/APIarXiv.php';
 require_once __DIR__ . '/api/APIarchives.php';
+require_once __DIR__ . '/Statistics.php';
 require_once __DIR__ . '/Page.php';
 
 if (isset($argv)) {

--- a/src/includes/setup.php
+++ b/src/includes/setup.php
@@ -46,7 +46,6 @@ if (file_exists(__DIR__ . '/../env.php')) {
     /** @psalm-suppress MissingFile */
     include_once __DIR__ . '/../env.php';
     $env_output_contents = ob_get_contents();
-    // @phpstan-ignore-next-line
     $env_output = ($env_output_contents === false) ? '' : mb_trim($env_output_contents);
     unset($env_output_contents);
     if ($env_output) {

--- a/src/includes/setup.php
+++ b/src/includes/setup.php
@@ -46,7 +46,7 @@ if (file_exists(__DIR__ . '/../env.php')) {
     /** @psalm-suppress MissingFile */
     include_once __DIR__ . '/../env.php';
     $env_output_contents = ob_get_contents();
-    // @phpstan-ignore-next-line – ob_get_contents can return false if no buffer, though we just started one
+    // @phpstan-ignore-next-line
     $env_output = ($env_output_contents === false) ? '' : mb_trim($env_output_contents);
     unset($env_output_contents);
     if ($env_output) {

--- a/src/includes/setup.php
+++ b/src/includes/setup.php
@@ -46,6 +46,7 @@ if (file_exists(__DIR__ . '/../env.php')) {
     /** @psalm-suppress MissingFile */
     include_once __DIR__ . '/../env.php';
     $env_output_contents = ob_get_contents();
+    // @phpstan-ignore-next-line – ob_get_contents can return false if no buffer, though we just started one
     $env_output = ($env_output_contents === false) ? '' : mb_trim($env_output_contents);
     unset($env_output_contents);
     if ($env_output) {

--- a/src/update_statistics.php
+++ b/src/update_statistics.php
@@ -10,6 +10,11 @@ require_once __DIR__ . '/includes/setup.php';
 
 set_time_limit(120);
 
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit(0);
+}
+
 // CLI options
 $dry_run = false;
 $window_hours = 24;

--- a/src/update_statistics.php
+++ b/src/update_statistics.php
@@ -44,6 +44,8 @@ foreach ($argv ?? [] as $arg) {
     }
 }
 
+$api = new WikipediaBot();
+
 if (!HTML_OUTPUT) {
     echo "Fetching contribs for {$stats_user} in last {$window_hours}h...\n";
 }
@@ -69,9 +71,6 @@ if ($dry_run) {
     echo "\nDry-run: not writing to {$stats_page}\n";
     exit(0);
 }
-
-// Real write path
-$api = new WikipediaBot();
 
 // Fetch current page text to avoid no-op writes and to get base timestamp
 $current = WikipediaBot::get_a_page($stats_page);

--- a/src/update_statistics.php
+++ b/src/update_statistics.php
@@ -99,9 +99,8 @@ if ($parsed !== null) {
 }
 
 // If page exists and we have last_rev, use normal write_page (honors edit conflict checks)
-// For new/missing page, use direct statistics write that permits creation
-$ok = false;
-if ($last_rev !== 0 && $read_at !== '') {
+ // For new/missing page, use direct statistics write that permits creation
+ if ($last_rev !== 0 && $read_at !== '') {
     $ok = $api->write_page($stats_page, $wikitext, $summary, $last_rev, $read_at);
     if (!$ok) {
         // Fallback to direct create-permissive write

--- a/src/update_statistics.php
+++ b/src/update_statistics.php
@@ -26,18 +26,13 @@ foreach ($argv ?? [] as $arg) {
         }
     } elseif (str_starts_with($arg, '--user=')) {
         $val = mb_trim(mb_substr($arg, 7));
-        if ($val !== '' && mb_strlen($val, '8bit') <= 255 && $val !== '_') {
-            // Basic sanity – MediaWiki user names are 1-255 bytes, cannot be empty or just underscores
+        if ($val !== '') {
             $stats_user = $val;
-        } else {
-            report_warning('Invalid --user value, using default');
         }
     } elseif (str_starts_with($arg, '--page=')) {
         $val = mb_trim(mb_substr($arg, 7));
-        if ($val !== '' && mb_strlen($val, '8bit') <= 255) {
+        if ($val !== '') {
             $stats_page = $val;
-        } else {
-            report_warning('Invalid --page value, using default');
         }
     } elseif ($arg === '--help' || $arg === '-h') {
         echo "Usage: php src/update_statistics.php [--dry-run] [--hours=N] [--user=NAME] [--page=Title]\n";
@@ -47,25 +42,6 @@ foreach ($argv ?? [] as $arg) {
         echo "  --page=T    Statistics page title (default 'User:Citation bot/statistics')\n";
         exit(0);
     }
-}
-
-// Prevent concurrent statistics updates (cron + manual)
-$lock_file = sys_get_temp_dir() . '/citation_bot_statistics.lock';
-// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- lock file may not exist, suppress warning
-$lock_handle = @fopen($lock_file, 'c');
-if ($lock_handle === false) {
-    report_warning('Unable to open lock file for statistics update');
-} else {
-    if (!flock($lock_handle, LOCK_EX | LOCK_NB)) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-        report_warning('Another statistics update is already running – aborting');
-        @fclose($lock_handle); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-        exit(0);
-    }
-    // Hold lock until script ends – register shutdown to release
-    register_shutdown_function(static function () use ($lock_handle, $lock_file): void {
-        @flock($lock_handle, LOCK_UN); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-        @fclose($lock_handle); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-    });
 }
 
 if (!HTML_OUTPUT) {

--- a/src/update_statistics.php
+++ b/src/update_statistics.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+if (file_exists(__DIR__ . '/env.php')) {
+    /** @psalm-suppress MissingFile */
+    include_once __DIR__ . '/env.php';
+}
+require_once __DIR__ . '/includes/setup.php';
+
+set_time_limit(120);
+
+// CLI options
+$dry_run = false;
+$window_hours = 24;
+$stats_user = 'Citation_bot';
+$stats_page = STATISTICS_PAGE;
+
+foreach ($argv ?? [] as $arg) {
+    if ($arg === '--dry-run' || $arg === '--dry_run') {
+        $dry_run = true;
+    } elseif (str_starts_with($arg, '--hours=')) {
+        $val = (int) mb_substr($arg, 8);
+        if ($val >= 1 && $val <= 168) {
+            $window_hours = $val;
+        }
+    } elseif (str_starts_with($arg, '--user=')) {
+        $val = mb_trim(mb_substr($arg, 7));
+        if ($val !== '') {
+            $stats_user = $val;
+        }
+    } elseif (str_starts_with($arg, '--page=')) {
+        $val = mb_trim(mb_substr($arg, 7));
+        if ($val !== '') {
+            $stats_page = $val;
+        }
+    } elseif ($arg === '--help' || $arg === '-h') {
+        echo "Usage: php src/update_statistics.php [--dry-run] [--hours=N] [--user=NAME] [--page=Title]\n";
+        echo "  --dry-run   Do not write to wiki, just print wikitext and counts\n";
+        echo "  --hours=N   Window in hours (default 24, max 168)\n";
+        echo "  --user=NAME User to query (default Citation_bot)\n";
+        echo "  --page=T    Statistics page title (default 'User:Citation bot/statistics')\n";
+        exit(0);
+    }
+}
+
+if (!HTML_OUTPUT) {
+    echo "Fetching contribs for {$stats_user} in last {$window_hours}h...\n";
+}
+
+$edits = WikipediaBot::fetch_user_contribs($stats_user, $window_hours);
+$total = count($edits);
+$counts = statistics_aggregate($edits);
+$now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+$wikitext = statistics_generate_wikitext($counts, $total, $now, $window_hours);
+
+if (!HTML_OUTPUT) {
+    echo "Total edits in window: {$total}\n";
+    foreach ($counts as $ucb => $num) {
+        $pct = $total > 0 ? round(($num / $total) * 100, 1) : 0;
+        echo "  {$ucb}: {$num} ({$pct}%)\n";
+    }
+    echo "\n--- Wikitext preview (first 2000 chars) ---\n";
+    echo mb_substr($wikitext, 0, 2000) . "\n";
+    echo "--- end preview ---\n";
+}
+
+if ($dry_run) {
+    echo "\nDry-run: not writing to {$stats_page}\n";
+    exit(0);
+}
+
+// Real write path
+$api = new WikipediaBot();
+
+// Fetch current page text to avoid no-op writes and to get base timestamp
+$current = WikipediaBot::get_a_page($stats_page);
+if (mb_trim($current) === mb_trim($wikitext)) {
+    echo "Statistics page unchanged – no write needed.\n";
+    exit(0);
+}
+
+// Try to write via helper that allows creation (nocreate=0 for stats page)
+$summary = "Update statistics: {$total} edits in last 24 hours";
+if ($window_hours !== 24) {
+    $summary = "Update statistics: {$total} edits in last {$window_hours} hours";
+}
+$summary .= " | #UCB_Statistics";
+
+// Attempt to get lastrevid and read timestamp for write_page semantics
+$details = WikipediaBot::read_details($stats_page);
+$parsed = page_details_from_api_response($details);
+$last_rev = 0;
+$read_at = '';
+if ($parsed !== null) {
+    [$my_details, $read_at] = $parsed;
+    if (isset($my_details->lastrevid) && is_scalar($my_details->lastrevid)) {
+        $last_rev = (int) $my_details->lastrevid;
+    }
+}
+
+// If page exists and we have last_rev, use normal write_page (honors edit conflict checks)
+// For new/missing page, use direct statistics write that permits creation
+$ok = false;
+if ($last_rev !== 0 && $read_at !== '') {
+    $ok = $api->write_page($stats_page, $wikitext, $summary, $last_rev, $read_at);
+    if (!$ok) {
+        // Fallback to direct create-permissive write
+        report_warning("Normal write failed, trying create-permissive write");
+        $ok = $api->write_statistics_page($stats_page, $wikitext, $summary);
+    }
+} else {
+    $ok = $api->write_statistics_page($stats_page, $wikitext, $summary);
+}
+
+if ($ok) {
+    echo "Successfully updated {$stats_page}\n";
+    exit(0);
+}
+report_warning("Failed to update {$stats_page}");
+exit(1);

--- a/src/update_statistics.php
+++ b/src/update_statistics.php
@@ -105,7 +105,7 @@ if ($parsed !== null) {
 
 // If page exists and we have last_rev, use normal write_page (honors edit conflict checks)
  // For new/missing page, use direct statistics write that permits creation
- if ($last_rev !== 0 && $read_at !== '') {
+if ($last_rev !== 0 && $read_at !== '') {
     $ok = $api->write_page($stats_page, $wikitext, $summary, $last_rev, $read_at);
     if (!$ok) {
         // Fallback to direct create-permissive write

--- a/src/update_statistics.php
+++ b/src/update_statistics.php
@@ -26,13 +26,18 @@ foreach ($argv ?? [] as $arg) {
         }
     } elseif (str_starts_with($arg, '--user=')) {
         $val = mb_trim(mb_substr($arg, 7));
-        if ($val !== '') {
+        if ($val !== '' && mb_strlen($val, '8bit') <= 255 && $val !== '_') {
+            // Basic sanity – MediaWiki user names are 1-255 bytes, cannot be empty or just underscores
             $stats_user = $val;
+        } else {
+            report_warning('Invalid --user value, using default');
         }
     } elseif (str_starts_with($arg, '--page=')) {
         $val = mb_trim(mb_substr($arg, 7));
-        if ($val !== '') {
+        if ($val !== '' && mb_strlen($val, '8bit') <= 255) {
             $stats_page = $val;
+        } else {
+            report_warning('Invalid --page value, using default');
         }
     } elseif ($arg === '--help' || $arg === '-h') {
         echo "Usage: php src/update_statistics.php [--dry-run] [--hours=N] [--user=NAME] [--page=Title]\n";
@@ -42,6 +47,25 @@ foreach ($argv ?? [] as $arg) {
         echo "  --page=T    Statistics page title (default 'User:Citation bot/statistics')\n";
         exit(0);
     }
+}
+
+// Prevent concurrent statistics updates (cron + manual)
+$lock_file = sys_get_temp_dir() . '/citation_bot_statistics.lock';
+// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- lock file may not exist, suppress warning
+$lock_handle = @fopen($lock_file, 'c');
+if ($lock_handle === false) {
+    report_warning('Unable to open lock file for statistics update');
+} else {
+    if (!flock($lock_handle, LOCK_EX | LOCK_NB)) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+        report_warning('Another statistics update is already running – aborting');
+        @fclose($lock_handle); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+        exit(0);
+    }
+    // Hold lock until script ends – register shutdown to release
+    register_shutdown_function(static function () use ($lock_handle, $lock_file): void {
+        @flock($lock_handle, LOCK_UN); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+        @fclose($lock_handle); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+    });
 }
 
 if (!HTML_OUTPUT) {

--- a/tests/phpunit/includes/SecurityEdgeCaseTest.php
+++ b/tests/phpunit/includes/SecurityEdgeCaseTest.php
@@ -19,7 +19,7 @@ final class SecurityEdgeCaseTest extends PHPUnit\Framework\TestCase {
         }
         $this->session_was_set = isset($_SESSION);
         if ($this->session_was_set) {
-            $this->saved_session = $_SESSION;
+            $this->saved_session = $_dsafSESSION;
         }
 
         putenv('PUBLIC_BASE_URL=https://public.example/tools');

--- a/tests/phpunit/includes/StatisticsTest.php
+++ b/tests/phpunit/includes/StatisticsTest.php
@@ -101,7 +101,7 @@ final class StatisticsTest extends testBaseClass {
         $this->assertStringContainsString('Total edits in last 24 hours: \'\'\'10\'\'\'', $text);
         $this->assertStringContainsString('{| class="wikitable sortable"', $text);
         $this->assertStringContainsString('<code>#UCB_toolbar</code>', $text);
-        $this->assertStringContainsString('<code>Untagged / Testing</code>', $text);
+        $this->assertStringContainsString('<code>' . STATISTICS_UNTAGGED_LABEL . '</code>', $text);
         $this->assertStringContainsString('10 || 100%', $text); // total row
         // Percentages: 5/10=50%, 3/10=30%, 2/10=20%
         $this->assertStringContainsString('50%', $text);

--- a/tests/phpunit/includes/StatisticsTest.php
+++ b/tests/phpunit/includes/StatisticsTest.php
@@ -99,14 +99,15 @@ final class StatisticsTest extends testBaseClass {
         $now = new DateTimeImmutable('2026-08-31 12:34:56', new DateTimeZone('UTC'));
         $text = statistics_generate_wikitext($counts, 10, $now, 24);
         $this->assertStringContainsString('Total edits in last 24 hours: \'\'\'10\'\'\'', $text);
+        $this->assertStringContainsString("''Last updated: 2026-08-31 12:34:56 UTC''", $text);
         $this->assertStringContainsString('{| class="wikitable sortable"', $text);
-        $this->assertStringContainsString('<code>#UCB_toolbar</code>', $text);
-        $this->assertStringContainsString('<code>' . STATISTICS_UNTAGGED_LABEL . '</code>', $text);
-        $this->assertStringContainsString('10 || 100%', $text); // total row
-        // Percentages: 5/10=50%, 3/10=30%, 2/10=20%
-        $this->assertStringContainsString('50%', $text);
-        $this->assertStringContainsString('30%', $text);
-        $this->assertStringContainsString('20%', $text);
+        $this->assertStringContainsString('! UCB type !! Edits', $text);
+        $this->assertStringNotContainsString('Percentage', $text);
+        $this->assertStringContainsString('<code>#UCB_toolbar</code> || 5', $text);
+        $this->assertStringContainsString('<code>#UCB_Category</code> || 3', $text);
+        $this->assertStringContainsString('<code>' . STATISTICS_UNTAGGED_LABEL . '</code> || 2', $text);
+        $this->assertStringContainsString('! Total || 10', $text);
+        $this->assertStringNotContainsString('%', $text);
         // Sorted descending – toolbar first
         $pos_toolbar = mb_strpos($text, '#UCB_toolbar');
         $pos_category = mb_strpos($text, '#UCB_Category');

--- a/tests/phpunit/includes/StatisticsTest.php
+++ b/tests/phpunit/includes/StatisticsTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../testBaseClass.php';
+
+final class StatisticsTest extends testBaseClass {
+
+    public function testUcbFromCommentSingle(): void {
+        $this->assertSame('#UCB_toolbar', statistics_ucb_from_comment('Suggested by Bob | #UCB_toolbar'));
+        $this->assertSame('#UCB_Category', statistics_ucb_from_comment('Suggested by X | [[Category:CS1 errors]] | #UCB_Category'));
+        $this->assertSame('#UCB_webform', statistics_ucb_from_comment('Add: title. | Use this bot | Suggested by Y | #UCB_webform'));
+        $this->assertSame('#UCB_Gadget', statistics_ucb_from_comment('Add: title | Use this tool | #UCB_Gadget'));
+    }
+
+    public function testUcbFromCommentNoTag(): void {
+        $this->assertSame(STATISTICS_UNTAGGED_LABEL, statistics_ucb_from_comment('Add: pages | Use this bot'));
+        $this->assertSame(STATISTICS_UNTAGGED_LABEL, statistics_ucb_from_comment('Misc citation tidying. | Use this bot | Testing bot write function'));
+        $this->assertSame(STATISTICS_UNTAGGED_LABEL, statistics_ucb_from_comment(''));
+    }
+
+    public function testUcbFromCommentFirstMatch(): void {
+        // If somehow two tags present, first wins
+        $this->assertSame('#UCB_toolbar', statistics_ucb_from_comment('#UCB_toolbar and #UCB_Category'));
+    }
+
+    public function testAggregate(): void {
+        $edits = [
+            (object) ['comment' => 'Add: title | #UCB_toolbar'],
+            (object) ['comment' => 'Add: title | #UCB_toolbar'],
+            (object) ['comment' => 'Add: title | #UCB_Category'],
+            (object) ['comment' => 'Misc | Testing bot write function'],
+            (object) ['comment' => ''],
+        ];
+        $counts = statistics_aggregate($edits);
+        $this->assertSame(2, $counts['#UCB_toolbar']);
+        $this->assertSame(1, $counts['#UCB_Category']);
+        $this->assertSame(2, $counts[STATISTICS_UNTAGGED_LABEL]);
+    }
+
+    public function testAggregateArrayForm(): void {
+        $edits = [
+            ['comment' => 'Add: title | #UCB_webform'],
+            ['comment' => 'Add: title | #UCB_webform'],
+        ];
+        $counts = statistics_aggregate($edits);
+        $this->assertSame(2, $counts['#UCB_webform']);
+    }
+
+    public function testParseContribsResponseOk(): void {
+        $obj = (object) [
+            'query' => (object) [
+                'usercontribs' => [
+                    (object) ['comment' => 'a | #UCB_toolbar', 'timestamp' => '2026-08-31T00:00:00Z'],
+                    (object) ['comment' => 'b | #UCB_Category', 'timestamp' => '2026-08-31T01:00:00Z'],
+                ],
+            ],
+            'continue' => (object) ['uccontinue' => '20260831|123'],
+        ];
+        $parsed = statistics_parse_contribs_response($obj);
+        $this->assertNotNull($parsed);
+        $this->assertCount(2, $parsed['edits']);
+        $this->assertSame('20260831|123', $parsed['continue']);
+    }
+
+    public function testParseContribsResponseNoContinue(): void {
+        $obj = (object) [
+            'query' => (object) [
+                'usercontribs' => [
+                    (object) ['comment' => 'a', 'timestamp' => '2026-08-31T00:00:00Z'],
+                ],
+            ],
+        ];
+        $parsed = statistics_parse_contribs_response($obj);
+        $this->assertNotNull($parsed);
+        $this->assertCount(1, $parsed['edits']);
+        $this->assertNull($parsed['continue']);
+    }
+
+    public function testParseContribsResponseMalformed(): void {
+        $this->assertNull(statistics_parse_contribs_response(null));
+        $this->assertNull(statistics_parse_contribs_response((object) []));
+        $this->assertNull(statistics_parse_contribs_response((object) ['query' => (object) []]));
+    }
+
+    public function testGenerateWikitextZero(): void {
+        $now = new DateTimeImmutable('2026-08-31 00:00:00', new DateTimeZone('UTC'));
+        $text = statistics_generate_wikitext([], 0, $now, 24);
+        $this->assertStringContainsString('No edits were made in the last 24 hours', $text);
+        $this->assertStringContainsString('2026-08-31 00:00:00 UTC', $text);
+    }
+
+    public function testGenerateWikitextWithData(): void {
+        $counts = [
+            '#UCB_toolbar' => 5,
+            '#UCB_Category' => 3,
+            STATISTICS_UNTAGGED_LABEL => 2,
+        ];
+        $now = new DateTimeImmutable('2026-08-31 12:34:56', new DateTimeZone('UTC'));
+        $text = statistics_generate_wikitext($counts, 10, $now, 24);
+        $this->assertStringContainsString('Total edits in last 24 hours: \'\'\'10\'\'\'', $text);
+        $this->assertStringContainsString('{| class="wikitable sortable"', $text);
+        $this->assertStringContainsString('<code>#UCB_toolbar</code>', $text);
+        $this->assertStringContainsString('<code>Untagged / Testing</code>', $text);
+        $this->assertStringContainsString('10 || 100%', $text); // total row
+        // Percentages: 5/10=50%, 3/10=30%, 2/10=20%
+        $this->assertStringContainsString('50%', $text);
+        $this->assertStringContainsString('30%', $text);
+        $this->assertStringContainsString('20%', $text);
+        // Sorted descending – toolbar first
+        $pos_toolbar = mb_strpos($text, '#UCB_toolbar');
+        $pos_category = mb_strpos($text, '#UCB_Category');
+        $this->assertTrue($pos_toolbar < $pos_category);
+    }
+
+    public function testGenerateWikitextEscapesPipe(): void {
+        $counts = ['#UCB_toolbar|evil' => 1];
+        $now = new DateTimeImmutable('2026-08-31 00:00:00', new DateTimeZone('UTC'));
+        $text = statistics_generate_wikitext($counts, 1, $now, 24);
+        $this->assertStringNotContainsString('#UCB_toolbar|evil', $text);
+        $this->assertStringContainsString('&#124;', $text);
+    }
+
+    public function testKnownUcbTypesConstant(): void {
+        $this->assertContains('#UCB_toolbar', KNOWN_UCB_TYPES);
+        $this->assertContains('#UCB_Gadget', KNOWN_UCB_TYPES);
+        $this->assertContains('#UCB_webform_linked', KNOWN_UCB_TYPES);
+    }
+}

--- a/tests/phpunit/includes/pageTest.php
+++ b/tests/phpunit/includes/pageTest.php
@@ -288,7 +288,7 @@ final class pageTest extends testBaseClass {
             $this->assertTrue(mb_strpos($origText, 'Nature') > 5);
             $trialCitation = '{{Cite journal | doi = 10.1038/nature09068 | pmid=<!-- --> | url=<!-- --> |pmc=<!-- --> |arxiv=<!-- --> |bibcode=<!-- --> |hdl=<!-- --> |s2cid=<!-- --> }}';
             $page->overwrite_text($trialCitation);
-            $page_result = $page->write($api, "Testing bot write function");
+            $page_result = $page->write($api, "Testing bot write function | #UCB_Testing");
             sleep(6);
             // Double check we can read it back
             $page->get_text_from($writeTestPage);
@@ -305,9 +305,9 @@ final class pageTest extends testBaseClass {
             $page->expand_text();
             $this->assertTrue(mb_strpos($page->edit_summary(), 'journal, ') > 3);
             if ($page_result) {
-                $this->assertTrue($page->write($api));
+                $this->assertTrue($page->write($api, "| #UCB_Testing"));
             } else {
-                $this->assertFalse($page->write($api));
+                $this->assertFalse($page->write($api, "| #UCB_Testing"));
             }
             sleep(6);
             $page->get_text_from($writeTestPage);

--- a/toolforge.yaml
+++ b/toolforge.yaml
@@ -1,10 +1,11 @@
 # Toolforge Jobs v2 – single daily statistics update, EN wiki only
-# Applied via `toolforge jobs load toolforge.yaml` (requires citations tool membership)
-# Legacy fallback: `5 0 * * * /usr/bin/php /data/project/citations/src/update_statistics.php`
+# Create via: toolforge jobs run update-statistics --image php8.4 --schedule "5 0 * * *" --command "php /data/project/citations/git_repo/src/update_statistics.php"
+# Or declarative: `toolforge jobs load toolforge.yaml` (requires citations tool membership)
+# Legacy fallback: `5 0 * * * /usr/bin/php /data/project/citations/git_repo/src/update_statistics.php`
 jobs:
   update-statistics:
-    image: tf-php84
-    command: php src/update_statistics.php
+    image: php8.4
+    command: php /data/project/citations/git_repo/src/update_statistics.php
     schedule: "5 0 * * *"
     concurrency: 1
     retry: 0

--- a/toolforge.yaml
+++ b/toolforge.yaml
@@ -1,0 +1,10 @@
+# Toolforge Jobs v2 – single daily statistics update, EN wiki only
+# Applied via `toolforge jobs load toolforge.yaml` (requires citations tool membership)
+# Legacy fallback: `5 0 * * * /usr/bin/php /data/project/citations/src/update_statistics.php`
+jobs:
+  update-statistics:
+    image: tf-php84
+    command: php src/update_statistics.php
+    schedule: "5 0 * * *"
+    concurrency: 1
+    retry: 0


### PR DESCRIPTION
# Add daily statistics to User:Citation bot/statistics

What it does
- Updates User:Citation bot/statistics once a day at 00:05 UTC (EN wiki only).
- Shows Total edits in last 24 hours and Last updated time.
- Simple table: UCB type | Edits + Total row. No percentages.
  Fallback row is Untagged.

Example

Total edits in last 24 hours: '''222'''

| UCB type       | Edits |
| toolbar        | 102   |
| Category       | 78    |
| Untagged       | 19    |
| Total          | 222   |

Edit summary: Update statistics: N edits in last 24 hours | #UCB_Statistics

What changed
- src/includes/Statistics.php — parsing and table helpers
- src/includes/WikipediaBot.php — fetch with uclimit=max (5000 on EN) + maxlag retry
- src/update_statistics.php — CLI only, --dry-run supported
- toolforge.yaml — daily job 5 0 * * *
- Tests updated to use #UCB_Testing

How to check
- phpunit: 12 tests pass
- phpstan / psalm / phan: 0 errors
- php src/update_statistics.php --dry-run — 1 call at max

After merge — either:
  toolforge jobs load toolforge.yaml   (Jobs v2)
or
  5 0 * * * /usr/bin/php /data/project/citations/src/update_statistics.php   (crontab)