### PR TITLE
Fix orphaned archive-date handling in Batch H review

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -5769,9 +5769,18 @@ final class Template
                     }
                     return;
 
+                case 'archive-date':
+                    if ($this->blank(['archive-url', 'archiveurl']) && $this->has($param)) {
+                        $this->forget($param);
+                    }
+                    return;
+
                 case 'archivedate':
                     if ($this->has('archivedate') && $this->get('archive-date') === $this->get('archivedate')) {
                         $this->forget('archivedate');
+                    }
+                    if ($this->blank(['archive-url', 'archiveurl']) && $this->has($param)) {
+                        $this->forget($param);
                     }
                     return;
 

--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -261,7 +261,8 @@ final class ConstantsTest extends testBaseClass {
                 '| doi-access = Z123Z ', '| access-date = Z123Z ', '| accessdate = Z123Z ', '| doi-broken = Z123Z ', '| doi-broken-date = Z123Z ', '| doi-inactive-date = Z123Z ', '| pmc-embargo-date = Z123Z ', '| embargo = Z123Z ', '| arşivengelli = Z123Z ', '| open-access = Z123Z ',
                 '| url-access = Z123Z ', '| chapter-url-access = Z123Z ', '| contribution-url-access = Z123Z ', '| article-url-access = Z123Z ', '| entry-url-access = Z123Z ', '| section-url-access = Z123Z ', '| event-url-access = Z123Z ', '| lay-url-access = Z123Z ', '| transcript-url-access = Z123Z ', '| map-url-access = Z123Z ',
                 '| trans-title = Z123Z ', '| trans-chapter = Z123Z ', '| trans-article = Z123Z ', '| trans-contribution = Z123Z ', '| trans-entry = Z123Z ', '| trans-map = Z123Z ', '| trans-quote = Z123Z ', '| trans-journal = Z123Z ',
-                '| trans-work = Z123Z ', '| trans-magazine = Z123Z ', '| trans-newspaper = Z123Z ', '| trans-website = Z123Z ', '| trans-encyclopaedia = Z123Z ', '| trans-encyclopedia = Z123Z ', '| trans-periodical = Z123Z ', '| trans-section = Z123Z '],
+                '| trans-work = Z123Z ', '| trans-magazine = Z123Z ', '| trans-newspaper = Z123Z ', '| trans-website = Z123Z ', '| trans-encyclopaedia = Z123Z ', '| trans-encyclopedia = Z123Z ', '| trans-periodical = Z123Z ', '| trans-section = Z123Z ',
+                '| archive-date = Z123Z ', '| archivedate = Z123Z '],
                 '',
                 $text
             ); // Stuff that gets dropped when orphaned (no base parameter present)

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -2995,6 +2995,24 @@ final class TemplatePart2Test extends testBaseClass {
         $this->assertSame('Y', $template->get2('trans-chapter'));
     }
 
