### PR TITLE
Tier 2 Batch G: drop orphaned pmc-embargo-date in tidy (CS1 coupling)

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -5083,6 +5083,9 @@ final class Template
                     return;
 
                 case 'pmc-embargo-date':
+                    if ($this->blank('pmc') && $this->has($param)) {
+                        $this->forget($param);
+                    }
                     if ($this->blank($param)) {
                         return;
                     }

--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -149,7 +149,7 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                 // Buffer the embargo date: add() tidies immediately, so adding
                                 // it before pmc= would drop it as an orphan.  Flushed below
                                 // once pmc= has had its chance.
-                                $embargo_date = '';
+                                $embargo_date = ''; // @codeCoverageIgnore
                                 foreach ($item->Item as $subItem) {
                                     switch ($subItem["Name"]) {
                                         case "pubmed":
@@ -168,7 +168,10 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                                 $embargo_ts = mktime(0, 0, 0, (int) $match[2], (int) $match[3], (int) $match[1]); // @codeCoverageIgnore
                                                 if ($embargo_ts !== false) {                                                 // @codeCoverageIgnore
                                                     $date_emb = date("F j, Y", $embargo_ts);                                  // @codeCoverageIgnore
-                                                    if ($embargo_date === '') {                                               // @codeCoverageIgnore
+                                                    // Buffer first-wins like sequential adds, but only dates
+                                                    // the add gate would accept: a past date must not block
+                                                    // a later future one.
+                                                    if ($embargo_date === '' && $embargo_ts >= strtotime('now')) {            // @codeCoverageIgnore
                                                         $embargo_date = $date_emb;                                            // @codeCoverageIgnore
                                                     }                                                                         // @codeCoverageIgnore
                                                 }                                                                              // @codeCoverageIgnore
@@ -181,9 +184,9 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                             }
                                     }
                                 }
-                                if ($embargo_date !== '') {
+                                if ($embargo_date !== '') { // @codeCoverageIgnore
                                     $this_template->add_if_new('pmc-embargo-date', $embargo_date, 'entrez'); // @codeCoverageIgnore
-                                }
+                                } // @codeCoverageIgnore
                                 break;
                         }
                     }

--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -146,6 +146,10 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                             case 'ISSN':
                                 break;
                             case "ArticleIds":
+                                // Buffer the embargo date: add() tidies immediately, so adding
+                                // it before pmc= would drop it as an orphan.  Flushed below
+                                // once pmc= has had its chance.
+                                $embargo_date = '';
                                 foreach ($item->Item as $subItem) {
                                     switch ($subItem["Name"]) {
                                         case "pubmed":
@@ -164,7 +168,9 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                                 $embargo_ts = mktime(0, 0, 0, (int) $match[2], (int) $match[3], (int) $match[1]); // @codeCoverageIgnore
                                                 if ($embargo_ts !== false) {                                                 // @codeCoverageIgnore
                                                     $date_emb = date("F j, Y", $embargo_ts);                                  // @codeCoverageIgnore
-                                                    $this_template->add_if_new('pmc-embargo-date', $date_emb, 'entrez');      // @codeCoverageIgnore
+                                                    if ($embargo_date === '') {                                               // @codeCoverageIgnore
+                                                        $embargo_date = $date_emb;                                            // @codeCoverageIgnore
+                                                    }                                                                         // @codeCoverageIgnore
                                                 }                                                                              // @codeCoverageIgnore
                                             }
                                             break;
@@ -174,6 +180,9 @@ function entrez_api(array $ids, array &$templates, string $db): void {    // Poi
                                                 $this_template->add_if_new('doi', $match[0], 'entrez');
                                             }
                                     }
+                                }
+                                if ($embargo_date !== '') {
+                                    $this_template->add_if_new('pmc-embargo-date', $embargo_date, 'entrez'); // @codeCoverageIgnore
                                 }
                                 break;
                         }

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -2950,6 +2950,18 @@ final class TemplatePart2Test extends testBaseClass {
         $this->assertNull($template->get2('trans-contribution'));
     }
 
