### PR TITLE
docs: sync AGENTS/README/labeler/architecture with live codebase

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,6 +39,8 @@ infrastructure:
       - src/includes/PublicConfig.php
       - src/includes/request_security.php
       - src/includes/Statistics.php
+      - src/includes/GadgetApi.php
+      - src/includes/RequestRateLimit.php
       - src/authenticate.php
       - toolforge.yaml
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,11 @@ Add Missing Metadata → Clean Formatting → Post to Wikipedia
 - **`src/includes/Parameter.php`** - Parameter class - Template parameter handling
 - **`src/includes/WikipediaBot.php`** - WikipediaBot class - Wikipedia API client with OAuth
 - **`src/includes/Statistics.php`** - Statistics helpers – UCB tag parsing, aggregation, and wikitext generation for `User:Citation bot/statistics`
+- **`src/includes/GadgetApi.php`** - Gadget API validation and rate limiting helpers
+- **`src/includes/PublicConfig.php`** - Public URL/host/origin canonicalization and CORS helpers
+- **`src/includes/RequestRateLimit.php`** - Token-bucket rate limiting for gadget and web requests
+- **`src/includes/request_security.php`** - CSRF and session security helpers for web entrypoints
+- **`src/includes/TextTools.php`** - String manipulation and CS1 identifier validators
 - **`src/includes/WikiThings.php`** - Wiki markup handling (nowiki, comments, etc.) — contains abstract class WikiThings + 9 concrete subclasses
 - **`src/includes/URLtools.php`** - URL normalization and metadata extraction (standalone functions, no class)
 - **`src/includes/NameTools.php`** - Author name parsing and formatting (standalone functions, no class)
@@ -278,6 +283,10 @@ The gadget MUST:
 │       ├── Parameter.php       # Parameter handling
 │       ├── WikipediaBot.php    # Wikipedia API client
 │       ├── Statistics.php      # Statistics helpers for User:Citation bot/statistics
+│       ├── GadgetApi.php       # Gadget API validation and rate limiting helpers
+│       ├── PublicConfig.php    # Public URL/host/origin canonicalization and CORS helpers
+│       ├── RequestRateLimit.php # Token-bucket rate limiting for gadget and web requests
+│       ├── request_security.php # CSRF and session security helpers
 │       ├── URLtools.php        # URL normalization & metadata
 │       ├── NameTools.php       # Author name parsing
 │       ├── MathTools.php       # MathML to LaTeX conversion

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ The Citation Bot has two main user-facing interfaces with different performance 
 - **Default mode**: Thorough mode (slow mode enabled via checkbox, checked by default)
 - **Slow mode operations**: Searches for new bibcodes and expands URLs via external APIs
 - **Use case**: Users who want comprehensive citation expansion and can wait longer
-- **Timeout limit**: Request-level processing continues as long as the HTTP connection holds, but individual page lists are subject to internal size caps (see "Structure" below)
+- **Timeout limit**: Request processing is bounded by `set_time_limit(120)` and internal size caps (`MAX_PAGES`: 50 for web, unlimited for CLI); thorough mode can use the full budget
 
 ### Citation Expander Gadget (`src/gadgetapi.php`)
 
@@ -105,6 +105,10 @@ Includes (under `src/includes/`):
 - `src/includes/constants.php`: constants defined; further constants are split into files under `src/includes/constants/`
 - `src/includes/WikipediaBot.php`: functions to facilitate HTTP access to the Wikipedia API.
 - `src/includes/Statistics.php`: UCB tag parsing and statistics wikitext generation for `User:Citation bot/statistics`
+- `src/includes/GadgetApi.php`: gadget request validation and rate-limiting helpers
+- `src/includes/PublicConfig.php`: public URL/host/origin canonicalization and CORS helpers
+- `src/includes/RequestRateLimit.php`: token-bucket rate limiting for gadget and web requests
+- `src/includes/request_security.php`: CSRF and session security helpers for web entrypoints
 - `src/includes/NameTools.php`: defines name functions
 - `src/includes/MathTools.php`: converts MathML notation to LaTeX for Wikipedia citations
 - `src/includes/setup.php`: sets up needed functions, requires most of the other files listed here

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -161,7 +161,7 @@
            style="stroke-width:0.264583"
            x="170.82115"
            y="42.890202"
-           id="tspan12">There's 6 wikis to choose</tspan><tspan
+           id="tspan12">There's 7 wikis to choose</tspan><tspan
            sodipodi:role="line"
            style="stroke-width:0.264583"
            x="170.82115"
@@ -171,7 +171,7 @@
            style="stroke-width:0.264583"
            x="170.82115"
            y="51.709629"
-           id="tspan14">ru, sr, and mdwiki</tspan><tspan
+           id="tspan14">ru, sr, vi, and mdwiki</tspan><tspan
            sodipodi:role="line"
            style="stroke-width:0.264583"
            x="170.82115"


### PR DESCRIPTION
- AGENTS.md Key Files + File Organization: add GadgetApi.php, PublicConfig.php, RequestRateLimit.php, request_security.php, TextTools.php (were missing post-rebase, verified via git ls-files)
- docs/README.md Includes: same 4 files; clarify Timeout limit to set_time_limit(120) + MAX_PAGES (50 web / unlimited CLI) replacing stale 'as long as HTTP holds' phrasing
- .github/labeler.yml: minimal additive GadgetApi.php (correct src/includes path) + RequestRateLimit.php to infrastructure (keeps existing src/GadgetApi.php dangling per constraint)
- docs/architecture.svg: 6 -> 7 wikis (adds vi per src/includes/setup.php:66 and src/index.php:105)