### PR TITLE
Drop site/publication name used as Zotero creator

### DIFF
--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -169,6 +169,29 @@ final class Zotero {
         return true;
     }
 
+    /**
+     * Some websites list the site or publication name as the only "author"
+     * (e.g. Citoid reports "Fun N' Taste" as the sole creator of funntaste.com).
+     * Such names are not people and must not be added as authors. Returns true
+     * when the given creator name matches the publication title, book title, or
+     * the URL host.
+     */
+    private static function creator_is_site_name(string $name, string $url, object $result): bool {
+        $name = mb_trim($name);
+        foreach (['publicationTitle', 'bookTitle'] as $field) {
+            if (isset($result->{$field}) && str_i_same($name, (string) $result->{$field})) {
+                return true;
+            }
+        }
+        if (preg_match('~^https?://([^/]+)~', $url, $hostname) === 1) {
+            $hostname = str_ireplace('www.', '', (string) $hostname[1]);
+            if (str_i_same($name, $hostname)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static function record_zotero_failure(): void {
         self::$zotero_failures_count += 1;
         if (self::$zotero_failures_count > self::ZOTERO_GIVE_UP) {
@@ -1290,6 +1313,12 @@ final class Zotero {
                 while (isset($result->creators[$i])) {
                     $creatorType = $result->creators[$i]->creatorType ?? 'author';
                     if (isset($result->creators[$i]->firstName) && isset($result->creators[$i]->lastName)) {
+                        // Websites often have non-authors listed in metadata.
+                        // Skip creators whose name is really the site or publication name.
+                        if (self::creator_is_site_name($result->creators[$i]->firstName . ' ' . $result->creators[$i]->lastName, $url, $result)) {
+                            $i++;
+                            continue;
+                        }
                         // Only process if author passes validation
                         if (author_is_human($result->creators[$i]->firstName . ' ' . $result->creators[$i]->lastName)) {
                             // Increment counter only after validation passes, based on creator type

--- a/tests/phpunit/includes/api/zoteroTest.php
+++ b/tests/phpunit/includes/api/zoteroTest.php
@@ -618,6 +618,51 @@ final class zoteroTest extends testBaseClass {
         $this->assertSame('Joe', $template->get2('author1'));
     }
 
+    public function testSiteNameAsSoleCreatorNotAddedAsAuthor(): void {
+        // funntaste.com has no per-article author; Citoid reports the site name
+        // "Fun N' Taste" as both the publication and the sole creator. That is not
+        // a person, so it must not be added as last1/first1.
+        $text = '{{cite web}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = 'https://funntaste.com/dry-chilli-pan-mee-restoran-kin-kin/';
+        $creators = [];
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => "Fun N'", 'lastName' => 'Taste'];
+        $zotero_data = [];
+        $zotero_data[0] = (object) [
+            'title' => 'Food Review: Chilli Pan Mee @ Restoran Kin Kin, Chow Kit, Kuala Lumpur',
+            'itemType' => 'newspaperArticle',
+            'publicationTitle' => "Fun N' Taste",
+            'creators' => $creators,
+        ];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertNull($template->get2('last1'));
+        $this->assertNull($template->get2('first1'));
+        $this->assertSame("Fun N' Taste", $template->get2('work'));
+    }
+
+    public function testHostnameAsSoleCreatorNotAddedAsAuthor(): void {
+        // Some sites report their bare domain as the sole creator; that is not a
+        // person, so it must not be added as last1/first1.
+        $text = '{{cite web}}';
+        $template = $this->make_citation($text);
+        $access_date = 0;
+        $url = 'https://www.example.com/some/article';
+        $creators = [];
+        $creators[0] = (object) ['creatorType' => 'author', 'firstName' => '', 'lastName' => 'example.com'];
+        $zotero_data = [];
+        $zotero_data[0] = (object) [
+            'title' => 'Some article',
+            'itemType' => 'report',
+            'creators' => $creators,
+        ];
+        $zotero_response = json_encode($zotero_data);
+        Zotero::process_zotero_response($zotero_response, $template, $url, $access_date);
+        $this->assertNull($template->get2('last1'));
+        $this->assertNull($template->get2('first1'));
+    }
+
     public function testZoteroResponse30(): void {
         $text = '{{cite web|id=}}';
         $template = $this->make_citation($text);


### PR DESCRIPTION
## Summary

Citoid/Zotero reports the site name as both the publication and the sole creator for blogs with no per-article author. For example, `funntaste.com` returns `"Fun N' Taste"` as the only creator, which the bot then added to cite web templates as `last1=Taste | first1=Fun N'`.

## Root cause

`author_is_human()` lets `"Fun N' Taste"` through (no forbidden keywords, <= 3 spaces, no 3 consecutive capitals), so the site name was treated as a person and emitted as an author.

## Fix

Add `Zotero::creator_is_site_name()`, which skips a creator in the Zotero `creators` path when the full name matches (case-insensitively) the `publicationTitle`, `bookTitle`, or URL host. The legitimate `work = Fun N' Taste` is still added.

## Tests / verification

- New regression tests: `testSiteNameAsSoleCreatorNotAddedAsAuthor` and `testHostnameAsSoleCreatorNotAddedAsAuthor`
- Offline Zotero suite: 63 tests pass
- CS1 harness (fast + slow): 33 passed, 0 unexpectedly resolved, 0 failed
- PHPStan: no new errors; Psalm: no errors