+    public function testPmcBeforeEmbargoKeepsBoth(): void {
+        // Documents the add order the PubMed path must use: pmc first, then
+        // the embargo date (the reverse order loses the date to the orphan
+        // drop inside add()).
+        $text = '{{Cite journal}}';
+        $template = $this->make_citation($text);
+        $this->assertTrue($template->add_if_new('pmc', 'PMC1234567', 'entrez'));
+        $this->assertTrue($template->add_if_new('pmc-embargo-date', 'November 15, 2090', 'entrez'));
+        $this->assertNotNull($template->get2('pmc'));
+        $this->assertSame('November 15, 2090', $template->get2('pmc-embargo-date'));
+    }
+
     public function testTidyRemovesOrphanedPmcEmbargoDate(): void {
         // A future pmc-embargo-date= without pmc= carries the CS1
         // "|pmc-embargo-date= requires |pmc=" error; tidy must drop the

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -603,9 +603,11 @@ final class TemplatePart2Test extends testBaseClass {
     }
 
     public function testPMCEmbargo2(): void {
+        // A future embargo date without pmc= is an orphan (CS1 "|pmc-embargo-date=
+        // requires |pmc=") and must be dropped, like the past date in test 1.
         $text = '{{Cite journal|pmc-embargo-date=January 22, 2090}}';
         $template = $this->process_citation($text);
-        $this->assertSame('January 22, 2090', $template->get2('pmc-embargo-date'));
+        $this->assertNull($template->get2('pmc-embargo-date'));
     }
 
     public function testPMCEmbargo3(): void {
@@ -615,7 +617,9 @@ final class TemplatePart2Test extends testBaseClass {
     }
 
     public function testPMCEmbargo4(): void {
-        $text = '{{Cite journal}}';
+        // With pmc= present the future embargo date sticks, so the slot is
+        // taken and the duplicate add is refused.
+        $text = '{{Cite journal|pmc=PMC1234567}}';
         $template = $this->make_citation($text);
         $this->assertFalse($template->add_if_new('pmc-embargo-date', 'November 15, 1990'));
         $this->assertFalse($template->add_if_new('pmc-embargo-date', 'November 15, 2010'));
@@ -2944,6 +2948,24 @@ final class TemplatePart2Test extends testBaseClass {
         $template = $this->make_citation($text);
         $template->tidy();
         $this->assertNull($template->get2('trans-contribution'));
+    }
+
+    public function testTidyRemovesOrphanedPmcEmbargoDate(): void {
+        // A future pmc-embargo-date= without pmc= carries the CS1
+        // "|pmc-embargo-date= requires |pmc=" error; tidy must drop the
+        // orphan instead of leaving it in place.
+        $text = '{{cite journal |title=T |journal=J |date=2020 |pmc-embargo-date=2035-06-01}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('pmc-embargo-date'));
+    }
+
+    public function testTidyKeepsPmcEmbargoDateWhenPmcPresent(): void {
+        // A pmc-embargo-date= whose base pmc= is present must be kept.
+        $text = '{{cite journal |title=T |journal=J |date=2020 |pmc=PMC1234567 |pmc-embargo-date=2035-06-01}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertSame('2035-06-01', $template->get2('pmc-embargo-date'));
     }
 
     public function testTidyKeepsTransChapterWhenBasePresent(): void {

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -625,6 +625,7 @@ final class TemplatePart2Test extends testBaseClass {
         $this->assertFalse($template->add_if_new('pmc-embargo-date', 'November 15, 2010'));
         $this->assertFalse($template->add_if_new('pmc-embargo-date', 'November 15, 3010'));
         $this->assertTrue($template->add_if_new('pmc-embargo-date', 'November 15, 2090'));
+        $this->assertSame('November 15, 2090', $template->get2('pmc-embargo-date')); // Stuck, not dropped as orphan
         $this->assertFalse($template->add_if_new('pmc-embargo-date', 'November 15, 2080'));
     }
 
@@ -2958,8 +2959,14 @@ final class TemplatePart2Test extends testBaseClass {
         $template = $this->make_citation($text);
         $this->assertTrue($template->add_if_new('pmc', 'PMC1234567', 'entrez'));
         $this->assertTrue($template->add_if_new('pmc-embargo-date', 'November 15, 2090', 'entrez'));
-        $this->assertNotNull($template->get2('pmc'));
+        $this->assertSame('1234567', $template->get2('pmc')); // Normalized PMC1234567 to digits
         $this->assertSame('November 15, 2090', $template->get2('pmc-embargo-date'));
+        // Reverse order loses the date to the orphan drop inside add().
+        $reversed = $this->make_citation('{{Cite journal}}');
+        $this->assertTrue($reversed->add_if_new('pmc-embargo-date', 'November 15, 2090', 'entrez'));
+        $this->assertNull($reversed->get2('pmc-embargo-date'));
+        $this->assertTrue($reversed->add_if_new('pmc', 'PMC1234567', 'entrez'));
+        $this->assertNull($reversed->get2('pmc-embargo-date')); // Gone: nothing re-adds it
     }
 
     public function testTidyRemovesOrphanedPmcEmbargoDate(): void {

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -384,6 +384,7 @@ function build_matrix(): array {
         ['doi-broken-date removed without doi', '{{cite journal |title=X |journal=J |doi-broken-date=2020-01-01}}', 'pass'],
         ['format removed without url', '{{cite journal |title=X |journal=J |format=PDF}}', 'pass'],
         ['pmc-embargo-date removed without pmc', '{{cite journal |title=X |journal=J |pmc-embargo-date=2020-01-01}}', 'pass'],
+        ['future pmc-embargo-date removed without pmc', '{{cite journal |title=X |journal=J |pmc-embargo-date=2035-06-01}}', 'pass'],
 
         // --- clean citations across template families ---
         ['Clean cite journal', '{{cite journal |title=Some paper |journal=Nature |year=2020 |volume=1 |issue=2 |pages=3}}', 'pass'],


### PR DESCRIPTION
Tier 2 CS1 audit follow-up ("never introduce a new CS1 error").

`tidy_parameter()` now drops `pmc-embargo-date` when `pmc` is blank (CS1
"|pmc-embargo-date= requires |pmc="), mirroring the merged `doi-broken-date`
precedent. The old code only validated the date itself, so a *future*
orphaned date survived; the existing harness case used a past date that
masked the gap — new `future pmc-embargo-date removed without pmc` matrix
case added. Harness: 38 passed / 9 gaps, fast + slow green.

Test updates (intended behavior changes, commented inline):
- `testPMCEmbargo2`: future orphan without `pmc` is now dropped.
- `testPMCEmbargo4`: provides `pmc=` so the future-date add sticks and the
  slot-taken refusal chain keeps its original intent.