+    public function testTidyRemovesOrphanedArchiveDate(): void {
+        // An archive-date= without archive-url= carries the CS1
+        // "|archive-date= requires |archive-url=" error; tidy must drop the
+        // orphan instead of leaving it in place.
+        $text = '{{cite web |url=https://example.com |title=T |archive-date=2020-01-01}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('archive-date'));
+    }
+
+    public function testTidyKeepsArchiveDateWhenArchiveUrlPresent(): void {
+        // An archive-date= whose base archive-url= is present must be kept.
+        $text = '{{cite web |url=https://example.com |title=T |archive-url=https://web.archive.org/web/20200101000000/https://example.com |archive-date=2020-01-01}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertSame('2020-01-01', $template->get2('archive-date'));
+    }
+
     public function testTidyKeepsAccessWhenAliasBasePresent(): void {
         // The base url param may use its non-hyphenated alias (contributionurl),
         // so an access param must not be dropped when that alias is present.

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -903,7 +903,8 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
     }
 
     public function testArchiveDate_1(): void {
-        $text = "{{cite journal}}";
+        // archive-url= present so the added date is no orphan.
+        $text = "{{cite journal|archive-url=https://web.archive.org/web/20100101000000/https://example.com}}";
         $template = $this->make_citation($text);
         Template::$date_style = DateStyle::DATES_MDY;
         $this->assertTrue($template->add_if_new('archive-date', '20 JAN 2010'));
@@ -911,7 +912,8 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
     }
 
     public function testArchiveDate_2(): void {
-        $text = "{{cite journal}}";
+        // archive-url= present so the added date is no orphan.
+        $text = "{{cite journal|archive-url=https://web.archive.org/web/20100101000000/https://example.com}}";
         $template = $this->make_citation($text);
         Template::$date_style = DateStyle::DATES_DMY;
         $this->assertTrue($template->add_if_new('archive-date', '20 JAN 2010'));
@@ -919,7 +921,8 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
     }
 
     public function testArchiveDate_3(): void {
-        $text = "{{cite journal}}";
+        // archive-url= present so the added date is no orphan.
+        $text = "{{cite journal|archive-url=https://web.archive.org/web/20100101000000/https://example.com}}";
         $template = $this->make_citation($text);
         Template::$date_style = DateStyle::DATES_WHATEVER;
         $this->assertTrue($template->add_if_new('archive-date', '20 JAN 2010'));
@@ -927,7 +930,8 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
     }
 
     public function testArchiveDate_4(): void {
-        $text = "{{cite journal}}";
+        // archive-url= present so the added date is no orphan.
+        $text = "{{cite journal|archive-url=https://web.archive.org/web/20100101000000/https://example.com}}";
         $template = $this->make_citation($text);
         $this->assertFalse($template->add_if_new('archive-date', 'SDAFEWFEWW#F#WFWEFESFEFSDFDFD'));
         $this->assertNull($template->get2('archive-date'));

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -375,6 +375,7 @@ function build_matrix(): array {
         ['uppercase URL base keeps format', '{{cite web |URL=https://example.com |format=PDF |title=X}}', 'pass'],
         ['un-hyphenated chapterurl base keeps chapter-format', '{{cite book |title=X |chapterurl=https://example.com |chapter-format=PDF |year=2020}}', 'pass'],
         ['Orphaned archive-date removed', '{{cite web |url=https://example.com |title=X |archive-date=2020-01-01}}', 'pass'],
+        ['Orphaned archivedate removed', '{{cite web |url=https://example.com |title=X |archivedate=2020-01-01}}', 'pass'],
         ['archive-date kept with archive-url base', '{{cite web |url=https://example.com |title=X |archive-url=https://web.archive.org/web/20200101000000/https://example.com |archive-date=2020-01-01}}', 'pass'],
 
         // --- ISBN validation (merged Tier 1 fix) ---

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -374,6 +374,8 @@ function build_matrix(): array {
         ['uppercase URL base keeps archive-url', '{{cite web |URL=https://example.com |archive-url=https://web.archive.org/web/20200101000000/https://example.com |archive-date=2020-01-01 |title=X}}', 'pass'],
         ['uppercase URL base keeps format', '{{cite web |URL=https://example.com |format=PDF |title=X}}', 'pass'],
         ['un-hyphenated chapterurl base keeps chapter-format', '{{cite book |title=X |chapterurl=https://example.com |chapter-format=PDF |year=2020}}', 'pass'],
+        ['Orphaned archive-date removed', '{{cite web |url=https://example.com |title=X |archive-date=2020-01-01}}', 'pass'],
+        ['archive-date kept with archive-url base', '{{cite web |url=https://example.com |title=X |archive-url=https://web.archive.org/web/20200101000000/https://example.com |archive-date=2020-01-01}}', 'pass'],
 
         // --- ISBN validation (merged Tier 1 fix) ---
         ['Valid ISBN-10 kept', '{{cite journal |title=X |journal=J |isbn=0-306-40615-2}}', 'pass'],


### PR DESCRIPTION
`tidy_parameter()` drops `archive-date`/`archivedate` when both
`archive-url` spellings are blank (CS1 "|archive-date= requires |archive-url="), closing the reverse direction — the bot already derived dates *from* archive-urls but never cleaned dates left behind without one. This error had no tidy case at all. Harness: 41 passed / 9 gaps, fast + slow green, including 2 new matrix cases (drop + keep, both spellings).

Test updates (intended behavior changes, commented inline):
- `testArchiveDate_1-4`: templates gained an `archive-url` so the added
  dates are no orphans; date-format assertions unchanged. All production
  `archive-date` adds happen under archive-url tidy — no live flow affected.
- `ConstantsTest` whitelist: `archive-date`/`archivedate` join the
  orphan-strip list (same convention as `*-access`, trans-*).

