### PR TITLE
Ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ src/includes/cookie.txt
 tmp/*
 vendor/*
 phpunit.local.xml
+.worktrees/


### PR DESCRIPTION
Add `.worktrees/` to `.gitignore` so local git worktree directories are not tracked. This keeps temporary parallel checkout directories out of the repository.