### PR TITLE
Honor edit=template and edit=automated_tools on category runs

### DIFF
--- a/src/category.php
+++ b/src/category.php
@@ -122,11 +122,16 @@ if ($total > intval($effective_max / 4)) {
 if (defined('MAX_PAGES_OVERRIDE') && $total > $default_web_limit) {
     report_info('Whitelisted category has ' . (string) $total . ' pages; proceeding with extended limit.');
 }
+$request_edit = null;
+if (!empty($_REQUEST["edit"]) && is_string($_REQUEST["edit"])) {
+    $request_edit = $_REQUEST["edit"];
+}
 $edit_summary_end = category_edit_summary_end(
     $api->get_the_user(),
     $category,
     defined('MAX_PAGES_OVERRIDE'),
-    $dev_user_run
+    $dev_user_run,
+    $request_edit
 );
 unset($_GET, $_POST, $_REQUEST); // Memory minimize
 edit_a_list_of_pages($pages_in_category, $api, $edit_summary_end);

--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -117,16 +117,24 @@ function page_batch_input_within_limit(string $pages, ?int $max_pages = null): b
 /**
  * Build the edit summary suffix for a category run.
  *
- * Scope wins over caller: category runs are always tagged #UCB_Category
- * (even when launched from the webform with edit=webform) so they stay
- * countable separately from single-page #UCB_webform runs in statistics.
- * The caller edit parameter is intentionally not accepted here and any
- * caller tag (toolbar, template, automated_tools, etc.) is discarded for
- * category scope, matching the linked-pages precedent.
+ * Scope wins over caller for human-launched runs: category runs are tagged
+ * #UCB_Category (even when launched from the webform with edit=webform) so
+ * they stay countable separately from single-page #UCB_webform runs in
+ * statistics. Programmatic callers take priority: an explicit edit=template
+ * or edit=automated_tools is tagged with its own token so those runs remain
+ * attributable to the template or automated-tool caller. Any other caller
+ * tag (toolbar, webform, etc.) is discarded for category scope, matching the
+ * linked-pages precedent.
  */
-function category_edit_summary_end(string $username, string $category, bool $has_override = false, bool $is_dev_run = false): string {
+function category_edit_summary_end(string $username, string $category, bool $has_override = false, bool $is_dev_run = false, ?string $edit = null): string {
     $edit_summary_end = "| Suggested by " . $username . " | [[Category:{$category}]] ";
-    $edit_summary_end .= "| #UCB_Category ";
+    if ($edit === 'template') {
+        $edit_summary_end .= "| #UCB_template ";
+    } elseif ($edit === 'automated_tools') {
+        $edit_summary_end .= "| #UCB_automated_tools ";
+    } else {
+        $edit_summary_end .= "| #UCB_Category ";
+    }
     if ($has_override) {
         if ($is_dev_run) {
             $edit_summary_end .= "| Developer - max category limit override enabled ";

--- a/tests/phpunit/includes/WebToolsTest.php
+++ b/tests/phpunit/includes/WebToolsTest.php
@@ -95,6 +95,28 @@ final class WebToolsTest extends testBaseClass {
         $this->assertSame('#UCB_Category', statistics_ucb_from_comment($summary));
     }
 
+    public function testCategoryEditPriorityTemplateAndAutomatedTools(): void {
+        $template = category_edit_summary_end('U', 'C', false, false, 'template');
+        $this->assertStringContainsString('#UCB_template', $template);
+        $this->assertStringNotContainsString('#UCB_Category', $template);
+        $this->assertSame('#UCB_template', statistics_ucb_from_comment($template));
+
+        $automated = category_edit_summary_end('U', 'C', false, false, 'automated_tools');
+        $this->assertStringContainsString('#UCB_automated_tools', $automated);
+        $this->assertStringNotContainsString('#UCB_Category', $automated);
+        $this->assertSame('#UCB_automated_tools', statistics_ucb_from_comment($automated));
+    }
+
+    public function testCategoryEditFallsBackToCategoryTag(): void {
+        foreach ([null, 'webform', 'toolbar', 'something-made-up'] as $edit) {
+            $summary = category_edit_summary_end('U', 'C', false, false, $edit);
+            $this->assertStringContainsString('#UCB_Category', $summary);
+            $this->assertStringNotContainsString('#UCB_template', $summary);
+            $this->assertStringNotContainsString('#UCB_automated_tools', $summary);
+            $this->assertSame('#UCB_Category', statistics_ucb_from_comment($summary));
+        }
+    }
+
     public function testCategoryOverrideSuffixes(): void {
         $plain = category_edit_summary_end('U', 'C', false, false);
         $this->assertStringNotContainsString('Whitelisted', $plain);


### PR DESCRIPTION
Template and automated tools can use category mode to run, but my latest patch made category runs always be marked as category. for these 2 activation methods we want to keep the original activation method as the UCB tag