### PR TITLE
Let DEV_USERS exceed the linked-pages limit

### DIFF
--- a/src/category.php
+++ b/src/category.php
@@ -33,11 +33,6 @@ const GET_IS_OKAY = [
     'Unflagged free DOI',
 ];
 
-const DEV_USERS = [
-    'AManWithNoPlan',
-    'Redalert2fan',
-];
-
 $category = '';
 $from_get = false;
 if (is_string(@$_POST["cat"])) {

--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -5,6 +5,15 @@ declare(strict_types=1);
 require_once __DIR__ . '/big_jobs.php';      // @codeCoverageIgnore
 
 /**
+ * Users allowed to exceed the web page-count limit (MAX_PAGES).
+ * Shared by the category and linked-pages entry points.
+ */
+const DEV_USERS = [
+    'AManWithNoPlan',
+    'Redalert2fan',
+];
+
+/**
  * Only on webpage
  */
 
@@ -126,6 +135,16 @@ function category_edit_summary_end(string $username, string $category, bool $has
         }
     }
     return $edit_summary_end;
+}
+
+/**
+ * Whether the given user may exceed the web page-count limit (MAX_PAGES)
+ * on linked-pages runs, mirroring the category entry point's DEV_USERS
+ * override. Note this is separate from the linked-pages User: restriction,
+ * which uses its own wider allow-list.
+ */
+function linked_pages_should_override_limit(string $username): bool {
+    return in_array($username, DEV_USERS, true);
 }
 
 /**

--- a/src/linked_pages.php
+++ b/src/linked_pages.php
@@ -42,7 +42,16 @@ if ($page_name === '') {
     exit(0);
 }
 
+$dev_user_run = false;
+if (!defined('MAX_PAGES_OVERRIDE') && linked_pages_should_override_limit($api->get_the_user())) {
+    define('MAX_PAGES_OVERRIDE', 1000000);
+    $dev_user_run = true;
+}
+
 $edit_summary_end = "| Suggested by " . $api->get_the_user() . " | Linked from {$page_name} | #UCB_webform_linked ";
+if ($dev_user_run) {
+    $edit_summary_end .= "| Developer - max linked-pages limit override enabled ";
+}
 
 $json = WikipediaBot::get_links($page_name);
 unset($page_name);

--- a/tests/phpunit/includes/WebToolsTest.php
+++ b/tests/phpunit/includes/WebToolsTest.php
@@ -162,6 +162,14 @@ final class WebToolsTest extends testBaseClass {
         );
     }
 
+    public function testLinkedPagesDevOverrideLimitedToDevUsers(): void {
+        $this->assertTrue(linked_pages_should_override_limit('AManWithNoPlan'));
+        $this->assertTrue(linked_pages_should_override_limit('Redalert2fan'));
+        $this->assertFalse(linked_pages_should_override_limit('Headbomb'));
+        $this->assertFalse(linked_pages_should_override_limit('SomeUser'));
+        $this->assertFalse(linked_pages_should_override_limit(''));
+    }
+
     public function testProcessPageSuggestedByPrefixAndCliTagInteraction(): void {
         $html = process_page_edit_summary_end('SomeUser', true, 'toolbar');
         $this->assertStringContainsString('| Suggested by SomeUser', $html);


### PR DESCRIPTION
Mirrors the category entry point: DEV_USERS pair members (AManWithNoPlan, Redalert2fan) get MAX_PAGES_OVERRIDE on linked-pages runs, plus a Developer summary note. 
DEV_USERS moved to WebTools.php as the shared home; category behavior unchanged. Big-job lock mode and the 120s limit still apply.

