### PR TITLE
Refuse malformed archive-url 

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -1964,6 +1964,11 @@ final class Template
 
             case 'archive-url':
                 if ($this->blank(['archive-url', 'archiveurl'])) {
+                    if (!archive_url_valid($value)) {
+                        // CS1 would report "|archive-url= is malformed"
+                        report_inaction("Not adding malformed archive-url: " . echoable($value));
+                        return false;
+                    }
                     if ($this->blank(['archive-date', 'archivedate']) && !archive_url_has_timestamp($value)) {
                         // CS1 would report "|archive-url= requires |archive-date="
                         report_inaction("Not adding archive-url without extractable archive-date: " . echoable($value));
@@ -5786,6 +5791,12 @@ final class Template
 
                 case 'archive-url':
                 case 'archiveurl':
+                    if ($this->has($param) && !archive_url_valid($this->get($param))) {
+                        // CS1 "|archive-url= is malformed": save commands and
+                        // wildcard searches are not snapshots.
+                        $this->forget($param);
+                        return;
+                    }
                     if ($this->blank(['archive-date', 'archivedate'])) {
                         if (preg_match('~^https?://(?:(?:www\.|web\.)?archive\.org/web/|archive\.today/|archive\.\S\S/|webarchive\.loc\.gov/all/|www\.webarchive\.org\.uk/wayback/archive/)(\d{4})(\d{2})(\d{2})\d{6}~', $this->get($param), $matches)) {
                                $this->add_if_new('archive-date', $matches[1] . '-' . $matches[2] . '-' . $matches[3]);

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1370,10 +1370,10 @@ function archive_url_valid(string $value): bool {
     if (!url_valid($value)) {
         return false;
     }
-    if (preg_match('~^https?://(?:(?:www\.|web\.)?archive\.org/)?save/~i', $value) === 1) {
+    if (preg_match('~^https?://(?:www\.|web\.)?archive\.org/save/~i', $value) === 1) {
         return false; // save command triggers a snapshot instead of linking one
     }
-    if (preg_match('~^https?://(?:www\.|web\.)?archive\.org/web/\*/~', $value) === 1) {
+    if (preg_match('~^https?://(?:www\.|web\.)?archive\.org/web/\*/~i', $value) === 1) {
         return false; // wildcard is a search page, not a snapshot
     }
     return true;

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -1360,6 +1360,26 @@ function url_valid(string $value): bool {
 }
 
 /**
+ * True when an archive URL is structurally usable as |archive-url=, mirroring
+ * the CS1 "|archive-url= is malformed" reasons the bot can detect locally.
+ * A save-command URL triggers a new snapshot instead of linking one, and a
+ * wildcard URL is a search page rather than a snapshot.  Timestamp coupling
+ * is handled separately by archive_url_has_timestamp().
+ */
+function archive_url_valid(string $value): bool {
+    if (!url_valid($value)) {
+        return false;
+    }
+    if (preg_match('~^https?://(?:(?:www\.|web\.)?archive\.org/)?save/~i', $value) === 1) {
+        return false; // save command triggers a snapshot instead of linking one
+    }
+    if (preg_match('~^https?://(?:www\.|web\.)?archive\.org/web/\*/~', $value) === 1) {
+        return false; // wildcard is a search page, not a snapshot
+    }
+    return true;
+}
+
+/**
  * True when an archive URL carries an extractable snapshot timestamp, mirroring
  * the timestamp extraction in Template::tidy_parameter('archive-url').  If no
  * timestamp can be extracted and |archive-date= is absent, CS1 would report

--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -262,7 +262,8 @@ final class ConstantsTest extends testBaseClass {
                 '| url-access = Z123Z ', '| chapter-url-access = Z123Z ', '| contribution-url-access = Z123Z ', '| article-url-access = Z123Z ', '| entry-url-access = Z123Z ', '| section-url-access = Z123Z ', '| event-url-access = Z123Z ', '| lay-url-access = Z123Z ', '| transcript-url-access = Z123Z ', '| map-url-access = Z123Z ',
                 '| trans-title = Z123Z ', '| trans-chapter = Z123Z ', '| trans-article = Z123Z ', '| trans-contribution = Z123Z ', '| trans-entry = Z123Z ', '| trans-map = Z123Z ', '| trans-quote = Z123Z ', '| trans-journal = Z123Z ',
                 '| trans-work = Z123Z ', '| trans-magazine = Z123Z ', '| trans-newspaper = Z123Z ', '| trans-website = Z123Z ', '| trans-encyclopaedia = Z123Z ', '| trans-encyclopedia = Z123Z ', '| trans-periodical = Z123Z ', '| trans-section = Z123Z ',
-                '| archive-date = Z123Z ', '| archivedate = Z123Z '],
+                '| archive-date = Z123Z ', '| archivedate = Z123Z ',
+                '| archive-url = Z123Z ', '| archiveurl = Z123Z '],
                 '',
                 $text
             ); // Stuff that gets dropped when orphaned (no base parameter present)

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -1787,25 +1787,29 @@ final class TemplatePart2Test extends testBaseClass {
     }
 
     public function testBadURLStatusSettings3(): void {
-        $text = "{{cite web|url-status=sì|url=X|archive-url=Y}}";
+        // Real snapshot URL: junk archive-url values are dropped in tidy.
+        $text = "{{cite web|url-status=sì|url=X|archive-url=https://web.archive.org/web/20200101000000/https://example.com}}";
         $expanded = $this->process_citation($text);
         $this->AssertSame('dead', $expanded->get2('url-status'));
     }
 
     public function testBadURLStatusSettings4(): void {
-        $text = "{{cite web|url-status=no|url=X|archive-url=Y}}";
+        // Real snapshot URL: junk archive-url values are dropped in tidy.
+        $text = "{{cite web|url-status=no|url=X|archive-url=https://web.archive.org/web/20200101000000/https://example.com}}";
         $expanded = $this->process_citation($text);
         $this->AssertSame('live', $expanded->get2('url-status'));
     }
 
     public function testBadURLStatusSettings5(): void {
-        $text = "{{cite web|url-status=dead|url=X|archive-url=Y}}";
+        // Real snapshot URL: junk archive-url values are dropped in tidy.
+        $text = "{{cite web|url-status=dead|url=X|archive-url=https://web.archive.org/web/20200101000000/https://example.com}}";
         $expanded = $this->process_citation($text);
         $this->AssertSame('dead', $expanded->get2('url-status'));
     }
 
     public function testBadURLStatusSettings6(): void {
-        $text = "{{cite web|url-status=live|url=X|archive-url=Y}}";
+        // Real snapshot URL: junk archive-url values are dropped in tidy.
+        $text = "{{cite web|url-status=live|url=X|archive-url=https://web.archive.org/web/20200101000000/https://example.com}}";
         $expanded = $this->process_citation($text);
         $this->AssertSame('live', $expanded->get2('url-status'));
     }

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -516,6 +516,30 @@ final class TemplatePart2Test extends testBaseClass {
         $this->assertSame($text, $template->parsed_text());
     }
 
+    public function testRefusesSaveCommandArchiveUrl(): void {
+        // A save-command URL triggers a new snapshot; the bot must never add
+        // one, even when an archive-date= is already present.
+        $text = '{{Cite web | url=https://example.com | title=T | archive-date=2020-01-01}}';
+        $template = $this->make_citation($text);
+        $this->assertFalse($template->add_if_new('archive-url', 'https://web.archive.org/save/https://example.com'));
+        $this->assertNull($template->get2('archive-url'));
+    }
+
+    public function testRefusesWildcardArchiveUrl(): void {
+        // A wildcard URL is a search page, not a snapshot.
+        $text = '{{Cite web | url=https://example.com | title=T | archive-date=2020-01-01}}';
+        $template = $this->make_citation($text);
+        $this->assertFalse($template->add_if_new('archive-url', 'https://web.archive.org/web/*/https://example.com'));
+        $this->assertNull($template->get2('archive-url'));
+    }
+
+    public function testKeepsSnapshotArchiveUrl(): void {
+        $text = '{{Cite web | url=https://example.com | title=T}}';
+        $template = $this->make_citation($text);
+        $this->assertTrue($template->add_if_new('archive-url', 'https://web.archive.org/web/20200101000000/https://example.com'));
+        $this->assertSame('https://web.archive.org/web/20200101000000/https://example.com', $template->get2('archive-url'));
+    }
+
     public function testReplaceBadDOI(): void {
         $text = '{{Cite journal | doi=10.0001/Rubbish_bot_failure_test|doi-broken-date=1999|pmid=<!-- -->|pmc=<!-- -->}}';
         $template = $this->make_citation($text);

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1488,7 +1488,10 @@ final class textToolsTest extends testBaseClass {
         $this->assertTrue(archive_url_valid('https://archive.today/20200101000000/https://example.com'));
         $this->assertTrue(archive_url_valid('https://ghostarchive.org/archive/xxxxx')); // structurally fine; timestamp rules are separate
         $this->assertFalse(archive_url_valid('https://web.archive.org/save/https://example.com')); // save command triggers a snapshot
+        $this->assertFalse(archive_url_valid('HTTPS://WEB.ARCHIVE.ORG/SAVE/https://example.com')); // host case must not matter
         $this->assertFalse(archive_url_valid('https://web.archive.org/web/*/https://example.com')); // wildcard is a search page
+        $this->assertFalse(archive_url_valid('HTTPS://WEB.ARCHIVE.ORG/WEB/*/https://example.com')); // host case must not matter
+        $this->assertTrue(archive_url_valid('https://example.com/save/foo')); // non-archive /save/ path is not a save command
         $this->assertFalse(archive_url_valid('not a url'));
         $this->assertFalse(archive_url_valid(''));
     }

--- a/tests/phpunit/includes/textToolsTest.php
+++ b/tests/phpunit/includes/textToolsTest.php
@@ -1483,6 +1483,16 @@ final class textToolsTest extends testBaseClass {
         $this->assertFalse(archive_url_has_timestamp(''));
     }
 
+    public function testArchiveUrlValid(): void {
+        $this->assertTrue(archive_url_valid('https://web.archive.org/web/20200101000000/https://example.com'));
+        $this->assertTrue(archive_url_valid('https://archive.today/20200101000000/https://example.com'));
+        $this->assertTrue(archive_url_valid('https://ghostarchive.org/archive/xxxxx')); // structurally fine; timestamp rules are separate
+        $this->assertFalse(archive_url_valid('https://web.archive.org/save/https://example.com')); // save command triggers a snapshot
+        $this->assertFalse(archive_url_valid('https://web.archive.org/web/*/https://example.com')); // wildcard is a search page
+        $this->assertFalse(archive_url_valid('not a url'));
+        $this->assertFalse(archive_url_valid(''));
+    }
+
     public function testUnicodeLevenshteinNormalizesCombiningMarkOrder(): void {
         $left = "a\u{0301}\u{0323}";
         $right = "a\u{0323}\u{0301}";

--- a/tools/cs1_harness.php
+++ b/tools/cs1_harness.php
@@ -340,6 +340,13 @@ function check_citation(Template $template): array {
         $violations[] = 'url-malformed: CS1 "Check |url= value"';
     }
 
+    // R20: archive-url must not be a save-command or wildcard URL (CS1 "|archive-url= is malformed").
+    foreach (ARCHIVE_URL_PARAMS as $archive_param) {
+        if ($template->has($archive_param) && !archive_url_valid($template->get($archive_param))) {
+            $violations[] = 'archive-url-malformed: CS1 "|archive-url= is malformed"';
+        }
+    }
+
     return $violations;
 }
 
@@ -377,6 +384,8 @@ function build_matrix(): array {
         ['Orphaned archive-date removed', '{{cite web |url=https://example.com |title=X |archive-date=2020-01-01}}', 'pass'],
         ['Orphaned archivedate removed', '{{cite web |url=https://example.com |title=X |archivedate=2020-01-01}}', 'pass'],
         ['archive-date kept with archive-url base', '{{cite web |url=https://example.com |title=X |archive-url=https://web.archive.org/web/20200101000000/https://example.com |archive-date=2020-01-01}}', 'pass'],
+        ['Save-command archive-url removed', '{{cite web |url=https://example.com |title=X |archive-url=https://web.archive.org/save/https://example.com |archive-date=2020-01-01}}', 'pass'],
+        ['Wildcard archive-url removed', '{{cite web |url=https://example.com |title=X |archive-url=https://web.archive.org/web/*/https://example.com |archive-date=2020-01-01}}', 'pass'],
 
         // --- ISBN validation (merged Tier 1 fix) ---
         ['Valid ISBN-10 kept', '{{cite journal |title=X |journal=J |isbn=0-306-40615-2}}', 'pass'],


### PR DESCRIPTION
Tier 2 CS1 audit follow-up ("never introduce a new CS1 error").

New `archive_url_valid()` validator (structurally sound URL, no save-command, no wildcard) enforced in two places: refused on add with `report_inaction`, and dropped in tidy — plus harness R20 checker rule mirroring it. Harness: 43 passed / 9 gaps, fast + slow green, including 2 new matrix cases (save + wildcard removal).

Why both places: the add path already refused these *without* a date (timestamp gate), but sailed them through once a date was present (proven by failing-before tests); and the old tidy pattern only matched a `/web/save/` form that doesn't exist, so real save-command input survived every run (caught by the new R20 rule on first execution).

- Fixed: wildcard case-insensitivity, mandatory save host (was matching any site's `/save/` path), both pinned by tests.
- Verified: no bot flow constructs save URLs; dropping save-URLs also removes an SSRF-adjacent side effect (fetching one triggers a snapshot); timestamp/flag/liveweb validation correctly deferred.

