### PR TITLE
allow local tests to use 2G memory instead of 1G (auto-detect CI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ The project uses extensive automated testing:
 
 The CS1 harness is the conformance regression gate (Phase 0 of the audit plan): it drives the bot's real expansion on a matrix of citations and flags any output that would trigger a `Help:CS1 errors` message. Run it locally (`php tools/cs1_harness.php` and `--slow`) before and after any citation-expansion change; a new fix should flip one of its documented gap cases to `RESOLVED` and add a matrix case.
 
-**Local PHPUnit note:** `phpunit.xml.dist` aborts without a coverage driver; for local runs use the stripped `phpunit.local.xml` (gitignored): `php -d memory_limit=1G vendor/bin/phpunit --configuration phpunit.local.xml <path>`.
+**Local PHPUnit note:** `phpunit.xml.dist` aborts without a coverage driver; for local runs use the stripped `phpunit.local.xml` (gitignored): `php -d memory_limit=2G vendor/bin/phpunit --configuration phpunit.local.xml <path>`.
 
 All tests must pass before merging. Some tests are network-dependent (Zotero, PubMed, Unpaywall, JSTOR) and may pass/fail with upstream API availability; those are unrelated to local changes.
 
@@ -415,7 +415,7 @@ Include:
 # Run tests
 php vendor/bin/phpunit
 # Local runs (phpunit.xml.dist needs a coverage driver): use the stripped config
-php -d memory_limit=1G vendor/bin/phpunit --configuration phpunit.local.xml <path>
+php -d memory_limit=2G vendor/bin/phpunit --configuration phpunit.local.xml <path>
 
 # CS1 conformance regression gate (fast + slow)
 php tools/cs1_harness.php

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,6 @@
         "progpilot": "php -d memory_limit=1G vendor/bin/progpilot --configuration progpilot.yml src/*.php src/*/*.php src/*/*/*.php tests/*.php tests/*/*.php tests/*/*/*.php tests/*/*/*/*.php .phan/config.php",
         "psalm": "PSALM_ALLOW_XDEBUG=1 php ./vendor/bin/psalm --memory-limit=4G --show-info=true",
         "psalm-taint": "PSALM_ALLOW_XDEBUG=1 php ./vendor/bin/psalm --taint-analysis --memory-limit=4G",
-        "test": "php -d memory_limit=1G tests/run_tests.php"
+        "test": "php tests/run_tests.php"
     }
 }

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -7,9 +7,15 @@ declare(strict_types=1);
  *
  * Runs the PHPUnit test suite via paratest, then generates a JUnit
  * timing report, and finally exits with paratest's exit code.
+ *
+ * Memory limit is auto-detected: 1G on CI (GITHUB_ACTIONS/CI set),
+ * 2G locally to allow more headroom for parallel coverage runs.
  */
 
-$paratest_command = PHP_BINARY . ' -d memory_limit=1G vendor/bin/paratest'
+$memory_limit = (getenv('GITHUB_ACTIONS') || getenv('CI')) ? '1G' : '2G';
+@ini_set('memory_limit', $memory_limit);
+
+$paratest_command = PHP_BINARY . ' -d memory_limit=' . $memory_limit . ' vendor/bin/paratest'
     . ' --processes=auto --runner=WrapperRunner --enforce-time-limit'
     . ' --default-time-limit=60000 --cache-directory=.phpunit.cache'
     . ' --coverage-clover=coverage.xml --log-junit=junit.xml --verbose';
@@ -33,7 +39,7 @@ if (!is_resource($process)) {
 $paratest_exit_code = proc_close($process);
 
 // Generate the timing report on stdout; its exit code is not propagated
-passthru(PHP_BINARY . ' -d memory_limit=1G tests/parse_junit.php', $junit_exit_code);
+passthru(PHP_BINARY . ' -d memory_limit=' . $memory_limit . ' tests/parse_junit.php', $junit_exit_code);
 unset($junit_exit_code);
 
 exit($paratest_exit_code);


### PR DESCRIPTION
This PR allows tests on local machines to use 2G instead of 1G while keeping CI strict at 1G (auto-detect).

- `composer.json`: `test` script now delegates to `tests/run_tests.php` without a hardcoded `-d memory_limit` for cross-platform compatibility
- `tests/run_tests.php`: auto-detects `GITHUB_ACTIONS`/`CI` env var -> `1G` on CI (`test-suite.yml`), `2G` locally (via `ini_set` + `-d memory_limit` for `paratest`/`parse_junit`)
- `AGENTS.md`: update local-run docs (`php -d memory_limit=1G vendor/bin/phpunit --configuration phpunit.local.xml`) -> `2G` for consistency

`composer run test` / `php tests/run_tests.php` works everywhere: `2G` locally, `1G` in GitHub Actions. Covers the previous hardcoded `1G` in both `composer.json:40` and `tests/run_tests.php:12,36`.

Branch: `fix/local-tests-2g-memory` based on `master` (`210d6ab90`), 3 files changed.