### PR TITLE
Never add ORCID author URLs as article url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ src/includes/cookie.txt
 tmp/*
 vendor/*
 phpunit.local.xml
+.worktrees/

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -1908,6 +1908,11 @@ final class Template
                     report_inaction("Not adding malformed URL: " . echoable($value));
                     return false;
                 }
+                if (preg_match('~^https?://(?:www\.|)orcid\.org/~i', $value) === 1) {
+                    // ORCID URLs identify authors, not the cited work: never use one as |url=
+                    report_inaction("Not adding ORCID author URL as article URL: " . echoable($value));
+                    return false;
+                }
                 if (!$this->blank([$param_name, ...TITLE_LINK_ALIASES])) {
                     return false;
                 }

--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -1703,6 +1703,20 @@ final class TemplatePart1Test extends testBaseClass {
         $this->assertSame('https://www.example.com/article', $expanded->get2('url'));
     }
 
+    public function testAddIfNewRejectsOrcidUrl(): void {
+        // ORCID URLs identify authors, not the cited work: the bot should
+        // never add one as |url= (User talk:Citation bot "Bad ORCID link",
+        // "Adds ORCID URL with invalid character...").
+        $text = '{{cite journal | title = X | journal = J }}';
+        $template = $this->make_citation($text);
+        $this->assertFalse($template->add_if_new('url', 'https://orcid.org/0000-0003-0487-0196'));
+        $this->assertNull($template->get2('url'));
+        $this->assertFalse($template->add_if_new('url', 'http://orcid.org/0000-0001-9153-2907'));
+        $this->assertNull($template->get2('url'));
+        $this->assertTrue($template->add_if_new('url', 'https://example.com/article'));
+        $this->assertSame('https://example.com/article', $template->get2('url'));
+    }
+
     public function testAddIfNewRejectsTimestamplessArchiveUrl(): void {
         $text = '{{cite journal | title = X | journal = J }}';
         $template = $this->make_citation($text);


### PR DESCRIPTION


> Expanding citations by DOI could add an author's `orcid.org` page as `|url=` — reported on User talk:Citation bot ("Bad ORCID link", "Adds ORCID URL with invalid character..."). ORCID identifies the author, not the cited work, so `add_if_new('url')` now refuses `orcid.org` URLs (per Headbomb: the bot should never add ORCID links).
>
> - `src/includes/Template.php`: reject `https?://(www.)orcid.org/` in the `url` case of `add_if_new()`
> - `tests/phpunit/includes/TemplatePart1Test.php`: new `testAddIfNewRejectsOrcidUrl` covering both reported ORCID IDs, plus a positive control
>
> Verification: new test watched failing first, then green; CS1 harness fast + slow both 31 passed / 0 failed; the 6 `TemplatePart1Test` failures are pre-existing live-API flakes (identical with the change stashed).